### PR TITLE
feat(cli): add cortex-admin operator CLI with AuthGate, AuditTrail, a…

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 dist/
 *.log
 coverage/
+src/cli/config/operators.json

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@stellar/stellar-sdk": "^13.1.0",
+        "blessed": "^0.1.81",
+        "commander": "^15.0.0",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
@@ -556,13 +558,13 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -2482,6 +2484,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/blessed": {
+      "version": "0.1.81",
+      "resolved": "https://registry.npmjs.org/blessed/-/blessed-0.1.81.tgz",
+      "integrity": "sha512-LoF5gae+hlmfORcG1M5+5XZi4LBmvlXTzwJWzUlPryN/SJdSflZvROM2TwkT0GMpq7oqT48NRd4GS7BiVBc5OQ==",
+      "license": "MIT",
+      "bin": {
+        "blessed": "bin/tput.js"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/body-parser": {
       "version": "1.20.6",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
@@ -2911,6 +2925,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/component-emitter": {
@@ -8224,7 +8247,7 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-     },
+    },
     "node_modules/zip-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,14 +3,20 @@
   "version": "0.1.0",
   "description": "Intelligence Rail backend API — agent discovery, asset indexing, and Stellar integration",
   "main": "src/index.js",
+  "bin": {
+    "cortex-admin": "src/cli/cortex-admin.js"
+  },
   "scripts": {
     "dev": "nodemon src/index.js",
     "start": "node src/index.js",
+    "admin": "node src/cli/cortex-admin.js",
     "lint": "eslint src/",
     "test": "jest --forceExit"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^13.1.0",
+    "blessed": "^0.1.81",
+    "commander": "^15.0.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",

--- a/backend/src/__tests__/cli/AuditTrail.test.js
+++ b/backend/src/__tests__/cli/AuditTrail.test.js
@@ -1,0 +1,70 @@
+jest.mock("../../repositories/adminActionRepository", () => ({
+  create: jest.fn(),
+  complete: jest.fn(),
+}));
+
+const adminActionRepository = require("../../repositories/adminActionRepository");
+const { withAudit } = require("../../cli/AuditTrail");
+
+const BASE_CALL = { operator: "GOPERATOR", role: "moderator", command: "agent ban", args: { id: 1 } };
+
+describe("AuditTrail.withAudit", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    adminActionRepository.create.mockResolvedValue({ id: 42 });
+  });
+
+  it("writes the admin_actions row before the command body runs", async () => {
+    const callOrder = [];
+    adminActionRepository.create.mockImplementation(async () => {
+      callOrder.push("create");
+      return { id: 42 };
+    });
+
+    await withAudit(BASE_CALL, async () => {
+      callOrder.push("command");
+      return { ok: true };
+    });
+
+    expect(callOrder).toEqual(["create", "command"]);
+    expect(adminActionRepository.create).toHaveBeenCalledWith(BASE_CALL);
+  });
+
+  it("stamps the row 'success' with the result when the command succeeds", async () => {
+    const result = await withAudit(BASE_CALL, async () => ({ banned: true }));
+
+    expect(result).toEqual({ banned: true });
+    expect(adminActionRepository.complete).toHaveBeenCalledWith(42, {
+      status: "success",
+      result: { banned: true },
+    });
+  });
+
+  it("writes an admin_actions entry even when the underlying command throws", async () => {
+    await expect(
+      withAudit(BASE_CALL, async () => {
+        throw new Error("stream 7 not found");
+      })
+    ).rejects.toThrow("stream 7 not found");
+
+    expect(adminActionRepository.create).toHaveBeenCalledTimes(1);
+    expect(adminActionRepository.complete).toHaveBeenCalledWith(42, {
+      status: "error",
+      error: "stream 7 not found",
+    });
+  });
+
+  it("still records the pending->error transition when the command crashes synchronously", async () => {
+    await expect(
+      withAudit(BASE_CALL, () => {
+        throw new Error("boom");
+      })
+    ).rejects.toThrow("boom");
+
+    expect(adminActionRepository.create).toHaveBeenCalledTimes(1);
+    expect(adminActionRepository.complete).toHaveBeenCalledWith(42, {
+      status: "error",
+      error: "boom",
+    });
+  });
+});

--- a/backend/src/__tests__/cli/AuthGate.test.js
+++ b/backend/src/__tests__/cli/AuthGate.test.js
@@ -1,0 +1,80 @@
+const { Keypair } = require("@stellar/stellar-sdk");
+const { authenticate, roleSatisfies, AuthError } = require("../../cli/AuthGate");
+
+const readonlyKp = Keypair.random();
+const moderatorKp = Keypair.random();
+const superadminKp = Keypair.random();
+const strangerKp = Keypair.random();
+
+const ALLOWLIST = [
+  { publicKey: readonlyKp.publicKey(), role: "readonly" },
+  { publicKey: moderatorKp.publicKey(), role: "moderator" },
+  { publicKey: superadminKp.publicKey(), role: "superadmin" },
+];
+
+describe("AuthGate.authenticate", () => {
+  it("rejects a command signed by a key not on the operator allowlist", () => {
+    expect(() =>
+      authenticate({ secretKey: strangerKp.secret(), minRole: "readonly", allowlist: ALLOWLIST })
+    ).toThrow(AuthError);
+    expect(() =>
+      authenticate({ secretKey: strangerKp.secret(), minRole: "readonly", allowlist: ALLOWLIST })
+    ).toThrow(/not on the operator allowlist/);
+  });
+
+  it("accepts an allowlisted key that meets the required role", () => {
+    const { publicKey, role } = authenticate({
+      secretKey: superadminKp.secret(),
+      minRole: "superadmin",
+      allowlist: ALLOWLIST,
+    });
+    expect(publicKey).toBe(superadminKp.publicKey());
+    expect(role).toBe("superadmin");
+  });
+
+  it.each(["moderator", "superadmin"])(
+    "rejects a readonly-role operator key on a command requiring '%s'",
+    (minRole) => {
+      expect(() =>
+        authenticate({ secretKey: readonlyKp.secret(), minRole, allowlist: ALLOWLIST })
+      ).toThrow(/has role 'readonly'/);
+    }
+  );
+
+  it("rejects a moderator-role operator key on a superadmin-only command", () => {
+    expect(() =>
+      authenticate({ secretKey: moderatorKp.secret(), minRole: "superadmin", allowlist: ALLOWLIST })
+    ).toThrow(AuthError);
+  });
+
+  it("allows a higher role than required (superadmin can run a readonly command)", () => {
+    expect(() =>
+      authenticate({ secretKey: superadminKp.secret(), minRole: "readonly", allowlist: ALLOWLIST })
+    ).not.toThrow();
+  });
+
+  it("requires a secret key to be configured", () => {
+    expect(() => authenticate({ secretKey: undefined, allowlist: ALLOWLIST })).toThrow(
+      /OPERATOR_SECRET_KEY is not set/
+    );
+  });
+
+  it("rejects a malformed secret key", () => {
+    expect(() => authenticate({ secretKey: "not-a-real-key", allowlist: ALLOWLIST })).toThrow(
+      /invalid operator secret key/
+    );
+  });
+});
+
+describe("roleSatisfies", () => {
+  it.each([
+    ["superadmin", "readonly", true],
+    ["superadmin", "moderator", true],
+    ["superadmin", "superadmin", true],
+    ["moderator", "superadmin", false],
+    ["readonly", "moderator", false],
+    ["bogus", "readonly", false],
+  ])("roleSatisfies(%s, %s) === %s", (role, minRole, expected) => {
+    expect(roleSatisfies(role, minRole)).toBe(expected);
+  });
+});

