### PR TITLE
feat(stellar): add paginated agent payment history endpoint Add GET /…

### DIFF
--- a/backend/src/__tests__/routes/stellar.test.js
+++ b/backend/src/__tests__/routes/stellar.test.js
@@ -1,0 +1,391 @@
+/**
+ * Tests for GET /api/v1/stellar/account/:publicKey/transactions
+ *
+ * The Horizon SDK is mocked so these tests run without a real network
+ * connection or a live Stellar node.
+ */
+
+"use strict";
+
+const request = require("supertest");
+const app = require("../../app");
+const { cacheClear } = require("../../services/transactionService");
+
+// ── Mock the Horizon server ───────────────────────────────────────────────────
+
+// We need to mock before the module cache loads the real horizonServer.
+// Jest hoists jest.mock() calls automatically.
+jest.mock("../../config/stellar", () => {
+  const buildOpsCall = (ops) => ({
+    call: jest.fn().mockResolvedValue({ records: ops }),
+    limit: jest.fn().mockReturnThis(),
+  });
+
+  const mockHorizonServer = {
+    loadAccount: jest.fn(),
+    feeStats: jest.fn(),
+    transactions: jest.fn(),
+    operations: jest.fn(),
+  };
+
+  return {
+    horizonServer: mockHorizonServer,
+    rpcServer: {},
+    NETWORK: "testnet",
+    CONTRACT_IDS: {
+      marketplace: "CCMARKETPLACE000000000000000000000000000000000000000000",
+      micropayments: "CCMICROPAY0000000000000000000000000000000000000000000",
+      agentRegistry: "CCAGENTREGISTRY000000000000000000000000000000000000000",
+    },
+    NETWORK_CONFIG: {},
+  };
+});
+
+// Grab the mock after jest.mock hoisting so we can configure behaviour per test.
+const { horizonServer, CONTRACT_IDS } = require("../../config/stellar");
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const VALID_KEY = "GBQNX4XFBKZ2S2GZPB2XVVZ5VVQYHXQAQYYVRJXPVDGXNVKGKBFLR3";
+const UNKNOWN_KEY = "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGGEWNG5PZWXU2CQKM4PAT";
+
+function makeTx(overrides = {}) {
+  return {
+    hash: "abc123",
+    ledger_attr: 50000,
+    created_at: "2026-07-18T10:00:00Z",
+    successful: true,
+    fee_charged: "100",
+    operation_count: 1,
+    paging_token: "50000",
+    contract_ids: [CONTRACT_IDS.marketplace],
+    ...overrides,
+  };
+}
+
+function makeOp(overrides = {}) {
+  return {
+    id: "op-1",
+    type: "invoke_host_function",
+    function: "purchase_license",
+    source_account: VALID_KEY,
+    contract_id: CONTRACT_IDS.marketplace,
+    parameters: [{ name: "asset_id", value: "3" }],
+    ...overrides,
+  };
+}
+
+/** Wire up horizonServer mocks for a successful transactions + operations call. */
+function mockHorizonSuccess(txs, ops) {
+  // transactions().forAccount().limit().order().includeFailed().call()
+  const txBuilder = {
+    forAccount: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    order: jest.fn().mockReturnThis(),
+    includeFailed: jest.fn().mockReturnThis(),
+    cursor: jest.fn().mockReturnThis(),
+    call: jest.fn().mockResolvedValue({ records: txs }),
+  };
+  horizonServer.transactions.mockReturnValue(txBuilder);
+
+  // operations().forTransaction().limit().call()
+  const opsBuilder = {
+    forTransaction: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    call: jest.fn().mockResolvedValue({ records: ops }),
+  };
+  horizonServer.operations.mockReturnValue(opsBuilder);
+}
+
+// ── Setup / teardown ──────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  cacheClear();
+  jest.clearAllMocks();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("GET /api/v1/stellar/account/:publicKey/transactions", () => {
+  // ── Happy path ─────────────────────────────────────────────────────────────
+
+  it("returns 200 with data and meta for a valid public key", async () => {
+    const tx = makeTx();
+    const op = makeOp();
+    mockHorizonSuccess([tx], [op]);
+
+    const res = await request(app)
+      .get(`/api/v1/stellar/account/${VALID_KEY}/transactions`)
+      .expect(200);
+
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body).toHaveProperty("meta");
+    expect(res.body.meta).toHaveProperty("page", 1);
+    expect(res.body.meta).toHaveProperty("limit", 20);
+    expect(res.body.meta).toHaveProperty("count");
+  });
+
+  it("returns parsed operation summaries in each transaction", async () => {
+    const tx = makeTx();
+    const op = makeOp({ function: "purchase_license", parameters: [{ name: "asset_id", value: "3" }] });
+    mockHorizonSuccess([tx], [op]);
+
+    const res = await request(app)
+      .get(`/api/v1/stellar/account/${VALID_KEY}/transactions`)
+      .expect(200);
+
+    expect(res.body.data).toHaveLength(1);
+    const record = res.body.data[0];
+    expect(record.summary).toBe("Purchased license for asset #3");
+    expect(record.operations).toHaveLength(1);
+    expect(record.operations[0].summary).toBe("Purchased license for asset #3");
+  });
+
+  it("includes standard transaction fields in each record", async () => {
+    const tx = makeTx();
+    const op = makeOp();
+    mockHorizonSuccess([tx], [op]);
+
+    const res = await request(app)
+      .get(`/api/v1/stellar/account/${VALID_KEY}/transactions`)
+      .expect(200);
+
+    const record = res.body.data[0];
+    expect(record).toHaveProperty("hash", "abc123");
+    expect(record).toHaveProperty("ledger", 50000);
+    expect(record).toHaveProperty("createdAt", "2026-07-18T10:00:00Z");
+    expect(record).toHaveProperty("successful", true);
+    expect(record).toHaveProperty("feeCharged", "100");
+    expect(record).toHaveProperty("operationCount", 1);
+    expect(record).toHaveProperty("pagingToken");
+  });
+
+  it("respects the limit query param", async () => {
+    // Return 5 transactions; request limit=2 → expect 2 in first page
+    const txs = Array.from({ length: 5 }, (_, i) => makeTx({ hash: `hash-${i}`, paging_token: String(i) }));
+    const op = makeOp();
+    mockHorizonSuccess(txs, [op]);
+
+    const res = await request(app)
+      .get(`/api/v1/stellar/account/${VALID_KEY}/transactions?page=1&limit=2`)
+      .expect(200);
+
+    expect(res.body.data.length).toBeLessThanOrEqual(2);
+    expect(res.body.meta.limit).toBe(2);
+  });
+
+  it("returns correct meta.page value", async () => {
+    mockHorizonSuccess([], []);
+
+    const res = await request(app)
+      .get(`/api/v1/stellar/account/${VALID_KEY}/transactions?page=3&limit=10`)
+      .expect(200);
+
+    expect(res.body.meta.page).toBe(3);
+    expect(res.body.meta.limit).toBe(10);
+  });
+
+  // ── Contract filtering ──────────────────────────────────────────────────────
+
+  it("filters out transactions that do not involve known contract addresses", async () => {
+    // tx1 involves the marketplace contract; tx2 has no known contract
+    const tx1 = makeTx({ hash: "match", contract_ids: [CONTRACT_IDS.marketplace] });
+    const tx2 = makeTx({ hash: "nomatch", contract_ids: [] });
+
+    const txBuilder = {
+      forAccount: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      includeFailed: jest.fn().mockReturnThis(),
+      cursor: jest.fn().mockReturnThis(),
+      call: jest.fn().mockResolvedValue({ records: [tx1, tx2] }),
+    };
+    horizonServer.transactions.mockReturnValue(txBuilder);
+
+    // Operations for tx1 have contract_id set; tx2 ops do not
+    horizonServer.operations
+      .mockReturnValueOnce({
+        forTransaction: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        call: jest.fn().mockResolvedValue({
+          records: [makeOp({ contract_id: CONTRACT_IDS.marketplace })],
+        }),
+      })
+      .mockReturnValueOnce({
+        forTransaction: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        call: jest.fn().mockResolvedValue({ records: [makeOp({ contract_id: "" })] }),
+      });
+
+    const res = await request(app)
+      .get(`/api/v1/stellar/account/${VALID_KEY}/transactions`)
+      .expect(200);
+
+    // Only tx1 should survive the filter
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0].hash).toBe("match");
+  });
+
+  // ── Operation summary parsing ───────────────────────────────────────────────
+
+  it("parses list_asset operation correctly", async () => {
+    mockHorizonSuccess(
+      [makeTx()],
+      [makeOp({ function: "list_asset", parameters: [] })]
+    );
+
+    const res = await request(app)
+      .get(`/api/v1/stellar/account/${VALID_KEY}/transactions`)
+      .expect(200);
+
+    expect(res.body.data[0].operations[0].summary).toBe(
+      "Listed a new intelligence asset"
+    );
+  });
+
+  it("parses delist_asset operation correctly", async () => {
+    mockHorizonSuccess(
+      [makeTx()],
+      [makeOp({ function: "delist_asset", parameters: [] })]
+    );
+
+    const res = await request(app)
+      .get(`/api/v1/stellar/account/${VALID_KEY}/transactions`)
+      .expect(200);
+
+    expect(res.body.data[0].operations[0].summary).toBe("Delisted an intelligence asset");
+  });
+
+  it("parses purchase_license without asset_id param gracefully", async () => {
+    mockHorizonSuccess(
+      [makeTx()],
+      [makeOp({ function: "purchase_license", parameters: [] })]
+    );
+
+    const res = await request(app)
+      .get(`/api/v1/stellar/account/${VALID_KEY}/transactions`)
+      .expect(200);
+
+    expect(res.body.data[0].operations[0].summary).toBe("Purchased a license");
+  });
+
+  it("parses payment operation correctly", async () => {
+    mockHorizonSuccess(
+      [makeTx()],
+      [makeOp({
+        type: "payment",
+        function: undefined,
+        amount: "10.0000000",
+        asset_type: "native",
+        to: UNKNOWN_KEY,
+        contract_id: CONTRACT_IDS.marketplace, // so it isn't filtered
+      })]
+    );
+
+    const res = await request(app)
+      .get(`/api/v1/stellar/account/${VALID_KEY}/transactions`)
+      .expect(200);
+
+    const summary = res.body.data[0].operations[0].summary;
+    expect(summary).toMatch(/Payment of 10.0000000 XLM/);
+  });
+
+  // ── Caching ─────────────────────────────────────────────────────────────────
+
+  it("returns cached response on second identical request within TTL", async () => {
+    const tx = makeTx();
+    const op = makeOp();
+    mockHorizonSuccess([tx], [op]);
+
+    // First call — hits Horizon
+    await request(app)
+      .get(`/api/v1/stellar/account/${VALID_KEY}/transactions`)
+      .expect(200);
+
+    // Second call — should use cache; Horizon mocks should NOT be called again
+    const txBuilderMock = horizonServer.transactions.mock.results[0]?.value;
+    const callCountBefore = txBuilderMock?.call.mock.calls.length ?? 0;
+
+    await request(app)
+      .get(`/api/v1/stellar/account/${VALID_KEY}/transactions`)
+      .expect(200);
+
+    // transactions().call() should still be at the same count (cache hit)
+    expect(txBuilderMock?.call.mock.calls.length).toBe(callCountBefore);
+  });
+
+  // ── Validation ──────────────────────────────────────────────────────────────
+
+  it("returns 422 for a public key shorter than 56 characters", async () => {
+    await request(app)
+      .get("/api/v1/stellar/account/TOOSHORT/transactions")
+      .expect(422);
+  });
+
+  it("returns 422 for a public key longer than 56 characters", async () => {
+    const tooLong = "G" + "B".repeat(56); // 57 chars
+    await request(app)
+      .get(`/api/v1/stellar/account/${tooLong}/transactions`)
+      .expect(422);
+  });
+
+  it("returns 422 for a non-integer limit param", async () => {
+    await request(app)
+      .get(`/api/v1/stellar/account/${VALID_KEY}/transactions?limit=abc`)
+      .expect(422);
+  });
+
+  it("returns 422 for a limit of 0", async () => {
+    await request(app)
+      .get(`/api/v1/stellar/account/${VALID_KEY}/transactions?limit=0`)
+      .expect(422);
+  });
+
+  it("returns 422 for a limit above 200", async () => {
+    await request(app)
+      .get(`/api/v1/stellar/account/${VALID_KEY}/transactions?limit=201`)
+      .expect(422);
+  });
+
+  it("returns 422 for page less than 1", async () => {
+    await request(app)
+      .get(`/api/v1/stellar/account/${VALID_KEY}/transactions?page=0`)
+      .expect(422);
+  });
+
+  // ── 404 ─────────────────────────────────────────────────────────────────────
+
+  it("returns 404 when Horizon reports account not found", async () => {
+    const notFoundError = { response: { status: 404 } };
+
+    const txBuilder = {
+      forAccount: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      includeFailed: jest.fn().mockReturnThis(),
+      cursor: jest.fn().mockReturnThis(),
+      call: jest.fn().mockRejectedValue(notFoundError),
+    };
+    horizonServer.transactions.mockReturnValue(txBuilder);
+
+    const res = await request(app)
+      .get(`/api/v1/stellar/account/${UNKNOWN_KEY}/transactions`)
+      .expect(404);
+
+    expect(res.body.error).toMatch(/not found/i);
+  });
+
+  // ── Empty result ─────────────────────────────────────────────────────────────
+
+  it("returns empty data array when no matching transactions exist", async () => {
+    mockHorizonSuccess([], []);
+
+    const res = await request(app)
+      .get(`/api/v1/stellar/account/${VALID_KEY}/transactions`)
+      .expect(200);
+
+    expect(res.body.data).toEqual([]);
+    expect(res.body.meta.count).toBe(0);
+    expect(res.body.meta.hasMore).toBe(false);
+  });
+});

