### PR TITLE
feat(backend): validate Stellar public keys on all route inputs

### DIFF
--- a/backend/src/__tests__/agents.test.js
+++ b/backend/src/__tests__/agents.test.js
@@ -3,6 +3,10 @@ const app = require("../app");
 const { seed } = require("../db/seed");
 const { truncateAll, closePool, OWNER_B } = require("./helpers/testDb");
 
+// Right length (56 chars), right "G" prefix, but an invalid checksum.
+const BAD_CHECKSUM_KEY =
+  "GA234567A234567A234567A234567A234567A234567A234567A23456";
+
 beforeAll(async () => {
   await truncateAll();
   await seed();
@@ -93,6 +97,32 @@ describe("POST /api/v1/agents", () => {
         capabilities: ["TimeTravel"],
       })
       .expect(422);
+  });
+
+  it("rejects an owner with the right length but an invalid checksum, naming the field", async () => {
+    const res = await request(app)
+      .post("/api/v1/agents")
+      .send({
+        id: 802,
+        owner: BAD_CHECKSUM_KEY,
+        name: "Bad Owner Agent",
+        description: "Should fail validation before reaching the DB.",
+        capabilities: ["Reasoning"],
+      })
+      .expect(422);
+
+    expect(res.body.details.some((d) => d.path === "owner")).toBe(true);
+  });
+});
+
+describe("POST /api/v1/agents/:id/reputation", () => {
+  it("rejects a voter with the right length but an invalid checksum, naming the field", async () => {
+    const res = await request(app)
+      .post("/api/v1/agents/1/reputation")
+      .send({ score: 80, voter: BAD_CHECKSUM_KEY })
+      .expect(422);
+
+    expect(res.body.details.some((d) => d.path === "voter")).toBe(true);
   });
 });
 

--- a/backend/src/__tests__/assets.test.js
+++ b/backend/src/__tests__/assets.test.js
@@ -3,6 +3,10 @@ const app = require("../app");
 const { seed } = require("../db/seed");
 const { truncateAll, closePool, OWNER_B } = require("./helpers/testDb");
 
+// Right length (56 chars), right "G" prefix, but an invalid checksum.
+const BAD_CHECKSUM_KEY =
+  "GA234567A234567A234567A234567A234567A234567A234567A23456";
+
 beforeAll(async () => {
   await truncateAll();
   await seed();
@@ -103,6 +107,23 @@ describe("POST /api/v1/assets", () => {
       .send({ id: 901, name: "incomplete" })
       .expect(422);
   });
+
+  it("rejects an owner with an invalid checksum, naming the field", async () => {
+    const res = await request(app)
+      .post("/api/v1/assets")
+      .send({
+        id: 902,
+        owner: BAD_CHECKSUM_KEY,
+        name: "Bad Owner Asset",
+        description: "Should fail validation before reaching the DB.",
+        assetType: "Dataset",
+        licenseType: "OpenSource",
+        price: 0,
+      })
+      .expect(422);
+
+    expect(res.body.details.some((d) => d.path === "owner")).toBe(true);
+  });
 });
 
 describe("POST /api/v1/assets/:id/purchase", () => {
@@ -138,6 +159,15 @@ describe("POST /api/v1/assets/:id/purchase", () => {
       .post("/api/v1/assets/2/purchase")
       .send({ buyer: "too-short" })
       .expect(422);
+  });
+
+  it("rejects a buyer with the right length but an invalid checksum", async () => {
+    const res = await request(app)
+      .post("/api/v1/assets/2/purchase")
+      .send({ buyer: BAD_CHECKSUM_KEY })
+      .expect(422);
+
+    expect(res.body.details.some((d) => d.path === "buyer")).toBe(true);
   });
 });
 