--- a/backend/src/__tests__/cli/commands.integration.test.js
+++ b/backend/src/__tests__/cli/commands.integration.test.js
@@ -1,0 +1,200 @@
+/**
+ * DB-backed integration coverage for the two cortex-admin acceptance
+ * criteria that can't be proven with mocks:
+ *
+ *   1. No admin action can bypass the audit trail — every mutating command
+ *      is attempted end-to-end and admin_actions is checked afterward.
+ *   2. A readonly-role operator key is provably rejected by every mutating
+ *      command.
+ *
+ * Runs against the real Postgres container (see globalSetup.js), invoking
+ * the command modules directly rather than mocking their dependencies.
+ */
+
+const { Keypair } = require("@stellar/stellar-sdk");
+const { query, closePool } = require("../../db/connection");
+const { AuthError } = require("../../cli/AuthGate");
+
+const contractCmd = require("../../cli/commands/contract");
+const streamCmd = require("../../cli/commands/stream");
+const agentCmd = require("../../cli/commands/agent");
+const licenseCmd = require("../../cli/commands/license");
+const eventsCmd = require("../../cli/commands/events");
+
+const assetRepository = require("../../repositories/assetRepository");
+const agentRepository = require("../../repositories/agentRepository");
+const streamRepository = require("../../repositories/streamRepository");
+const licenseRepository = require("../../repositories/licenseRepository");
+const agentBanRepository = require("../../repositories/agentBanRepository");
+const eventLogRepository = require("../../repositories/eventLogRepository");
+
+const { truncateAll, buildAsset, buildAgent, buildStream, buildEvent, OWNER_B } = require("../helpers/testDb");
+
+const readonlyKp = Keypair.random();
+const moderatorKp = Keypair.random();
+const superadminKp = Keypair.random();
+
+const ALLOWLIST = [
+  { publicKey: readonlyKp.publicKey(), role: "readonly" },
+  { publicKey: moderatorKp.publicKey(), role: "moderator" },
+  { publicKey: superadminKp.publicKey(), role: "superadmin" },
+];
+
+function asOperator(keypair) {
+  process.env.OPERATOR_SECRET_KEY = keypair.secret();
+}
+
+beforeEach(async () => {
+  await truncateAll();
+  process.env.OPERATOR_ALLOWLIST = JSON.stringify(ALLOWLIST);
+});
+
+afterEach(() => {
+  delete process.env.OPERATOR_ALLOWLIST;
+  delete process.env.OPERATOR_SECRET_KEY;
+});
+
+afterAll(async () => {
+  await closePool();
+});
+
+async function adminActionCount() {
+  const { rows } = await query("SELECT count(*)::int AS n FROM admin_actions");
+  return rows[0].n;
+}
+
+async function latestAdminAction() {
+  const { rows } = await query("SELECT * FROM admin_actions ORDER BY id DESC LIMIT 1");
+  return rows[0];
+}
+
+// Every state-changing command, each exercised with real fixtures and a
+// real (mocked-nothing) call into the command module.
+const MUTATING_COMMANDS = [
+  {
+    name: "contract pause",
+    authorized: superadminKp,
+    run: () => contractCmd.pause("marketplace"),
+  },
+  {
+    name: "contract unpause",
+    authorized: superadminKp,
+    run: () => contractCmd.unpause("marketplace"),
+  },
+  {
+    name: "stream force-settle",
+    authorized: moderatorKp,
+    setup: async () => {
+      const stream = buildStream({ status: "Active" });
+      await streamRepository.create(stream);
+      return stream.id;
+    },
+    run: (id) => streamCmd.forceSettle(id),
+  },
+  {
+    name: "agent ban",
+    authorized: moderatorKp,
+    setup: async () => {
+      const agent = buildAgent();
+      await agentRepository.create(agent);
+      return agent.id;
+    },
+    run: (id) => agentCmd.ban(id, "abusive behavior"),
+  },
+  {
+    name: "agent unban",
+    authorized: moderatorKp,
+    setup: async () => {
+      const agent = buildAgent();
+      await agentRepository.create(agent);
+      await agentBanRepository.ban(agent.id, { reason: "prior ban", bannedBy: "GOPERATOR" });
+      return agent.id;
+    },
+    run: (id) => agentCmd.unban(id),
+  },
+  {
+    name: "license revoke",
+    authorized: moderatorKp,
+    setup: async () => {
+      const asset = await assetRepository.create(buildAsset({ licenseType: "UsageBased" }));
+      const license = await licenseRepository.create({
+        assetId: asset.id,
+        buyer: OWNER_B,
+        licenseType: "UsageBased",
+        pricePaid: 0,
+        callsRemaining: 100,
+        expiresAt: null,
+      });
+      return license.id;
+    },
+    run: (id) => licenseCmd.revoke(id, "policy violation"),
+  },
+  {
+    name: "events replay",
+    authorized: superadminKp,
+    setup: async () => {
+      await eventLogRepository.append(buildEvent({ ledger: 500, txHash: "tx-replay-1" }));
+      await eventLogRepository.append(buildEvent({ ledger: 501, txHash: "tx-replay-2" }));
+      return { from: 500, to: 501 };
+    },
+    run: ({ from, to }) => eventsCmd.replay(from, to),
+  },
+];
+
+describe.each(MUTATING_COMMANDS)("cortex-admin $name", ({ authorized, name, setup, run }) => {
+  it("writes an admin_actions row and succeeds when the operator is authorized", async () => {
+    const arg = setup ? await setup() : undefined;
+    asOperator(authorized);
+
+    const before = await adminActionCount();
+    await run(arg);
+    const after = await adminActionCount();
+
+    expect(after).toBe(before + 1);
+    const action = await latestAdminAction();
+    expect(action.command).toBe(name);
+    expect(action.status).toBe("success");
+    expect(action.operator).toBe(authorized.publicKey());
+  });
+
+  it("rejects a readonly-role operator key without writing any admin_actions row", async () => {
+    const arg = setup ? await setup() : undefined;
+    asOperator(readonlyKp);
+
+    const before = await adminActionCount();
+    await expect(run(arg)).rejects.toThrow(AuthError);
+    const after = await adminActionCount();
+
+    // Auth happens before AuditTrail runs — a rejected operator never gets
+    // the chance to attempt the command, so no row (pending or otherwise)
+    // should exist for it.
+    expect(after).toBe(before);
+  });
+});
+
+describe("admin_actions cannot be bypassed across a full command run", () => {
+  it("leaves exactly one successful admin_actions row per mutating command attempted", async () => {
+    for (const { authorized, run, setup } of MUTATING_COMMANDS) {
+      const arg = setup ? await setup() : undefined;
+      asOperator(authorized);
+      await run(arg);
+    }
+
+    const { rows } = await query("SELECT command, status FROM admin_actions ORDER BY id ASC");
+    expect(rows).toHaveLength(MUTATING_COMMANDS.length);
+    expect(rows.every((r) => r.status === "success")).toBe(true);
+    expect(rows.map((r) => r.command)).toEqual(MUTATING_COMMANDS.map((c) => c.name));
+  });
+
+  it("still records the attempt when the command itself fails", async () => {
+    // force-settling a stream that doesn't exist reaches BatchSettler and
+    // throws from inside the audited call — the row must still land.
+    asOperator(moderatorKp);
+    await expect(streamCmd.forceSettle(999_999)).rejects.toThrow(/not found/);
+
+    const action = await latestAdminAction();
+    expect(action.command).toBe("stream force-settle");
+    expect(action.status).toBe("error");
+    expect(action.error).toMatch(/not found/);
+  });
+});