--- a/backend/src/routes/stellar.js
+++ b/backend/src/routes/stellar.js
@@ -1,9 +1,23 @@
 const { Router } = require("express");
 const { query, param } = require("express-validator");
+const rateLimit = require("express-rate-limit");
 const validate = require("../middleware/validate");
 const { horizonServer, rpcServer, NETWORK, CONTRACT_IDS } = require("../config/stellar");
+const { getAccountTransactions } = require("../services/transactionService");
 
 const router = Router();
+
+// ── Per-key rate limiter for the transactions endpoint ────────────────────────
+// Keyed on the publicKey path param so each Stellar address gets its own quota.
+// 30 requests per 60-second window per key.
+const txRateLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 30,
+  keyGenerator: (req) => req.params.publicKey || req.ip,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many requests for this public key. Please wait before retrying." },
+});
 
 /**
  * GET /api/v1/stellar/account/:publicKey
@@ -61,5 +75,51 @@ router.get("/fee", async (_req, res, next) => {
     next(err);
   }
 });
+
+/**
+ * GET /api/v1/stellar/account/:publicKey/transactions
+ *
+ * Returns a paginated list of Horizon transactions for the given public key,
+ * filtered to those involving known contract addresses, with each operation
+ * parsed into a human-readable summary.
+ *
+ * Query params:
+ *   page    — 1-based page number (default: 1)
+ *   limit   — records per page, 1–200 (default: 20)
+ *   cursor  — Horizon paging token; when supplied, overrides `page`
+ *
+ * Caching: results are cached for 5 seconds per (publicKey × page × limit × cursor).
+ * Rate limiting: 30 requests per 60-second window per public key.
+ */
+router.get(
+  "/account/:publicKey/transactions",
+  txRateLimiter,
+  [
+    param("publicKey").isString().isLength({ min: 56, max: 56 }),
+    query("page").optional().isInt({ min: 1 }),
+    query("limit").optional().isInt({ min: 1, max: 200 }),
+    query("cursor").optional().isString().trim(),
+  ],
+  validate,
+  async (req, res, next) => {
+    try {
+      const { publicKey } = req.params;
+      const { page, limit, cursor } = req.query;
+
+      const result = await getAccountTransactions(publicKey, {
+        page: page ? Number(page) : 1,
+        limit: limit ? Number(limit) : 20,
+        cursor: cursor || undefined,
+      });
+
+      res.json(result);
+    } catch (err) {
+      if (err.response?.status === 404) {
+        return res.status(404).json({ error: "Account not found on network" });
+      }
+      next(err);
+    }
+  }
+);
 
 module.exports = router;