--- a/backend/src/__tests__/helpers/testDb.js
+++ b/backend/src/__tests__/helpers/testDb.js
@@ -18,8 +18,11 @@ async function truncateAll() {
 
 // ── Fixture builders ─────────────────────────────────────────────────────────
 
-const OWNER_A = "GBQNX4XFBKZ2S2GZPB2XVVZ5VVQYHXQAQYYVRJXPVDGXNVKGKBFLR3";
-const OWNER_B = "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGGEWNG5PZWXU2CQKM4PAT";
+// Real, checksum-valid Ed25519 public keys (generated via Keypair.random()) —
+// route validation now checks the StrKey checksum, so placeholder-looking
+// strings of the right length are no longer sufficient here.
+const OWNER_A = "GD226Q4QUIIDFBQ7TWPTP4UT4TKPX2MQRVEJSFMMCSM6ORDCPNZPPKCT";
+const OWNER_B = "GAHC3JKJCBTPODO2GEOLUCXWTIQYBCPHBOTAT2KMPZ35PXCITJ57UYGC";
 
 let nextId = 1;
 

--- a/backend/src/__tests__/routes/stellar.test.js
+++ b/backend/src/__tests__/routes/stellar.test.js
@@ -46,8 +46,11 @@ const { horizonServer, CONTRACT_IDS } = require("../../config/stellar");
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
-const VALID_KEY = "GBQNX4XFBKZ2S2GZPB2XVVZ5VVQYHXQAQYYVRJXPVDGXNVKGKBFLR3";
-const UNKNOWN_KEY = "GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGGEWNG5PZWXU2CQKM4PAT";
+// Real, checksum-valid Ed25519 public keys — route validation now checks the
+// StrKey checksum, so placeholder-looking strings of the right length no
+// longer pass.
+const VALID_KEY = "GDQRRTSA2OFYBTJT2Y7BWE5HM5TGQJBSTD2VJKSCOH62SY7TRYLUS24Y";
+const UNKNOWN_KEY = "GA7JTW4JG2MYKF4GB3FAAJD3DNPRROXUSP2GUXRJUY5HS2H5EMQTDKPJ";
 
 function makeTx(overrides = {}) {
   return {
@@ -105,6 +108,38 @@ beforeEach(() => {
 });
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("GET /api/v1/stellar/account/:publicKey", () => {
+  it("returns 200 with account data for a valid public key", async () => {
+    horizonServer.loadAccount.mockResolvedValue({
+      account_id: VALID_KEY,
+      sequence: "123",
+      balances: [],
+      subentry_count: 0,
+    });
+
+    const res = await request(app)
+      .get(`/api/v1/stellar/account/${VALID_KEY}`)
+      .expect(200);
+
+    expect(res.body.publicKey).toBe(VALID_KEY);
+  });
+
+  it("returns 422 for a public key shorter than 56 characters", async () => {
+    await request(app).get("/api/v1/stellar/account/TOOSHORT").expect(422);
+  });
+
+  it("returns 422, naming the field, for a 56-char key with an invalid checksum", async () => {
+    const badChecksum =
+      "GA234567A234567A234567A234567A234567A234567A234567A23456";
+
+    const res = await request(app)
+      .get(`/api/v1/stellar/account/${badChecksum}`)
+      .expect(422);
+
+    expect(res.body.details.some((d) => d.path === "publicKey")).toBe(true);
+  });
+});
 
 describe("GET /api/v1/stellar/account/:publicKey/transactions", () => {
   // ── Happy path ─────────────────────────────────────────────────────────────
@@ -327,6 +362,18 @@ describe("GET /api/v1/stellar/account/:publicKey/transactions", () => {
     await request(app)
       .get(`/api/v1/stellar/account/${tooLong}/transactions`)
       .expect(422);
+  });
+
+  it("returns 422, naming the field, for a 56-char key with an invalid checksum", async () => {
+    // Right length, right "G" prefix, but the checksum doesn't verify.
+    const badChecksum =
+      "GA234567A234567A234567A234567A234567A234567A234567A23456";
+
+    const res = await request(app)
+      .get(`/api/v1/stellar/account/${badChecksum}/transactions`)
+      .expect(422);
+
+    expect(res.body.details.some((d) => d.path === "publicKey")).toBe(true);
   });
 
   it("returns 422 for a non-integer limit param", async () => {

--- a/backend/src/__tests__/streams.test.js
+++ b/backend/src/__tests__/streams.test.js
@@ -8,6 +8,10 @@ const {
   OWNER_B,
 } = require("./helpers/testDb");
 
+// Right length (56 chars), right "G" prefix, but an invalid checksum.
+const BAD_CHECKSUM_KEY =
+  "GA234567A234567A234567A234567A234567A234567A234567A23456";
+
 beforeEach(async () => {
   await truncateAll();
 });
@@ -47,6 +51,25 @@ describe("POST /api/v1/streams", () => {
       .send({ id: 1, sender: "short" })
       .expect(422);
   });
+
+  it("rejects a sender/recipient with the right length but an invalid checksum, naming the field", async () => {
+    const stream = buildStream({ sender: BAD_CHECKSUM_KEY });
+    const res = await request(app)
+      .post("/api/v1/streams")
+      .send({
+        id: stream.id,
+        sender: stream.sender,
+        recipient: stream.recipient,
+        token: stream.token,
+        deposit: stream.deposit,
+        ratePerSecond: stream.ratePerSecond,
+        startTime: stream.startTime,
+        endTime: stream.endTime,
+      })
+      .expect(422);
+
+    expect(res.body.details.some((d) => d.path === "sender")).toBe(true);
+  });
 });
 
 describe("GET /api/v1/streams", () => {
@@ -73,6 +96,18 @@ describe("GET /api/v1/streams", () => {
       .get("/api/v1/streams?status=Cancelled")
       .expect(200);
     expect(res.body.data).toHaveLength(0);
+  });
+
+  it("rejects a sender query param with an invalid checksum", async () => {
+    await request(app)
+      .get(`/api/v1/streams?sender=${BAD_CHECKSUM_KEY}`)
+      .expect(422);
+  });
+
+  it("rejects a recipient query param with an invalid checksum", async () => {
+    await request(app)
+      .get(`/api/v1/streams?recipient=${BAD_CHECKSUM_KEY}`)
+      .expect(422);
   });
 });
 

--- a/backend/src/__tests__/utils/stellar.test.js
+++ b/backend/src/__tests__/utils/stellar.test.js
@@ -1,0 +1,103 @@
+const { isValidStellarAddress } = require("../../utils/stellar");
+
+describe("isValidStellarAddress", () => {
+  // ── Valid ──────────────────────────────────────────────────────────────────
+
+  it("accepts a genuine Ed25519 public key", () => {
+    expect(
+      isValidStellarAddress(
+        "GAOWLGIKI5J7CZIRCIY46MRSILFSXZW4A53SW7DMFNEWLLVYU6PBHK6C"
+      )
+    ).toBe(true);
+  });
+
+  it("accepts another genuine Ed25519 public key", () => {
+    expect(
+      isValidStellarAddress(
+        "GDQRRTSA2OFYBTJT2Y7BWE5HM5TGQJBSTD2VJKSCOH62SY7TRYLUS24Y"
+      )
+    ).toBe(true);
+  });
+
+  // ── Invalid: wrong checksum / wrong key type ────────────────────────────────
+
+  it("rejects a secret seed (S...) even though it is a valid StrKey", () => {
+    expect(
+      isValidStellarAddress(
+        "SCRSAKV7GWCRMUHBYMJBTERBRHREPSOQY4V23ZJGGNZXASYS4D4QXDDA"
+      )
+    ).toBe(false);
+  });
+
+  it("rejects a 56-char string with a corrupted checksum", () => {
+    // Flip the last character of a valid key so length/prefix look right
+    // but the checksum no longer matches.
+    const valid = "GAOWLGIKI5J7CZIRCIY46MRSILFSXZW4A53SW7DMFNEWLLVYU6PBHK6C";
+    const corrupted = valid.slice(0, -1) + (valid.endsWith("C") ? "D" : "C");
+    expect(isValidStellarAddress(corrupted)).toBe(false);
+  });
+
+  it("rejects a lowercased valid key", () => {
+    expect(
+      isValidStellarAddress(
+        "gaowlgiki5j7cziriy46mrsilfsxzw4a53sw7dmfnewllvyu6pbhk6c"
+      )
+    ).toBe(false);
+  });
+
+  // ── Invalid: length / format ─────────────────────────────────────────────
+
+  it("rejects an empty string", () => {
+    expect(isValidStellarAddress("")).toBe(false);
+  });
+
+  it("rejects a string that is too short", () => {
+    expect(isValidStellarAddress("GTOOSHORT")).toBe(false);
+  });
+
+  it("rejects a string that is too long", () => {
+    expect(
+      isValidStellarAddress(
+        "GAOWLGIKI5J7CZIRCIY46MRSILFSXZW4A53SW7DMFNEWLLVYU6PBHK6CX"
+      )
+    ).toBe(false);
+  });
+
+  it("rejects a key with a valid-looking checksum but padded whitespace", () => {
+    expect(
+      isValidStellarAddress(
+        " GAOWLGIKI5J7CZIRCIY46MRSILFSXZW4A53SW7DMFNEWLLVYU6PBHK6C "
+      )
+    ).toBe(false);
+  });
+
+  it("rejects a 56-char base32 string with a G prefix but no valid checksum", () => {
+    expect(
+      isValidStellarAddress(
+        "GA234567A234567A234567A234567A234567A234567A234567A23456"
+      )
+    ).toBe(false);
+  });
+
+  // ── Invalid: non-string types ────────────────────────────────────────────
+
+  it("rejects null", () => {
+    expect(isValidStellarAddress(null)).toBe(false);
+  });
+
+  it("rejects undefined", () => {
+    expect(isValidStellarAddress(undefined)).toBe(false);
+  });
+
+  it("rejects a number", () => {
+    expect(isValidStellarAddress(123)).toBe(false);
+  });
+
+  it("rejects an object", () => {
+    expect(isValidStellarAddress({ key: "value" })).toBe(false);
+  });
+
+  it("rejects an array", () => {
+    expect(isValidStellarAddress(["G".repeat(56)])).toBe(false);
+  });
+});

--- a/backend/src/routes/agents.js
+++ b/backend/src/routes/agents.js
@@ -2,6 +2,7 @@ const { Router } = require("express");
 const { body, query, param } = require("express-validator");
 const validate = require("../middleware/validate");
 const asyncHandler = require("../middleware/asyncHandler");
+const { isValidStellarAddress } = require("../utils/stellar");
 const {
   listAgents,
   getAgent,
@@ -93,7 +94,11 @@ router.post(
   "/",
   [
     body("id").isInt({ min: 1 }),
-    body("owner").isString().isLength({ min: 56, max: 56 }),
+    body("owner")
+      .isString()
+      .bail()
+      .custom(isValidStellarAddress)
+      .withMessage("must be a valid Stellar public key"),
     body("name").isString().trim().isLength({ min: 1, max: 100 }),
     body("description").isString().trim().isLength({ min: 1, max: 1000 }),
     body("capabilities").isArray(),
@@ -137,7 +142,11 @@ router.post(
   [
     param("id").isInt({ min: 1 }),
     body("score").isInt({ min: 0, max: 100 }),
-    body("voter").isString().isLength({ min: 56, max: 56 }),
+    body("voter")
+      .isString()
+      .bail()
+      .custom(isValidStellarAddress)
+      .withMessage("must be a valid Stellar public key"),
   ],
   validate,
   (req, res) => {

--- a/backend/src/routes/assets.js
+++ b/backend/src/routes/assets.js
@@ -10,6 +10,7 @@ const {
   LICENSE_TYPES,
 } = require("../services/assetService");
 const { purchaseLicense } = require("../services/licenseService");
+const { isValidStellarAddress } = require("../utils/stellar");
 
 const router = Router();
 
@@ -72,7 +73,11 @@ router.post(
   "/",
   [
     body("id").isInt({ min: 1 }),
-    body("owner").isString().isLength({ min: 56, max: 56 }),
+    body("owner")
+      .isString()
+      .bail()
+      .custom(isValidStellarAddress)
+      .withMessage("must be a valid Stellar public key"),
     body("name").isString().trim().isLength({ min: 1, max: 200 }),
     body("description").isString().trim().isLength({ min: 1, max: 2000 }),
     body("assetType").isIn(ASSET_TYPES),
@@ -96,7 +101,11 @@ router.post(
   "/:id/purchase",
   [
     param("id").isInt({ min: 1 }),
-    body("buyer").isString().isLength({ min: 56, max: 56 }),
+    body("buyer")
+      .isString()
+      .bail()
+      .custom(isValidStellarAddress)
+      .withMessage("must be a valid Stellar public key"),
   ],
   validate,
   asyncHandler(async (req, res) => {

--- a/backend/src/routes/stellar.js
+++ b/backend/src/routes/stellar.js
@@ -4,6 +4,7 @@ const rateLimit = require("express-rate-limit");
 const validate = require("../middleware/validate");
 const { horizonServer, rpcServer, NETWORK, CONTRACT_IDS } = require("../config/stellar");
 const { getAccountTransactions } = require("../services/transactionService");
+const { isValidStellarAddress } = require("../utils/stellar");
 
 const router = Router();
 
@@ -25,7 +26,13 @@ const txRateLimiter = rateLimit({
  */
 router.get(
   "/account/:publicKey",
-  [param("publicKey").isString().isLength({ min: 56, max: 56 })],
+  [
+    param("publicKey")
+      .isString()
+      .bail()
+      .custom(isValidStellarAddress)
+      .withMessage("must be a valid Stellar public key"),
+  ],
   validate,
   async (req, res, next) => {
     try {
@@ -95,7 +102,11 @@ router.get(
   "/account/:publicKey/transactions",
   txRateLimiter,
   [
-    param("publicKey").isString().isLength({ min: 56, max: 56 }),
+    param("publicKey")
+      .isString()
+      .bail()
+      .custom(isValidStellarAddress)
+      .withMessage("must be a valid Stellar public key"),
     query("page").optional().isInt({ min: 1 }),
     query("limit").optional().isInt({ min: 1, max: 200 }),
     query("cursor").optional().isString().trim(),

--- a/backend/src/routes/streams.js
+++ b/backend/src/routes/streams.js
@@ -8,6 +8,7 @@ const {
   listStreams,
   STREAM_STATUSES,
 } = require("../services/streamService");
+const { isValidStellarAddress } = require("../utils/stellar");
 
 const router = Router();
 
@@ -18,8 +19,18 @@ const router = Router();
 router.get(
   "/",
   [
-    query("sender").optional().isString().isLength({ min: 56, max: 56 }),
-    query("recipient").optional().isString().isLength({ min: 56, max: 56 }),
+    query("sender")
+      .optional()
+      .isString()
+      .bail()
+      .custom(isValidStellarAddress)
+      .withMessage("must be a valid Stellar public key"),
+    query("recipient")
+      .optional()
+      .isString()
+      .bail()
+      .custom(isValidStellarAddress)
+      .withMessage("must be a valid Stellar public key"),
     query("status").optional().isIn(STREAM_STATUSES),
     query("page").optional().isInt({ min: 1 }),
     query("limit").optional().isInt({ min: 1, max: 100 }),
@@ -62,8 +73,16 @@ router.post(
   "/",
   [
     body("id").isInt({ min: 1 }),
-    body("sender").isString().isLength({ min: 56, max: 56 }),
-    body("recipient").isString().isLength({ min: 56, max: 56 }),
+    body("sender")
+      .isString()
+      .bail()
+      .custom(isValidStellarAddress)
+      .withMessage("must be a valid Stellar public key"),
+    body("recipient")
+      .isString()
+      .bail()
+      .custom(isValidStellarAddress)
+      .withMessage("must be a valid Stellar public key"),
     body("token").isString(),
     body("deposit").isInt({ min: 1 }),
     body("ratePerSecond").isInt({ min: 1 }),

--- a/backend/src/utils/stellar.js
+++ b/backend/src/utils/stellar.js
@@ -1,0 +1,17 @@
+const { StrKey } = require("@stellar/stellar-sdk");
+
+/**
+ * Check whether a value is a valid Stellar Ed25519 public key (a "G..."
+ * address). Accepts any input type — non-strings simply return false
+ * rather than throwing, so this is safe to call directly on unsanitized
+ * request data.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+function isValidStellarAddress(value) {
+  if (typeof value !== "string") return false;
+  return StrKey.isValidEd25519PublicKey(value);
+}
+
+module.exports = { isValidStellarAddress };


### PR DESCRIPTION
Adds isValidStellarAddress(), backed by stellar-sdk's StrKey.isValidEd25519PublicKey, and applies it to every route param and body/query field that accepts a Stellar public key (stellar.js, agents.js, assets.js, streams.js). Previously these fields only checked isString + 56-char length, which let checksum-invalid addresses reach Horizon/DB calls. Invalid values now return a 422 naming the offending field.

Closes #45