--- a/backend/src/__tests__/cli/tui/__snapshots__/render.test.js.snap
+++ b/backend/src/__tests__/cli/tui/__snapshots__/render.test.js.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TUI dashboard rendering renders all four panels from a live-data snapshot 1`] = `
+{
+  "deadLetters": "{bold}Dead-lettered settlements{/bold}
+ledger 481900  processor threw: unknown topic",
+  "disputes": "{bold}Open disputes{/bold}
+#5  asset 101  Plagiarism  2023-11-14 22:13:20
+#6  asset 102  Spam  2023-11-14 22:15:00",
+  "pipeline": "{bold}Pipeline{/bold}
+last processed ledger: 481920
+events/min:            12
+p99 latency:            84ms
+queue depth:            3
+dead letters:           1
+circuit breaker:        closed",
+  "recentActions": "{bold}Recent admin actions{/bold}
+2023-11-14 22:16:40  GOPERATOR1  stream force-settle  {green-fg}ok{/green-fg}
+2023-11-14 22:18:20  GOPERATOR2  agent ban  {red-fg}err{/red-fg}",
+}
+`;
+
+exports[`TUI dashboard rendering renders empty-state placeholders when there's nothing to show 1`] = `
+{
+  "deadLetters": "{bold}Dead-lettered settlements{/bold}
+(none)",
+  "disputes": "{bold}Open disputes{/bold}
+(none)",
+  "pipeline": "{bold}Pipeline{/bold}
+last processed ledger: 0
+events/min:            0
+p99 latency:            0ms
+queue depth:            0
+dead letters:           0
+circuit breaker:        closed",
+  "recentActions": "{bold}Recent admin actions{/bold}
+(none)",
+}
+`;

--- a/backend/src/__tests__/cli/tui/dashboard.integration.test.js
+++ b/backend/src/__tests__/cli/tui/dashboard.integration.test.js
@@ -1,0 +1,56 @@
+/**
+ * DB-backed proof of the third acceptance criterion: the TUI dashboard
+ * reflects a manually triggered state change within one refresh cycle.
+ *
+ * `fetchData()` is exactly what dashboard.js's setInterval tick calls on
+ * every refresh, so calling it once after a real forced settlement is a
+ * faithful test of "one refresh cycle" without needing a real terminal
+ * (blessed requires a TTY, which isn't available in CI).
+ */
+
+const { Keypair } = require("@stellar/stellar-sdk");
+const { closePool } = require("../../../db/connection");
+const streamRepository = require("../../../repositories/streamRepository");
+const streamCmd = require("../../../cli/commands/stream");
+const { fetchData } = require("../../../cli/tui/dashboard");
+const { renderDashboard } = require("../../../cli/tui/render");
+const { truncateAll, buildStream } = require("../../helpers/testDb");
+
+const moderatorKp = Keypair.random();
+const ALLOWLIST = [{ publicKey: moderatorKp.publicKey(), role: "moderator" }];
+
+beforeEach(async () => {
+  await truncateAll();
+  process.env.OPERATOR_ALLOWLIST = JSON.stringify(ALLOWLIST);
+  process.env.OPERATOR_SECRET_KEY = moderatorKp.secret();
+});
+
+afterEach(() => {
+  delete process.env.OPERATOR_ALLOWLIST;
+  delete process.env.OPERATOR_SECRET_KEY;
+});
+
+afterAll(async () => {
+  await closePool();
+});
+
+describe("dashboard reflects a manually triggered state change within one refresh cycle", () => {
+  it("shows a forced settlement in the recent admin actions panel after a single fetchData() call", async () => {
+    const stream = buildStream({ status: "Active" });
+    await streamRepository.create(stream);
+
+    const before = await fetchData();
+    expect(before.recentActions.some((a) => a.command === "stream force-settle")).toBe(false);
+
+    await streamCmd.forceSettle(stream.id);
+
+    // One refresh cycle == one fetchData() call.
+    const after = await fetchData();
+    const action = after.recentActions.find((a) => a.command === "stream force-settle");
+    expect(action).toBeDefined();
+    expect(action.status).toBe("success");
+
+    const rendered = renderDashboard(after);
+    expect(rendered.recentActions).toContain("stream force-settle");
+  });
+});

--- a/backend/src/__tests__/cli/tui/render.test.js
+++ b/backend/src/__tests__/cli/tui/render.test.js
@@ -1,0 +1,54 @@
+const { renderDashboard } = require("../../../cli/tui/render");
+
+const MOCKED_DATA = {
+  metrics: {
+    events_per_minute: 12,
+    processing_latency_p99: 84,
+    queue_depth: 3,
+    dead_letter_count: 1,
+    last_processed_ledger: 481920,
+  },
+  status: { circuitOpen: false },
+  disputes: [
+    { id: 5, assetId: 101, reason: "Plagiarism", createdAt: 1_700_000_000_000 },
+    { id: 6, assetId: 102, reason: "Spam", createdAt: 1_700_000_100_000 },
+  ],
+  deadLetters: [{ event: { ledger: 481900 }, error: "processor threw: unknown topic" }],
+  recentActions: [
+    { operator: "GOPERATOR1", command: "stream force-settle", status: "success", createdAt: 1_700_000_200_000 },
+    { operator: "GOPERATOR2", command: "agent ban", status: "error", createdAt: 1_700_000_300_000 },
+  ],
+};
+
+describe("TUI dashboard rendering", () => {
+  it("renders all four panels from a live-data snapshot", () => {
+    expect(renderDashboard(MOCKED_DATA)).toMatchSnapshot();
+  });
+
+  it("renders empty-state placeholders when there's nothing to show", () => {
+    expect(
+      renderDashboard({
+        metrics: {},
+        status: {},
+        disputes: [],
+        deadLetters: [],
+        recentActions: [],
+      })
+    ).toMatchSnapshot();
+  });
+
+  it("reflects a manually triggered state change within one refresh cycle", () => {
+    const before = renderDashboard(MOCKED_DATA);
+    const after = renderDashboard({
+      ...MOCKED_DATA,
+      recentActions: [
+        { operator: "GOPERATOR3", command: "stream force-settle", status: "success", createdAt: 1_700_000_400_000 },
+        ...MOCKED_DATA.recentActions,
+      ],
+    });
+
+    expect(after.recentActions).not.toEqual(before.recentActions);
+    expect(after.recentActions).toContain("stream force-settle");
+    expect(after.recentActions.split("\n")).toHaveLength(before.recentActions.split("\n").length + 1);
+  });
+});

--- a/backend/src/__tests__/helpers/testDb.js
+++ b/backend/src/__tests__/helpers/testDb.js
@@ -12,7 +12,9 @@ const { query, closePool } = require("../../db/connection");
  */
 async function truncateAll() {
   await query(
-    "TRUNCATE TABLE reports, licenses, events_log, event_cursor, streams, agents, assets RESTART IDENTITY CASCADE"
+    `TRUNCATE TABLE reports, licenses, events_log, event_cursor, streams, agents, assets,
+       admin_actions, agent_bans, contract_state
+     RESTART IDENTITY CASCADE`
   );
 }
 

--- a/backend/src/__tests__/services/agentService.test.js
+++ b/backend/src/__tests__/services/agentService.test.js
@@ -1,0 +1,40 @@
+jest.mock("../../repositories/agentRepository", () => ({
+  create: jest.fn(),
+  updateReputation: jest.fn(),
+}));
+
+jest.mock("../../repositories/agentBanRepository", () => ({
+  isBanned: jest.fn(),
+}));
+
+const agentRepository = require("../../repositories/agentRepository");
+const agentBanRepository = require("../../repositories/agentBanRepository");
+const { registerAgent, updateAgentReputation } = require("../../services/agentService");
+
+describe("agentService ban enforcement", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("registerAgent rejects a banned agent id without touching the repository", async () => {
+    agentBanRepository.isBanned.mockResolvedValue(true);
+
+    await expect(registerAgent({ id: 7, owner: "GOWNER", name: "Bot" })).rejects.toThrow(/banned/);
+    expect(agentRepository.create).not.toHaveBeenCalled();
+  });
+
+  it("registerAgent proceeds when the agent isn't banned", async () => {
+    agentBanRepository.isBanned.mockResolvedValue(false);
+    agentRepository.create.mockResolvedValue({ id: 7 });
+
+    await registerAgent({ id: 7, owner: "GOWNER", name: "Bot" });
+    expect(agentRepository.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("updateAgentReputation rejects a banned agent without touching the repository", async () => {
+    agentBanRepository.isBanned.mockResolvedValue(true);
+
+    await expect(updateAgentReputation(7, 6000)).rejects.toThrow(/banned/);
+    expect(agentRepository.updateReputation).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/__tests__/services/licenseService.test.js
+++ b/backend/src/__tests__/services/licenseService.test.js
@@ -13,10 +13,16 @@ jest.mock("../../repositories/licenseRepository", () => ({
   findByBuyerAndAsset: jest.fn(),
   findAllByBuyer: jest.fn(),
   expire: jest.fn(),
+  updateCallsRemaining: jest.fn(),
+}));
+
+jest.mock("../../repositories/contractStateRepository", () => ({
+  isPaused: jest.fn(),
 }));
 
 const assetRepository = require("../../repositories/assetRepository");
 const licenseRepository = require("../../repositories/licenseRepository");
+const contractStateRepository = require("../../repositories/contractStateRepository");
 const { purchaseLicense } = require("../../services/licenseService");
 
 const ASSET = {
@@ -29,6 +35,7 @@ const ASSET = {
 describe("licenseService asset version selection", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    contractStateRepository.isPaused.mockResolvedValue(false);
     assetRepository.findById.mockResolvedValue(ASSET);
     assetRepository.incrementUsage.mockResolvedValue(12);
     licenseRepository.create.mockImplementation(async (license) => ({
@@ -72,6 +79,14 @@ describe("licenseService asset version selection", () => {
       purchaseLicense({ assetId: 42, buyer: "GBUYER", assetVersion })
     ).rejects.toThrow(error);
     expect(assetRepository.incrementUsage).not.toHaveBeenCalled();
+    expect(licenseRepository.create).not.toHaveBeenCalled();
+  });
+
+  it("refuses to purchase while the marketplace contract is paused", async () => {
+    contractStateRepository.isPaused.mockResolvedValue(true);
+
+    await expect(purchaseLicense({ assetId: 42, buyer: "GBUYER" })).rejects.toThrow(/marketplace is paused/);
+    expect(assetRepository.findById).not.toHaveBeenCalled();
     expect(licenseRepository.create).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/cli/AuditTrail.js
+++ b/backend/src/cli/AuditTrail.js
@@ -1,0 +1,28 @@
+/**
+ * AuditTrail — wraps every state-changing cortex-admin command so intent is
+ * durable before the command body runs.
+ *
+ * `withAudit` writes a 'pending' admin_actions row first, then runs the
+ * command. If the command throws (including a crash mid-operation), the row
+ * is stamped 'error' with the message; on success it's stamped 'success'
+ * with the returned result. Either way, the row insertion happens before
+ * any side effect the command performs, so `admin_actions` always reflects
+ * what was attempted even when the attempt didn't finish.
+ */
+
+const adminActionRepository = require("../repositories/adminActionRepository");
+
+async function withAudit({ operator, role, command, args = {} }, fn) {
+  const action = await adminActionRepository.create({ operator, role, command, args });
+
+  try {
+    const result = await fn();
+    await adminActionRepository.complete(action.id, { status: "success", result: result ?? null });
+    return result;
+  } catch (err) {
+    await adminActionRepository.complete(action.id, { status: "error", error: err.message });
+    throw err;
+  }
+}
+
+module.exports = { withAudit };

--- a/backend/src/cli/AuthGate.js
+++ b/backend/src/cli/AuthGate.js
@@ -1,0 +1,96 @@
+/**
+ * AuthGate — every cortex-admin command signs a fresh challenge with the
+ * operator's Stellar keypair to prove key possession, then checks the
+ * resulting public key against the operator allowlist and the role the
+ * command requires.
+ *
+ * The allowlist is a config file (OPERATOR_ALLOWLIST_PATH, or an inline
+ * OPERATOR_ALLOWLIST_PATH JSON array via OPERATOR_ALLOWLIST for tests/CI)
+ * of { publicKey, role } entries. An on-chain allowlist can replace this
+ * loader later without touching call sites — everything downstream only
+ * depends on the { publicKey, role } shape `authenticate` returns.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { Keypair } = require("@stellar/stellar-sdk");
+
+const ROLE_LEVELS = { readonly: 0, moderator: 1, superadmin: 2 };
+
+const DEFAULT_ALLOWLIST_PATH = path.join(__dirname, "config", "operators.json");
+
+class AuthError extends Error {}
+
+function loadAllowlist(allowlistPath = process.env.OPERATOR_ALLOWLIST_PATH || DEFAULT_ALLOWLIST_PATH) {
+  if (process.env.OPERATOR_ALLOWLIST) {
+    return JSON.parse(process.env.OPERATOR_ALLOWLIST);
+  }
+  if (!fs.existsSync(allowlistPath)) {
+    return [];
+  }
+  return JSON.parse(fs.readFileSync(allowlistPath, "utf8"));
+}
+
+function findOperator(publicKey, allowlist) {
+  return allowlist.find((entry) => entry.publicKey === publicKey) || null;
+}
+
+function roleSatisfies(role, minRole) {
+  return ROLE_LEVELS[role] !== undefined && ROLE_LEVELS[role] >= ROLE_LEVELS[minRole];
+}
+
+/**
+ * Sign a time-boxed challenge with the operator's secret key, verify the
+ * signature, then authorize the resulting public key against the allowlist.
+ *
+ * @param {object} options
+ * @param {string} [options.secretKey] - defaults to OPERATOR_SECRET_KEY
+ * @param {'readonly'|'moderator'|'superadmin'} [options.minRole]
+ * @param {Array<{publicKey: string, role: string}>} [options.allowlist] - override for tests
+ * @returns {{ publicKey: string, role: string }}
+ */
+function authenticate({ secretKey = process.env.OPERATOR_SECRET_KEY, minRole = "readonly", allowlist } = {}) {
+  if (ROLE_LEVELS[minRole] === undefined) {
+    throw new AuthError(`unknown role requirement '${minRole}'`);
+  }
+
+  if (!secretKey) {
+    throw new AuthError("OPERATOR_SECRET_KEY is not set — cannot sign the operator challenge");
+  }
+
+  let keypair;
+  try {
+    keypair = Keypair.fromSecret(secretKey);
+  } catch (err) {
+    throw new AuthError(`invalid operator secret key: ${err.message}`);
+  }
+
+  const challenge = Buffer.from(`cortex-admin:${Date.now()}:${Math.random()}`);
+  const signature = keypair.sign(challenge);
+  if (!keypair.verify(challenge, signature)) {
+    throw new AuthError("challenge signature verification failed");
+  }
+
+  const publicKey = keypair.publicKey();
+  const list = allowlist || loadAllowlist();
+  const operator = findOperator(publicKey, list);
+  if (!operator) {
+    throw new AuthError(`operator ${publicKey} is not on the operator allowlist`);
+  }
+
+  if (!roleSatisfies(operator.role, minRole)) {
+    throw new AuthError(
+      `operator ${publicKey} has role '${operator.role}'; this command requires at least '${minRole}'`
+    );
+  }
+
+  return { publicKey, role: operator.role };
+}
+
+module.exports = {
+  authenticate,
+  loadAllowlist,
+  roleSatisfies,
+  ROLE_LEVELS,
+  AuthError,
+};

--- a/backend/src/cli/commands/agent.js
+++ b/backend/src/cli/commands/agent.js
@@ -1,0 +1,53 @@
+/**
+ * `agent ban <id> --reason <text>` / `agent unban <id>` — moderator+.
+ *
+ * The identifier is the agent's on-chain registration id (agents.id), the
+ * same id every other agent-scoped route and command uses — an owner
+ * wallet can control more than one agent, so the ban has to target the
+ * specific agent record, not the wallet. The ban is consulted by
+ * agentService.js on every agent write path (see registerAgent /
+ * updateAgentReputation).
+ */
+
+const { authenticate } = require("../AuthGate");
+const { withAudit } = require("../AuditTrail");
+const agentRepository = require("../../repositories/agentRepository");
+const agentBanRepository = require("../../repositories/agentBanRepository");
+
+async function ban(id, reason) {
+  const agentId = Number(id);
+  if (!reason) {
+    throw new Error("--reason is required");
+  }
+
+  const { publicKey, role } = authenticate({ minRole: "moderator" });
+
+  return withAudit(
+    { operator: publicKey, role, command: "agent ban", args: { id: agentId, reason } },
+    async () => {
+      const agent = await agentRepository.findById(agentId);
+      if (!agent) {
+        throw new Error(`agent ${agentId} not found`);
+      }
+      return agentBanRepository.ban(agentId, { reason, bannedBy: publicKey });
+    }
+  );
+}
+
+async function unban(id) {
+  const agentId = Number(id);
+  const { publicKey, role } = authenticate({ minRole: "moderator" });
+
+  return withAudit(
+    { operator: publicKey, role, command: "agent unban", args: { id: agentId } },
+    async () => {
+      const removed = await agentBanRepository.unban(agentId);
+      if (!removed) {
+        throw new Error(`agent ${agentId} has no active ban`);
+      }
+      return { agentId, unbanned: true };
+    }
+  );
+}
+
+module.exports = { ban, unban };

--- a/backend/src/cli/commands/contract.js
+++ b/backend/src/cli/commands/contract.js
@@ -1,0 +1,48 @@
+/**
+ * `contract pause|unpause <name>` — superadmin only.
+ *
+ * Toggles the off-chain `contract_state.paused` flag that services consult
+ * before performing the write the named contract backs (today: licenseService
+ * checks 'marketplace' before purchaseLicense). Recognized names match the
+ * three deployed contracts in ../../config/stellar CONTRACT_IDS.
+ *
+ * NOTE: the Soroban contracts themselves don't yet expose an on-chain pause
+ * entrypoint — that's tracked as follow-up work. This flag is the backend's
+ * own enforcement point in the meantime, and every service that should
+ * respect a pause needs its own `contractStateRepository.isPaused(name)`
+ * check (see licenseService.purchaseLicense for the pattern).
+ */
+
+const { authenticate } = require("../AuthGate");
+const { withAudit } = require("../AuditTrail");
+const contractStateRepository = require("../../repositories/contractStateRepository");
+
+const KNOWN_CONTRACTS = ["marketplace", "micropayments", "agent_registry"];
+
+function assertKnownContract(name) {
+  if (!KNOWN_CONTRACTS.includes(name)) {
+    throw new Error(`unknown contract '${name}'; expected one of ${KNOWN_CONTRACTS.join(", ")}`);
+  }
+}
+
+async function pause(name) {
+  assertKnownContract(name);
+  const { publicKey, role } = authenticate({ minRole: "superadmin" });
+
+  return withAudit(
+    { operator: publicKey, role, command: "contract pause", args: { name } },
+    () => contractStateRepository.setPaused(name, true, publicKey)
+  );
+}
+
+async function unpause(name) {
+  assertKnownContract(name);
+  const { publicKey, role } = authenticate({ minRole: "superadmin" });
+
+  return withAudit(
+    { operator: publicKey, role, command: "contract unpause", args: { name } },
+    () => contractStateRepository.setPaused(name, false, publicKey)
+  );
+}
+
+module.exports = { pause, unpause, KNOWN_CONTRACTS };

--- a/backend/src/cli/commands/events.js
+++ b/backend/src/cli/commands/events.js
@@ -1,0 +1,29 @@
+/**
+ * `events replay --from-ledger <n> --to-ledger <m>` — superadmin only.
+ *
+ * Re-runs already-ingested raw events (events_log) through EventProcessor
+ * for a historical ledger range — recovery from a processing bug that's
+ * since been fixed, without re-fetching from RPC or touching the live
+ * pipeline cursor.
+ */
+
+const { authenticate } = require("../AuthGate");
+const { withAudit } = require("../AuditTrail");
+const EventPipeline = require("../../pipeline/EventPipeline");
+
+async function replay(fromLedger, toLedger) {
+  const from = Number(fromLedger);
+  const to = Number(toLedger);
+  if (!Number.isInteger(from) || !Number.isInteger(to) || from > to) {
+    throw new Error("--from-ledger must be an integer <= --to-ledger");
+  }
+
+  const { publicKey, role } = authenticate({ minRole: "superadmin" });
+
+  return withAudit(
+    { operator: publicKey, role, command: "events replay", args: { fromLedger: from, toLedger: to } },
+    () => EventPipeline.replayLedgerRange(from, to)
+  );
+}
+
+module.exports = { replay };

--- a/backend/src/cli/commands/license.js
+++ b/backend/src/cli/commands/license.js
@@ -1,0 +1,23 @@
+/**
+ * `license revoke <id> --reason <text>` — moderator+.
+ */
+
+const { authenticate } = require("../AuthGate");
+const { withAudit } = require("../AuditTrail");
+const licenseService = require("../../services/licenseService");
+
+async function revoke(id, reason) {
+  const licenseId = Number(id);
+  if (!reason) {
+    throw new Error("--reason is required");
+  }
+
+  const { publicKey, role } = authenticate({ minRole: "moderator" });
+
+  return withAudit(
+    { operator: publicKey, role, command: "license revoke", args: { id: licenseId, reason } },
+    () => licenseService.revokeLicense(licenseId)
+  );
+}
+
+module.exports = { revoke };

--- a/backend/src/cli/commands/stream.js
+++ b/backend/src/cli/commands/stream.js
@@ -1,0 +1,42 @@
+/**
+ * `stream force-settle <id>` (moderator+) and `stream inspect <id>` (readonly).
+ */
+
+const { authenticate } = require("../AuthGate");
+const { withAudit } = require("../AuditTrail");
+const streamRepository = require("../../repositories/streamRepository");
+const eventLogRepository = require("../../repositories/eventLogRepository");
+const BatchSettler = require("../../protocol/BatchSettler");
+const { CONTRACT_IDS } = require("../../config/stellar");
+
+async function forceSettle(id) {
+  const streamId = Number(id);
+  const { publicKey, role } = authenticate({ minRole: "moderator" });
+
+  return withAudit(
+    { operator: publicKey, role, command: "stream force-settle", args: { id: streamId } },
+    () => BatchSettler.forceSettleStream(streamId)
+  );
+}
+
+/**
+ * Dumps the indexed stream row plus its recent on-chain event history —
+ * readonly, no audit entry (nothing is mutated).
+ */
+async function inspect(id) {
+  const streamId = Number(id);
+  authenticate({ minRole: "readonly" });
+
+  const stream = await streamRepository.findById(streamId);
+  if (!stream) {
+    throw new Error(`stream ${streamId} not found`);
+  }
+
+  const recentEvents = CONTRACT_IDS.micropayments
+    ? await eventLogRepository.findRecentByContract(CONTRACT_IDS.micropayments, { limit: 20 })
+    : [];
+
+  return { stream, recentEvents };
+}
+
+module.exports = { forceSettle, inspect };

--- a/backend/src/cli/config/operators.example.json
+++ b/backend/src/cli/config/operators.example.json
@@ -1,0 +1,14 @@
+[
+  {
+    "publicKey": "GA6HCMBLTZS5VYYBCATRBRZ3BZJMAFUDKYYF6AH6MVCMGWMRDNSWJPIH",
+    "role": "readonly"
+  },
+  {
+    "publicKey": "GBHPPBAY65KWA5AAJTRNHR2M7C5NIT4RLZLDBKDX7HZJEC7JOMKZOD5D",
+    "role": "moderator"
+  },
+  {
+    "publicKey": "GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W37",
+    "role": "superadmin"
+  }
+]

--- a/backend/src/cli/cortex-admin.js
+++ b/backend/src/cli/cortex-admin.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+/**
+ * cortex-admin — the operator CLI for Cortex Protocol.
+ *
+ * Every subcommand goes through AuthGate (signs a challenge with
+ * OPERATOR_SECRET_KEY, checks the resulting key + role against the
+ * operator allowlist) and, for state-changing commands, AuditTrail (writes
+ * an admin_actions row before executing). See AuthGate.js and
+ * AuditTrail.js for the mechanics; commands/*.js wire them into each
+ * operation.
+ *
+ *   cortex-admin contract pause <name>
+ *   cortex-admin contract unpause <name>
+ *   cortex-admin stream force-settle <id>
+ *   cortex-admin stream inspect <id>
+ *   cortex-admin agent ban <id> --reason <text>
+ *   cortex-admin agent unban <id>
+ *   cortex-admin license revoke <id> --reason <text>
+ *   cortex-admin events replay --from-ledger <n> --to-ledger <m>
+ *   cortex-admin dashboard
+ */
+
+require("dotenv").config();
+const { Command } = require("commander");
+const { closePool } = require("../db/connection");
+
+const contractCmd = require("./commands/contract");
+const streamCmd = require("./commands/stream");
+const agentCmd = require("./commands/agent");
+const licenseCmd = require("./commands/license");
+const eventsCmd = require("./commands/events");
+
+const program = new Command();
+program.name("cortex-admin").description("Cortex Protocol operator CLI").version("0.1.0");
+
+function printResult(result) {
+  console.log(JSON.stringify(result, null, 2));
+}
+
+/**
+ * Wraps a command action so auth/audit/business errors print a single
+ * clean line instead of a raw stack trace, and the pg pool always drains
+ * before the process exits (this is a short-lived CLI process, not the
+ * long-running server).
+ */
+function action(fn) {
+  return async (...args) => {
+    try {
+      const result = await fn(...args);
+      printResult(result);
+    } catch (err) {
+      console.error(`cortex-admin: ${err.message}`);
+      process.exitCode = 1;
+    } finally {
+      await closePool();
+    }
+  };
+}
+
+const contract = program.command("contract").description("Pause/unpause protocol contracts (superadmin)");
+contract
+  .command("pause <name>")
+  .description("Pause a contract's write path")
+  .action(action((name) => contractCmd.pause(name)));
+contract
+  .command("unpause <name>")
+  .description("Unpause a contract's write path")
+  .action(action((name) => contractCmd.unpause(name)));
+
+const stream = program.command("stream").description("Payment stream operations");
+stream
+  .command("force-settle <id>")
+  .description("Force-settle a stuck stream outside its normal schedule (moderator+)")
+  .action(action((id) => streamCmd.forceSettle(id)));
+stream
+  .command("inspect <id>")
+  .description("Dump full on-chain + off-chain state for a stream (readonly)")
+  .action(action((id) => streamCmd.inspect(id)));
+
+const agent = program.command("agent").description("Agent moderation");
+agent
+  .command("ban <id>")
+  .description("Ban an agent from all write paths (moderator+)")
+  .requiredOption("--reason <text>", "reason for the ban")
+  .action(action((id, opts) => agentCmd.ban(id, opts.reason)));
+agent
+  .command("unban <id>")
+  .description("Lift an agent ban (moderator+)")
+  .action(action((id) => agentCmd.unban(id)));
+
+const license = program.command("license").description("License moderation");
+license
+  .command("revoke <id>")
+  .description("Zero a license's remaining metered calls (moderator+)")
+  .requiredOption("--reason <text>", "reason for revocation")
+  .action(action((id, opts) => licenseCmd.revoke(id, opts.reason)));
+
+const events = program.command("events").description("Event pipeline recovery");
+events
+  .command("replay")
+  .description("Re-run the pipeline over a historical ledger range (superadmin)")
+  .requiredOption("--from-ledger <n>", "first ledger (inclusive)")
+  .requiredOption("--to-ledger <n>", "last ledger (inclusive)")
+  .action(action((opts) => eventsCmd.replay(opts.fromLedger, opts.toLedger)));
+
+program
+  .command("dashboard")
+  .description("Launch the live operator TUI")
+  .option("--refresh-ms <n>", "panel refresh interval in ms", "3000")
+  .action(async (opts) => {
+    // The TUI owns the process until the operator quits — no closePool()
+    // here, dashboard.js's own key handler exits the process.
+    const dashboard = require("./tui/dashboard");
+    try {
+      dashboard.start({ refreshIntervalMs: Number(opts.refreshMs) });
+    } catch (err) {
+      console.error(`cortex-admin: ${err.message}`);
+      process.exitCode = 1;
+    }
+  });
+
+if (require.main === module) {
+  program.parseAsync(process.argv);
+}
+
+module.exports = program;

--- a/backend/src/cli/tui/dashboard.js
+++ b/backend/src/cli/tui/dashboard.js
@@ -1,0 +1,133 @@
+/**
+ * `cortex-admin dashboard` — live-updating operator TUI.
+ *
+ * Four panels (pipeline lag, open disputes, dead-lettered settlements,
+ * recent admin actions) refresh on a timer so a manually triggered state
+ * change — e.g. a forced settlement from another terminal — shows up
+ * within one refresh cycle. Tab cycles focus between panels; arrow keys
+ * scroll the focused panel; Enter on a disputes row drills into the
+ * underlying asset; q/Ctrl-C quits.
+ */
+
+const blessed = require("blessed");
+const { authenticate } = require("../AuthGate");
+const EventPipeline = require("../../pipeline/EventPipeline");
+const reportRepository = require("../../repositories/reportRepository");
+const assetRepository = require("../../repositories/assetRepository");
+const adminActionRepository = require("../../repositories/adminActionRepository");
+const { renderDashboard } = require("./render");
+
+const DEFAULT_REFRESH_MS = 3000;
+
+async function fetchData() {
+  const [disputesPage, recentActionsPage] = await Promise.all([
+    reportRepository.findAll({ status: "Pending" }, { limit: 10 }),
+    adminActionRepository.findRecent({ limit: 10 }),
+  ]);
+
+  return {
+    metrics: EventPipeline.getMetrics(),
+    status: EventPipeline.getStatus(),
+    deadLetters: EventPipeline.getDeadLetters(),
+    disputes: disputesPage.data,
+    recentActions: recentActionsPage.data,
+  };
+}
+
+function buildScreen() {
+  const screen = blessed.screen({ smartCSR: true, title: "cortex-admin dashboard" });
+
+  const panelOptions = {
+    top: 0,
+    width: "50%",
+    height: "50%",
+    border: { type: "line" },
+    tags: true,
+    scrollable: true,
+    keys: true,
+    vi: true,
+    alwaysScroll: true,
+    scrollbar: { ch: " ", inverse: true },
+    style: { border: { fg: "white" }, focus: { border: { fg: "cyan" } } },
+  };
+
+  const pipelineBox = blessed.box({ ...panelOptions, left: 0, top: 0 });
+  const disputesBox = blessed.box({ ...panelOptions, left: "50%", top: 0 });
+  const deadLettersBox = blessed.box({ ...panelOptions, left: 0, top: "50%" });
+  const recentActionsBox = blessed.box({ ...panelOptions, left: "50%", top: "50%" });
+
+  screen.append(pipelineBox);
+  screen.append(disputesBox);
+  screen.append(deadLettersBox);
+  screen.append(recentActionsBox);
+
+  return { screen, pipelineBox, disputesBox, deadLettersBox, recentActionsBox };
+}
+
+/**
+ * @param {{ refreshIntervalMs?: number, load?: () => Promise<object> }} [options]
+ * @returns {{ stop: () => void }}
+ */
+function start({ refreshIntervalMs = DEFAULT_REFRESH_MS, load = fetchData } = {}) {
+  authenticate({ minRole: "readonly" });
+
+  const { screen, pipelineBox, disputesBox, deadLettersBox, recentActionsBox } = buildScreen();
+  const panels = [pipelineBox, disputesBox, deadLettersBox, recentActionsBox];
+  let focusIndex = 0;
+  let lastDisputes = [];
+
+  panels[focusIndex].focus();
+
+  screen.key(["tab"], () => {
+    focusIndex = (focusIndex + 1) % panels.length;
+    panels[focusIndex].focus();
+    screen.render();
+  });
+
+  screen.key(["q", "C-c", "escape"], () => {
+    stop();
+    process.exit(0);
+  });
+
+  disputesBox.key(["enter"], async () => {
+    const selected = lastDisputes[0];
+    if (!selected) return;
+    const asset = await assetRepository.findById(selected.assetId, { includeInactive: true });
+    disputesBox.setContent(
+      asset
+        ? `{bold}Asset ${asset.id}{/bold}\n${asset.name}\nowner: ${asset.owner}\nflagged: ${asset.flagged}\n\nPress tab to return.`
+        : `asset ${selected.assetId} not found`
+    );
+    screen.render();
+  });
+
+  async function refresh() {
+    try {
+      const data = await load();
+      lastDisputes = data.disputes || [];
+      const rendered = renderDashboard(data);
+      pipelineBox.setContent(rendered.pipeline);
+      disputesBox.setContent(rendered.disputes);
+      deadLettersBox.setContent(rendered.deadLetters);
+      recentActionsBox.setContent(rendered.recentActions);
+      screen.render();
+    } catch (err) {
+      pipelineBox.setContent(`{red-fg}refresh failed: ${err.message}{/red-fg}`);
+      screen.render();
+    }
+  }
+
+  screen.key(["r"], refresh);
+
+  const intervalId = setInterval(refresh, refreshIntervalMs);
+  refresh();
+
+  function stop() {
+    clearInterval(intervalId);
+    screen.destroy();
+  }
+
+  return { stop };
+}
+
+module.exports = { start, fetchData };

--- a/backend/src/cli/tui/render.js
+++ b/backend/src/cli/tui/render.js
@@ -1,0 +1,86 @@
+/**
+ * Pure rendering for the `cortex-admin dashboard` TUI panels.
+ *
+ * Kept separate from the blessed screen wiring in dashboard.js so panel
+ * content can be snapshot-tested against a plain data object instead of a
+ * real terminal.
+ */
+
+function formatTimestamp(ms) {
+  if (!ms) return "—";
+  return new Date(ms).toISOString().replace("T", " ").slice(0, 19);
+}
+
+function truncate(str, max) {
+  const s = String(str ?? "");
+  return s.length > max ? `${s.slice(0, max - 1)}…` : s;
+}
+
+/**
+ * @param {object} metrics - shape of pipelineMetrics.getMetrics()
+ * @param {{ circuitOpen: boolean }} status - shape of EventPoller#getStatus()
+ */
+function renderPipelinePanel(metrics = {}, status = {}) {
+  const lines = [
+    "{bold}Pipeline{/bold}",
+    `last processed ledger: ${metrics.last_processed_ledger ?? 0}`,
+    `events/min:            ${metrics.events_per_minute ?? 0}`,
+    `p99 latency:            ${metrics.processing_latency_p99 ?? 0}ms`,
+    `queue depth:            ${metrics.queue_depth ?? 0}`,
+    `dead letters:           ${metrics.dead_letter_count ?? 0}`,
+    `circuit breaker:        ${status.circuitOpen ? "{red-fg}OPEN{/red-fg}" : "closed"}`,
+  ];
+  return lines.join("\n");
+}
+
+function renderDisputesPanel(reports = []) {
+  if (reports.length === 0) return "{bold}Open disputes{/bold}\n(none)";
+  const rows = reports
+    .slice(0, 10)
+    .map((r) => `#${r.id}  asset ${r.assetId}  ${r.reason}  ${formatTimestamp(r.createdAt)}`);
+  return ["{bold}Open disputes{/bold}", ...rows].join("\n");
+}
+
+function renderDeadLettersPanel(deadLetters = []) {
+  if (deadLetters.length === 0) return "{bold}Dead-lettered settlements{/bold}\n(none)";
+  const rows = deadLetters
+    .slice(0, 10)
+    .map((d) => `ledger ${d.event?.ledger ?? "?"}  ${truncate(d.error || d.reason || "unknown error", 40)}`);
+  return ["{bold}Dead-lettered settlements{/bold}", ...rows].join("\n");
+}
+
+function renderRecentActionsPanel(actions = []) {
+  if (actions.length === 0) return "{bold}Recent admin actions{/bold}\n(none)";
+  const rows = actions
+    .slice(0, 10)
+    .map((a) => {
+      const statusTag =
+        a.status === "success" ? "{green-fg}ok{/green-fg}" : a.status === "error" ? "{red-fg}err{/red-fg}" : "…";
+      return `${formatTimestamp(a.createdAt)}  ${truncate(a.operator, 10)}  ${a.command}  ${statusTag}`;
+    });
+  return ["{bold}Recent admin actions{/bold}", ...rows].join("\n");
+}
+
+/**
+ * @param {{
+ *   metrics: object, status: object, disputes: object[],
+ *   deadLetters: object[], recentActions: object[]
+ * }} data
+ * @returns {{ pipeline: string, disputes: string, deadLetters: string, recentActions: string }}
+ */
+function renderDashboard(data = {}) {
+  return {
+    pipeline: renderPipelinePanel(data.metrics, data.status),
+    disputes: renderDisputesPanel(data.disputes),
+    deadLetters: renderDeadLettersPanel(data.deadLetters),
+    recentActions: renderRecentActionsPanel(data.recentActions),
+  };
+}
+
+module.exports = {
+  renderDashboard,
+  renderPipelinePanel,
+  renderDisputesPanel,
+  renderDeadLettersPanel,
+  renderRecentActionsPanel,
+};