--- a/backend/src/services/transactionService.js
+++ b/backend/src/services/transactionService.js
@@ -1,0 +1,282 @@
+/**
+ * transactionService.js
+ *
+ * Fetches paginated Horizon transactions for a given Stellar public key,
+ * filters to only those that touch a known contract address, parses each
+ * operation into a human-readable summary, and caches results to avoid
+ * hammering the Horizon API.
+ */
+
+const { horizonServer, CONTRACT_IDS } = require("../config/stellar");
+
+// ── Cache ─────────────────────────────────────────────────────────────────────
+
+const CACHE_TTL_MS = 5_000; // 5-second TTL
+
+/**
+ * Simple in-memory TTL cache.
+ * Key: string  →  Value: { data, expiresAt }
+ */
+const _cache = new Map();
+
+function cacheGet(key) {
+  const entry = _cache.get(key);
+  if (!entry) return null;
+  if (Date.now() > entry.expiresAt) {
+    _cache.delete(key);
+    return null;
+  }
+  return entry.data;
+}
+
+function cacheSet(key, data) {
+  _cache.set(key, { data, expiresAt: Date.now() + CACHE_TTL_MS });
+}
+
+/** Exposed for tests that need to wipe the cache between cases. */
+function cacheClear() {
+  _cache.clear();
+}
+
+// ── Contract address set ──────────────────────────────────────────────────────
+
+/**
+ * Returns a Set of all known contract addresses (lower-cased for comparison).
+ * Filters out empty strings so unconfigured env vars are ignored.
+ */
+function knownContractAddresses() {
+  return new Set(
+    Object.values(CONTRACT_IDS)
+      .filter(Boolean)
+      .map((a) => a.toLowerCase())
+  );
+}
+
+// ── Operation parsing ─────────────────────────────────────────────────────────
+
+/**
+ * Extract a human-readable summary from a single Horizon operation record.
+ *
+ * Horizon operation types relevant to Soroban / contract interactions:
+ *   - invoke_host_function  (Soroban contract calls)
+ *   - payment
+ *   - path_payment_strict_send / path_payment_strict_receive
+ *   - create_account
+ *   - change_trust
+ *
+ * We inspect the function name when available to build a richer label.
+ */
+function parseOperationSummary(op, contractAddresses) {
+  const type = op.type || "unknown";
+
+  switch (type) {
+    case "invoke_host_function": {
+      const fn = (op.function || "").toLowerCase();
+      const contractId = (op.contract_id || "").toLowerCase();
+
+      if (fn === "list_asset" || fn === "listasset") {
+        return "Listed a new intelligence asset";
+      }
+      if (fn === "delist_asset" || fn === "delistasset") {
+        return "Delisted an intelligence asset";
+      }
+      if (fn === "purchase_license" || fn === "purchaselicense") {
+        // Try to extract asset id from the raw args if present
+        const assetId = op.parameters?.find(
+          (p) => p.name === "asset_id" || p.name === "assetId"
+        )?.value;
+        return assetId
+          ? `Purchased license for asset #${assetId}`
+          : "Purchased a license";
+      }
+      if (fn === "update_price" || fn === "updateprice") {
+        return "Updated asset price";
+      }
+      if (fn === "open_stream" || fn === "openstream") {
+        return "Opened a micropayment stream";
+      }
+      if (fn === "withdraw") {
+        return "Withdrew from a micropayment stream";
+      }
+      if (fn === "cancel_stream" || fn === "cancelstream") {
+        return "Cancelled a micropayment stream";
+      }
+      if (fn === "register_agent" || fn === "registeragent") {
+        return "Registered an agent";
+      }
+      if (fn === "record_transaction" || fn === "recordtransaction") {
+        return "Recorded an agent transaction";
+      }
+
+      // Generic contract call label
+      if (contractAddresses.has(contractId)) {
+        return fn ? `Called contract function: ${op.function}` : "Invoked contract";
+      }
+
+      return "Invoked a smart contract";
+    }
+
+    case "payment": {
+      const asset =
+        op.asset_type === "native"
+          ? "XLM"
+          : `${op.asset_code}/${op.asset_issuer?.slice(0, 6)}…`;
+      const dir = op.to ? `to ${op.to.slice(0, 8)}…` : "";
+      return `Payment of ${op.amount} ${asset} ${dir}`.trim();
+    }
+
+    case "path_payment_strict_send":
+    case "path_payment_strict_receive": {
+      const srcAsset = op.source_asset_type === "native" ? "XLM" : op.source_asset_code;
+      const destAsset = op.asset_type === "native" ? "XLM" : op.asset_code;
+      return `Path payment: ${op.source_amount} ${srcAsset} → ${op.amount} ${destAsset}`;
+    }
+
+    case "create_account":
+      return `Created account ${op.account?.slice(0, 8)}…`;
+
+    case "change_trust":
+      return `Changed trust for ${op.asset_code || "asset"}`;
+
+    default:
+      return `${type.replace(/_/g, " ")} operation`;
+  }
+}
+
+// ── Transaction filtering ─────────────────────────────────────────────────────
+
+/**
+ * Return true if the transaction or any of its embedded operations involves
+ * a known contract address.
+ *
+ * Horizon exposes contract_ids at the transaction level for Soroban txns.
+ * We also fall back to inspecting individual operation.contract_id fields.
+ */
+function involvesKnownContract(tx, ops, contractAddresses) {
+  if (contractAddresses.size === 0) return true; // no filter configured → show all
+
+  // Horizon Soroban txns expose a `soroban_meta` with contract IDs
+  const txContractIds = (tx.contract_ids || []).map((c) => c.toLowerCase());
+  if (txContractIds.some((c) => contractAddresses.has(c))) return true;
+
+  // Check each operation's contract_id
+  return ops.some((op) => {
+    const cid = (op.contract_id || "").toLowerCase();
+    return cid && contractAddresses.has(cid);
+  });
+}
+
+// ── Main fetch function ───────────────────────────────────────────────────────
+
+/**
+ * Fetch paginated, filtered, and annotated transactions for a public key.
+ *
+ * @param {string} publicKey       - Stellar G-address
+ * @param {object} [options]
+ * @param {number} [options.page]  - 1-based page number (default: 1)
+ * @param {number} [options.limit] - Records per page, 1–200 (default: 20)
+ * @param {string} [options.cursor] - Horizon paging token (overrides page)
+ * @returns {Promise<{ data: object[], meta: object }>}
+ */
+async function getAccountTransactions(publicKey, { page = 1, limit = 20, cursor } = {}) {
+  const clampedLimit = Math.min(Math.max(Number(limit) || 20, 1), 200);
+  const cacheKey = `txns:${publicKey}:p${page}:l${clampedLimit}:c${cursor || ""}`;
+
+  const cached = cacheGet(cacheKey);
+  if (cached) return cached;
+
+  const contractAddresses = knownContractAddresses();
+
+  // ── Horizon call ───────────────────────────────────────────────────────────
+  // We request more than `limit` because some may be filtered out.
+  // Fetch up to 200 at once (Horizon cap) to fill the requested page.
+  const horizonLimit = Math.min(clampedLimit * 5, 200);
+
+  let builder = horizonServer
+    .transactions()
+    .forAccount(publicKey)
+    .limit(horizonLimit)
+    .order("desc")
+    .includeFailed(false);
+
+  if (cursor) {
+    builder = builder.cursor(cursor);
+  }
+
+  const txPage = await builder.call();
+  const records = txPage.records || [];
+
+  // ── Fetch operations for each transaction in parallel ─────────────────────
+  const withOps = await Promise.all(
+    records.map(async (tx) => {
+      try {
+        const opsPage = await horizonServer
+          .operations()
+          .forTransaction(tx.hash)
+          .limit(50)
+          .call();
+        return { tx, ops: opsPage.records || [] };
+      } catch {
+        return { tx, ops: [] };
+      }
+    })
+  );
+
+  // ── Filter to contract-related transactions ────────────────────────────────
+  const filtered = withOps.filter(({ tx, ops }) =>
+    involvesKnownContract(tx, ops, contractAddresses)
+  );
+
+  // ── Apply page-level slicing ───────────────────────────────────────────────
+  const pageIndex = Math.max(Number(page) || 1, 1);
+  const offset = (pageIndex - 1) * clampedLimit;
+  const slice = filtered.slice(offset, offset + clampedLimit);
+
+  // ── Shape the response ─────────────────────────────────────────────────────
+  const data = slice.map(({ tx, ops }) => {
+    const summaries = ops.map((op) => parseOperationSummary(op, contractAddresses));
+    const primarySummary =
+      summaries.find((s) => !s.startsWith("Payment") && !s.includes("operation")) ||
+      summaries[0] ||
+      "Transaction";
+
+    return {
+      hash: tx.hash,
+      ledger: tx.ledger_attr,
+      createdAt: tx.created_at,
+      successful: tx.successful,
+      feeCharged: tx.fee_charged,
+      operationCount: tx.operation_count,
+      summary: primarySummary,
+      operations: ops.map((op) => ({
+        id: op.id,
+        type: op.type,
+        summary: parseOperationSummary(op, contractAddresses),
+        sourceAccount: op.source_account,
+        ...(op.contract_id ? { contractId: op.contract_id } : {}),
+      })),
+      pagingToken: tx.paging_token,
+    };
+  });
+
+  const nextCursor =
+    slice.length === clampedLimit
+      ? slice[slice.length - 1]?.tx?.paging_token
+      : null;
+
+  const result = {
+    data,
+    meta: {
+      page: pageIndex,
+      limit: clampedLimit,
+      count: data.length,
+      hasMore: nextCursor !== null,
+      nextCursor,
+    },
+  };
+
+  cacheSet(cacheKey, result);
+  return result;
+}
+
+module.exports = { getAccountTransactions, cacheClear, parseOperationSummary };


### PR DESCRIPTION
Adds GET /api/v1/stellar/account/:publicKey/transactions. Returns a paginated list of Horizon transactions filtered to those involving known contract addresses, with each operation parsed into a plain-English summary (e.g. "Purchased license for asset #3"). Results are cached for 5 seconds to avoid hammering Horizon, and the route is rate-limited to 30 requests per 60-second window per public key. 18 tests cover filtering, parsing, caching, validation, and 404 handling.
Closes #22 