--- a/backend/src/db/migrations/011_add_admin_actions_and_bans.sql
+++ b/backend/src/db/migrations/011_add_admin_actions_and_bans.sql
@@ -1,0 +1,42 @@
+-- Operator audit trail, agent bans, and off-chain contract pause flags for
+-- the cortex-admin CLI.
+
+-- Every cortex-admin command writes a row here before it executes (status
+-- 'pending'), then stamps the outcome afterward — so a crashed command still
+-- leaves a record of intent.
+CREATE TABLE IF NOT EXISTS admin_actions (
+    id           BIGSERIAL   PRIMARY KEY,
+    operator     TEXT        NOT NULL,
+    role         TEXT        NOT NULL CHECK (role IN ('readonly', 'moderator', 'superadmin')),
+    command      TEXT        NOT NULL,
+    args         JSONB       NOT NULL DEFAULT '{}',
+    status       TEXT        NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'success', 'error')),
+    result       JSONB,
+    error        TEXT,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    completed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_admin_actions_created_at ON admin_actions (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_admin_actions_operator ON admin_actions (operator);
+CREATE INDEX IF NOT EXISTS idx_admin_actions_status ON admin_actions (status) WHERE status = 'pending';
+
+-- Consulted by agentService.js on every agent write path (registration,
+-- reputation changes) to reject calls from a banned agent.
+CREATE TABLE IF NOT EXISTS agent_bans (
+    agent_id  BIGINT      PRIMARY KEY REFERENCES agents (id) ON DELETE CASCADE,
+    reason    TEXT        NOT NULL,
+    banned_by TEXT        NOT NULL,
+    banned_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Off-chain pause flag per contract, toggled by `cortex-admin contract
+-- pause|unpause`. Services consult this before performing the write the
+-- named contract backs (e.g. licenseService checks 'marketplace').
+CREATE TABLE IF NOT EXISTS contract_state (
+    name      TEXT        PRIMARY KEY,
+    paused    BOOLEAN     NOT NULL DEFAULT FALSE,
+    paused_by TEXT,
+    paused_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/backend/src/pipeline/EventPipeline.js
+++ b/backend/src/pipeline/EventPipeline.js
@@ -71,6 +71,31 @@ async function startPipeline(options = {}) {
   });
 }
 
+/**
+ * Recovery path for `cortex-admin events replay`: re-runs EventProcessor
+ * over already-ingested raw events in an inclusive ledger range. Does not
+ * touch dedup bookkeeping or the live LedgerCursor — this replays history,
+ * it doesn't advance the pipeline's head.
+ *
+ * @returns {Promise<{ replayed: number, failed: Array<{ event: object, error: string }> }>}
+ */
+async function replayLedgerRange(fromLedger, toLedger) {
+  const events = await eventLogRepository.findByLedgerRange(fromLedger, toLedger);
+
+  let replayed = 0;
+  const failed = [];
+  for (const event of events) {
+    try {
+      await EventProcessor.process(event);
+      replayed += 1;
+    } catch (err) {
+      failed.push({ event: { ledger: event.ledger, contractId: event.contractId, txHash: event.txHash }, error: err.message });
+    }
+  }
+
+  return { replayed, failed };
+}
+
 function getMetrics() {
   return pipelineMetrics.getMetrics();
 }
@@ -86,6 +111,7 @@ function getStatus() {
 module.exports = {
   startPipeline,
   stopPipeline,
+  replayLedgerRange,
   getMetrics,
   getDeadLetters,
   getStatus,

--- a/backend/src/protocol/BatchSettler.js
+++ b/backend/src/protocol/BatchSettler.js
@@ -109,6 +109,52 @@ async function settleOffline() {
 }
 
 /**
+ * Force-settle a single stream outside the normal batch schedule (used by
+ * `cortex-admin stream force-settle` to unstick a stream that hasn't yet
+ * crossed the calls_used threshold `runSettlement` waits for).
+ *
+ * Mirrors runSettlement/settleOffline's per-stream logic without the
+ * calls_used >= 25 gate, and throws instead of silently skipping so the CLI
+ * command can report a clear failure.
+ */
+async function forceSettleStream(id) {
+  const keypair = getServerKeypair();
+
+  return withTransaction(async (client) => {
+    const locked = await streamRepository.findAndLockById(id, client);
+    if (!locked) {
+      throw new Error(`stream ${id} not found`);
+    }
+    if (locked.status !== "Active") {
+      throw new Error(`stream ${id} is not Active (status: ${locked.status})`);
+    }
+
+    if (keypair) {
+      const contractId = CONTRACT_IDS.micropayments;
+      if (!contractId) {
+        throw new Error("micropayments contract not configured; cannot force-settle on-chain");
+      }
+      const recipientSc = Address.fromString(keypair.publicKey()).toScVal();
+      const streamIdsSc = nativeToScVal([BigInt(locked.id)]);
+      await invokeContract(contractId, "batch_settle", [recipientSc, streamIdsSc], keypair);
+      await streamRepository.updateCalls(id, locked.callsRemaining, 0, client);
+      return streamRepository.findById(id, client);
+    }
+
+    // Offline/test fallback — mirrors settleOffline's mock withdrawal.
+    const elapsed = Math.floor(Date.now() / 1000) - locked.startTime;
+    const claimable = Math.min(locked.deposit - locked.withdrawn, elapsed * locked.ratePerSecond);
+    const settledAmount = claimable > 0 ? claimable : 0;
+
+    await streamRepository.updateCalls(id, locked.callsRemaining, 0, client);
+    if (settledAmount > 0) {
+      await streamRepository.recordWithdrawal(id, settledAmount, client);
+    }
+    return streamRepository.findById(id, client);
+  });
+}
+
+/**
  * Start the BatchSettler daemon.
  */
 function start(intervalMs = 60_000) {
@@ -132,4 +178,5 @@ module.exports = {
   start,
   stop,
   runSettlement,
+  forceSettleStream,
 };

--- a/backend/src/repositories/adminActionRepository.js
+++ b/backend/src/repositories/adminActionRepository.js
@@ -1,0 +1,77 @@
+/**
+ * Admin action repository — all SQL touching the `admin_actions` table.
+ *
+ * Rows are written in two steps: `create` inserts a 'pending' row before the
+ * command body runs, `complete` stamps the outcome afterward. A command that
+ * crashes mid-execution still leaves the 'pending' row behind as a record of
+ * intent (see AuditTrail.js).
+ */
+
+const { run, toMs, normalizePagination, buildMeta } = require("./repoUtils");
+
+const COLUMNS = `
+  id, operator, role, command, args, status, result, error,
+  created_at, completed_at
+`;
+
+function mapAction(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    operator: row.operator,
+    role: row.role,
+    command: row.command,
+    args: row.args,
+    status: row.status,
+    result: row.result,
+    error: row.error,
+    createdAt: toMs(row.created_at),
+    completedAt: toMs(row.completed_at),
+  };
+}
+
+async function create({ operator, role, command, args = {} }, client) {
+  const { rows } = await run(
+    `INSERT INTO admin_actions (operator, role, command, args)
+     VALUES ($1, $2, $3, $4::jsonb)
+     RETURNING ${COLUMNS}`,
+    [operator, role, command, JSON.stringify(args)],
+    client
+  );
+  return mapAction(rows[0]);
+}
+
+async function complete(id, { status, result = null, error = null }, client) {
+  const { rows } = await run(
+    `UPDATE admin_actions
+     SET status = $2, result = $3::jsonb, error = $4, completed_at = now()
+     WHERE id = $1
+     RETURNING ${COLUMNS}`,
+    [id, status, result === null ? null : JSON.stringify(result), error],
+    client
+  );
+  return mapAction(rows[0]);
+}
+
+/**
+ * Most recent actions first — used by `stream inspect`-style debugging and
+ * the TUI dashboard's "recent admin actions" panel.
+ */
+async function findRecent(pagination = {}, client) {
+  const { page, limit, offset } = normalizePagination(pagination);
+
+  const countResult = await run("SELECT count(*)::bigint AS total FROM admin_actions", [], client);
+  const total = Number(countResult.rows[0].total);
+
+  const { rows } = await run(
+    `SELECT ${COLUMNS} FROM admin_actions
+     ORDER BY created_at DESC, id DESC
+     LIMIT $1 OFFSET $2`,
+    [limit, offset],
+    client
+  );
+
+  return { data: rows.map(mapAction), meta: buildMeta(total, page, limit) };
+}
+
+module.exports = { create, complete, findRecent };

--- a/backend/src/repositories/agentBanRepository.js
+++ b/backend/src/repositories/agentBanRepository.js
@@ -1,0 +1,55 @@
+/**
+ * Agent ban repository — all SQL touching the `agent_bans` table.
+ *
+ * A row's presence is the ban; there is no separate active/inactive flag,
+ * so `unban` deletes the row outright.
+ */
+
+const { run, toMs } = require("./repoUtils");
+
+const COLUMNS = "agent_id, reason, banned_by, banned_at";
+
+function mapBan(row) {
+  if (!row) return null;
+  return {
+    agentId: row.agent_id,
+    reason: row.reason,
+    bannedBy: row.banned_by,
+    bannedAt: toMs(row.banned_at),
+  };
+}
+
+async function ban(agentId, { reason, bannedBy }, client) {
+  const { rows } = await run(
+    `INSERT INTO agent_bans (agent_id, reason, banned_by)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (agent_id) DO UPDATE SET
+       reason    = EXCLUDED.reason,
+       banned_by = EXCLUDED.banned_by,
+       banned_at = now()
+     RETURNING ${COLUMNS}`,
+    [agentId, reason, bannedBy],
+    client
+  );
+  return mapBan(rows[0]);
+}
+
+async function unban(agentId, client) {
+  const { rowCount } = await run("DELETE FROM agent_bans WHERE agent_id = $1", [agentId], client);
+  return rowCount > 0;
+}
+
+async function findByAgentId(agentId, client) {
+  const { rows } = await run(
+    `SELECT ${COLUMNS} FROM agent_bans WHERE agent_id = $1`,
+    [agentId],
+    client
+  );
+  return mapBan(rows[0]);
+}
+
+async function isBanned(agentId, client) {
+  return (await findByAgentId(agentId, client)) !== null;
+}
+
+module.exports = { ban, unban, findByAgentId, isBanned };

--- a/backend/src/repositories/contractStateRepository.js
+++ b/backend/src/repositories/contractStateRepository.js
@@ -1,0 +1,51 @@
+/**
+ * Contract state repository — all SQL touching the `contract_state` table.
+ *
+ * Tracks the off-chain pause flag `cortex-admin contract pause|unpause`
+ * toggles for a named contract (marketplace, micropayments, agent_registry).
+ * Rows are created on first pause; an unpaused, never-paused contract has
+ * no row, and `isPaused` treats that as not-paused.
+ */
+
+const { run, toMs } = require("./repoUtils");
+
+const COLUMNS = "name, paused, paused_by, paused_at, updated_at";
+
+function mapState(row) {
+  if (!row) return null;
+  return {
+    name: row.name,
+    paused: row.paused,
+    pausedBy: row.paused_by,
+    pausedAt: toMs(row.paused_at),
+    updatedAt: toMs(row.updated_at),
+  };
+}
+
+async function setPaused(name, paused, pausedBy, client) {
+  const { rows } = await run(
+    `INSERT INTO contract_state (name, paused, paused_by, paused_at)
+     VALUES ($1, $2, $3, CASE WHEN $2 THEN now() ELSE NULL END)
+     ON CONFLICT (name) DO UPDATE SET
+       paused     = EXCLUDED.paused,
+       paused_by  = EXCLUDED.paused_by,
+       paused_at  = CASE WHEN EXCLUDED.paused THEN now() ELSE NULL END,
+       updated_at = now()
+     RETURNING ${COLUMNS}`,
+    [name, paused, pausedBy],
+    client
+  );
+  return mapState(rows[0]);
+}
+
+async function findByName(name, client) {
+  const { rows } = await run(`SELECT ${COLUMNS} FROM contract_state WHERE name = $1`, [name], client);
+  return mapState(rows[0]);
+}
+
+async function isPaused(name, client) {
+  const state = await findByName(name, client);
+  return state ? state.paused : false;
+}
+
+module.exports = { setPaused, findByName, isPaused };

--- a/backend/src/repositories/eventLogRepository.js
+++ b/backend/src/repositories/eventLogRepository.js
@@ -96,6 +96,39 @@ async function findByUniqueEvent(contractId, ledger, txHash, eventIndex, client)
  * Highest ledger seen so far (0 when the log is empty) — the event
  * listener resumes from here after a restart.
  */
+/**
+ * Every logged event within an inclusive ledger range, oldest first — used
+ * by `cortex-admin events replay` to re-run already-ingested raw events
+ * through the processor after fixing a processing bug.
+ */
+async function findByLedgerRange(fromLedger, toLedger, client) {
+  const { rows } = await run(
+    `SELECT ${COLUMNS} FROM events_log
+     WHERE ledger >= $1 AND ledger <= $2
+     ORDER BY ledger ASC, id ASC`,
+    [fromLedger, toLedger],
+    client
+  );
+  return rows.map(mapEvent);
+}
+
+/**
+ * Most recent events logged for a contract, newest first — used by
+ * `cortex-admin stream inspect` to show recent on-chain activity for the
+ * micropayments contract alongside the indexed stream row.
+ */
+async function findRecentByContract(contractId, { limit = 20 } = {}, client) {
+  const { rows } = await run(
+    `SELECT ${COLUMNS} FROM events_log
+     WHERE contract_id = $1
+     ORDER BY ledger DESC, id DESC
+     LIMIT $2`,
+    [contractId, limit],
+    client
+  );
+  return rows.map(mapEvent);
+}
+
 async function getLastLedger(client) {
   const { rows } = await run(
     "SELECT COALESCE(MAX(ledger), 0) AS last_ledger FROM events_log",
@@ -110,5 +143,7 @@ module.exports = {
   findSince,
   findByContractAndTopic,
   findByUniqueEvent,
+  findByLedgerRange,
+  findRecentByContract,
   getLastLedger,
 };

--- a/backend/src/services/agentService.js
+++ b/backend/src/services/agentService.js
@@ -4,6 +4,7 @@
  */
 
 const agentRepository = require("../repositories/agentRepository");
+const agentBanRepository = require("../repositories/agentBanRepository");
 
 const CAPABILITIES = [
   "TextGeneration",
@@ -16,10 +17,19 @@ const CAPABILITIES = [
   "ActionExecution",
 ];
 
+function bannedError(id) {
+  const err = new Error(`agent ${id} is banned and cannot write`);
+  err.status = 403;
+  return err;
+}
+
 /**
  * Index an agent identity after on-chain registration (upsert by id).
  */
 async function registerAgent(agentData) {
+  if (await agentBanRepository.isBanned(agentData.id)) {
+    throw bannedError(agentData.id);
+  }
   return agentRepository.create(agentData);
 }
 
@@ -50,6 +60,9 @@ async function getAgent(id) {
  * Update an agent's reputation score (basis points, 0–10000).
  */
 async function updateAgentReputation(id, reputation) {
+  if (await agentBanRepository.isBanned(id)) {
+    throw bannedError(id);
+  }
   return agentRepository.updateReputation(id, reputation);
 }
 

--- a/backend/src/services/licenseService.js
+++ b/backend/src/services/licenseService.js
@@ -10,6 +10,7 @@
 const { withTransaction } = require("../db/connection");
 const assetRepository = require("../repositories/assetRepository");
 const licenseRepository = require("../repositories/licenseRepository");
+const contractStateRepository = require("../repositories/contractStateRepository");
 
 // Terms applied when the on-chain contract doesn't dictate them explicitly.
 const DEFAULT_USAGE_BASED_CALLS = 100;
@@ -45,6 +46,10 @@ function httpError(status, message) {
  * @returns {Promise<{ license: object, usageCount: number }>}
  */
 async function purchaseLicense({ assetId, buyer, assetVersion }) {
+  if (await contractStateRepository.isPaused("marketplace")) {
+    throw httpError(503, "marketplace is paused by an operator; license purchases are disabled");
+  }
+
   return withTransaction(async (client) => {
     const asset = await assetRepository.findById(assetId, {}, client);
     if (!asset) {
@@ -129,12 +134,26 @@ async function expireLicense(licenseId) {
   return licenseRepository.expire(licenseId);
 }
 
+/**
+ * Operator revocation: immediately zeroes the metered-call counter so a
+ * usage-based license can't be drawn on further. Used by
+ * `cortex-admin license revoke`.
+ */
+async function revokeLicense(licenseId) {
+  const license = await licenseRepository.updateCallsRemaining(licenseId, 0);
+  if (!license) {
+    throw httpError(404, `License ${licenseId} not found`);
+  }
+  return license;
+}
+
 module.exports = {
   purchaseLicense,
   consumeLicenseCall,
   getLicense,
   listLicensesForBuyer,
   expireLicense,
+  revokeLicense,
   DEFAULT_USAGE_BASED_CALLS,
   SUBSCRIPTION_PERIOD_MS,
 };


### PR DESCRIPTION
### Summary

* Adds the `cortex-admin` operator CLI with role-gated commands for contract, stream, agent, license, and event operations.
* Adds `AuthGate` with signed-challenge authentication against the configured operator allowlist and role enforcement.
* Adds `AuditTrail` with pre-execution logging to the new `admin_actions` table, including failed operations.
* Adds a live `blessed` TUI dashboard for operational monitoring.
* Adds migration `011_add_admin_actions_and_bans.sql`.

### Related Issue
Closes: #82

### Testing

* All acceptance criteria are covered by end-to-end tests against a real Postgres database — no mocks.
* Every mutating command is executed and verified against `admin_actions`, including failure paths.
* A `readonly` operator key is explicitly rejected by every mutating command.
* TUI data refresh is verified to reflect a real forced settlement in a single refresh cycle.
* Full suite: **31 test files / 364 tests — all passing.**

### Known Follow-up

* Soroban contract-level `pause()` is not implemented yet. `contract pause/unpause` currently enforces the pause state off-chain, with `licenseService.purchaseLicense` as the integration point.
* Contract-side pause support will be handled separately with its own implementation and test cycle.
