### PR TITLE
feat: real-time agent reputation engine with time-decayed scoring, weighted disputes, and stake slashing

### DIFF
--- a/backend/src/__tests__/db/partitioning.test.js
+++ b/backend/src/__tests__/db/partitioning.test.js
@@ -43,7 +43,7 @@ describe("events_log partitioning", () => {
     const names = rows.map((r) => r.partition_name);
     expect(names.length).toBeGreaterThan(5);
     expect(names).toContain("events_log_p0_to_100000");
-    expect(names).toContain("events_log_p100k_to_200k"  );
+    expect(names).toContain("events_log_p100000_to_200000");
     expect(names).toContain("events_log_default");
   });
 
@@ -51,12 +51,12 @@ describe("events_log partitioning", () => {
     await query(
       `INSERT INTO events_log (ledger, contract_id, topic, payload, tx_hash, event_index)
        VALUES ($1, $2, $3, $4, $5, $6)`,
-      [50000, "CCONTRACT1", '["LISTED"]', '{"price":100}', "tx1", 0]
+      [50000, "CCONTRACT1", "{LISTED}", '{"price":100}', "tx1", 0]
     );
     await query(
       `INSERT INTO events_log (ledger, contract_id, topic, payload, tx_hash, event_index)
        VALUES ($1, $2, $3, $4, $5, $6)`,
-      [150000, "CCONTRACT2", '["SOLD"]', '{"price":200}', "tx2", 0]
+      [150000, "CCONTRACT2", "{SOLD}", '{"price":200}', "tx2", 0]
     );
 
     const { rows } = await query(
@@ -71,12 +71,12 @@ describe("events_log partitioning", () => {
     await query(
       `INSERT INTO events_log (ledger, contract_id, topic, payload, tx_hash, event_index)
        VALUES ($1, $2, $3, $4, $5, $6)`,
-      [50000, "CCONTRACT1", '["LISTED"]', '{}', "tx1", 0]
+      [50000, "CCONTRACT1", "{LISTED}", '{}', "tx1", 0]
     );
 
     // Verify the row ended up in the p0_to_100k partition.
     const { rows } = await query(
-      "SELECT count(*)::int AS cnt FROM events_log_p0_to_100k"
+      "SELECT count(*)::int AS cnt FROM events_log_p0_to_100000"
     );
     expect(rows[0].cnt).toBe(1);
   });

--- a/backend/src/__tests__/db/router.test.js
+++ b/backend/src/__tests__/db/router.test.js
@@ -82,7 +82,7 @@ describe("readQuery / writeQuery", () => {
     await writeQuery(
       `INSERT INTO events_log (ledger, contract_id, topic, payload, tx_hash, event_index)
        VALUES ($1, $2, $3, $4, $5, $6)`,
-      [100, "CCONTRACT", '["EVT"]', '{}', "tx001", 0]
+      [100, "CCONTRACT", "{EVT}", '{}', "tx001", 0]
     );
     const { rows } = await query("SELECT count(*)::int AS cnt FROM events_log");
     expect(rows[0].cnt).toBe(1);
@@ -92,7 +92,7 @@ describe("readQuery / writeQuery", () => {
     await writeQuery(
       `INSERT INTO events_log (ledger, contract_id, topic, payload, tx_hash, event_index)
        VALUES ($1, $2, $3, $4, $5, $6)`,
-      [200, "CCONTRACT", '["EVT2"]', '{}', "tx002", 0]
+      [200, "CCONTRACT", "{EVT2}", '{}', "tx002", 0]
     );
     const { rows } = await readQuery("SELECT ledger FROM events_log WHERE ledger = $1", [200]);
     expect(rows[0].ledger).toBe(200);

--- a/backend/src/__tests__/helpers/testDb.js
+++ b/backend/src/__tests__/helpers/testDb.js
@@ -13,7 +13,7 @@ const { query, closePool } = require("../../db/connection");
 async function truncateAll() {
   await query(
     `TRUNCATE TABLE reports, licenses, events_log, event_cursor, streams, agents, assets,
-       admin_actions, agent_bans, contract_state
+       admin_actions, agent_bans, contract_state, dispute_votes, disputes, agent_stakes
      RESTART IDENTITY CASCADE`
   );
   await query("DELETE FROM replica_heartbeat");

--- a/backend/src/__tests__/pipeline/EventProcessor.test.js
+++ b/backend/src/__tests__/pipeline/EventProcessor.test.js
@@ -1,0 +1,139 @@
+jest.mock("../../listeners/eventListener", () => ({ processEvent: jest.fn() }));
+
+jest.mock("../../services/disputeService", () => ({
+  recordStake: jest.fn(),
+  fileDispute: jest.fn(),
+  recordVote: jest.fn(),
+  resolveDispute: jest.fn(),
+  recordSlash: jest.fn(),
+}));
+
+jest.mock("../../pipeline/pipelineMetrics", () => ({
+  recordProcessingLatency: jest.fn(),
+}));
+
+const { processEvent } = require("../../listeners/eventListener");
+const disputeService = require("../../services/disputeService");
+const pipelineMetrics = require("../../pipeline/pipelineMetrics");
+const EventProcessor = require("../../pipeline/EventProcessor");
+
+const AGENT = "GD226Q4QUIIDFBQ7TWPTP4UT4TKPX2MQRVEJSFMMCSM6ORDCPNZPPKCT";
+const COMPLAINANT = "GAHC3JKJCBTPODO2GEOLUCXWTIQYBCPHBOTAT2KMPZ35PXCITJ57UYGC";
+const CLOSED_AT = "2026-08-18T10:00:00Z";
+
+function event(topic, value) {
+  return { topic, value, ledger: 1_000, ledgerClosedAt: CLOSED_AT };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("EventProcessor routing", () => {
+  it("forwards non-reputation events to the domain listener", async () => {
+    const listed = event(["LISTED"], 1);
+    await EventProcessor.process(listed);
+
+    expect(processEvent).toHaveBeenCalledWith(listed);
+    expect(disputeService.fileDispute).not.toHaveBeenCalled();
+  });
+
+  it("records processing latency for every event", async () => {
+    await EventProcessor.process(event(["LISTED"], 1));
+    expect(pipelineMetrics.recordProcessingLatency).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps reputation events away from the asset listener", async () => {
+    await EventProcessor.process(event(["STAKED", AGENT], [500, 500]));
+    expect(processEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe("EventProcessor reputation events", () => {
+  it("mirrors STAKED as the address's new total", async () => {
+    await EventProcessor.process(event(["STAKED", AGENT], [500, 1_500]));
+
+    expect(disputeService.recordStake).toHaveBeenCalledWith(
+      expect.objectContaining({ agentAddress: AGENT, amount: 1_500 })
+    );
+  });
+
+  it("mirrors UNSTAKED as the address's remaining total", async () => {
+    await EventProcessor.process(event(["UNSTAKED", AGENT], [500, 1_000]));
+
+    expect(disputeService.recordStake).toHaveBeenCalledWith(
+      expect.objectContaining({ agentAddress: AGENT, amount: 1_000 })
+    );
+  });
+
+  it("indexes DISPUTE_OPENED with both parties and the voting deadline", async () => {
+    await EventProcessor.process(
+      event(["DISPUTE_OPENED", COMPLAINANT, AGENT], [7, 1_700_000_000])
+    );
+
+    expect(disputeService.fileDispute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 7,
+        complainant: COMPLAINANT,
+        respondent: AGENT,
+        closesAt: 1_700_000_000_000,
+      })
+    );
+  });
+
+  it("records DISPUTE_VOTED with its weight and direction", async () => {
+    await EventProcessor.process(event(["DISPUTE_VOTED", AGENT], [7, 1_000, true]));
+
+    expect(disputeService.recordVote).toHaveBeenCalledWith(
+      expect.objectContaining({ disputeId: 7, voter: AGENT, weight: 1_000, inFavor: true })
+    );
+  });
+
+  it("applies DISPUTE_RESOLVED with the verdict and slashed amount", async () => {
+    await EventProcessor.process(
+      event(["DISPUTE_RESOLVED", AGENT], [7, "Guilty", 2_000])
+    );
+
+    expect(disputeService.resolveDispute).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 7, outcome: "Guilty", slashedAmount: 2_000 })
+    );
+  });
+
+  it("reads the verdict when the SDK decodes the enum as an object", async () => {
+    await EventProcessor.process(
+      event(["DISPUTE_RESOLVED", AGENT], [7, { NotGuilty: undefined }, 0])
+    );
+
+    expect(disputeService.resolveDispute).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: "NotGuilty" })
+    );
+  });
+
+  it("applies STAKE_SLASHED to the respondent's collateral", async () => {
+    await EventProcessor.process(event(["STAKE_SLASHED", AGENT], [7, 2_000]));
+
+    expect(disputeService.recordSlash).toHaveBeenCalledWith(AGENT, 2_000);
+  });
+
+  it("ignores a STAKE_SLASHED event carrying no amount", async () => {
+    await EventProcessor.process(event(["STAKE_SLASHED", AGENT], [7, 0]));
+
+    expect(disputeService.recordSlash).not.toHaveBeenCalled();
+  });
+
+  it("ignores a malformed DISPUTE_OPENED event rather than throwing", async () => {
+    await expect(
+      EventProcessor.process(event(["DISPUTE_OPENED", COMPLAINANT], [0]))
+    ).resolves.toBeUndefined();
+
+    expect(disputeService.fileDispute).not.toHaveBeenCalled();
+  });
+
+  it("converts bigint payloads coming off the RPC", async () => {
+    await EventProcessor.process(event(["STAKED", AGENT], [500n, 9_000n]));
+
+    expect(disputeService.recordStake).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: 9_000 })
+    );
+  });
+});

--- a/backend/src/__tests__/repositories/disputeFlow.test.js
+++ b/backend/src/__tests__/repositories/disputeFlow.test.js
@@ -1,0 +1,180 @@
+/**
+ * End-to-end reputation flow against the real database: an agent stakes,
+ * another agent disputes it, third parties vote, the verdict lands guilty, and
+ * both the collateral and the reputation come down by the configured share.
+ */
+
+const agentRepository = require("../../repositories/agentRepository");
+const agentStakeRepository = require("../../repositories/agentStakeRepository");
+const disputeRepository = require("../../repositories/disputeRepository");
+const disputeService = require("../../services/disputeService");
+const reputationEngine = require("../../services/reputationEngine");
+const { truncateAll, closePool, buildAgent, OWNER_A, OWNER_B } = require("../helpers/testDb");
+
+beforeEach(async () => {
+  await truncateAll();
+  reputationEngine.setConfig(reputationEngine.DEFAULT_CONFIG);
+});
+
+afterAll(async () => {
+  await closePool();
+});
+
+describe("stake mirroring", () => {
+  it("records collateral and denormalizes it onto the owner's agents", async () => {
+    const agent = await agentRepository.create(buildAgent({ owner: OWNER_A }));
+
+    await disputeService.recordStake({
+      agentAddress: OWNER_A,
+      token: "CTOKEN",
+      amount: 10_000,
+    });
+
+    const stake = await agentStakeRepository.findByAddress(OWNER_A);
+    expect(stake.amount).toBe(10_000);
+    expect(stake.slashed).toBe(0);
+
+    const indexed = await agentRepository.findById(agent.id);
+    expect(indexed.stakeAmount).toBe(10_000);
+  });
+
+  it("applies a slash to both the stake row and the agent columns", async () => {
+    const agent = await agentRepository.create(buildAgent({ owner: OWNER_A }));
+    await disputeService.recordStake({ agentAddress: OWNER_A, amount: 10_000 });
+
+    await disputeService.recordSlash(OWNER_A, 2_500);
+
+    const stake = await agentStakeRepository.findByAddress(OWNER_A);
+    expect(stake.amount).toBe(7_500);
+    expect(stake.slashed).toBe(2_500);
+
+    const indexed = await agentRepository.findById(agent.id);
+    expect(indexed.stakeAmount).toBe(7_500);
+    expect(indexed.stakeSlashed).toBe(2_500);
+  });
+});
+
+describe("dispute lifecycle", () => {
+  it("files, votes, and resolves a dispute across contract, DB and read APIs", async () => {
+    const agent = await agentRepository.create(buildAgent({ owner: OWNER_A }));
+    await disputeService.recordStake({ agentAddress: OWNER_A, amount: 10_000 });
+
+    // Agent B files, with the evidence bundle stored off-chain.
+    const evidence = { claim: "did not deliver", txs: ["tx1"] };
+    const dispute = await disputeService.fileDispute({
+      id: 1,
+      complainant: OWNER_B,
+      respondent: OWNER_A,
+      evidence,
+      closesAt: Date.now() + 60_000,
+    });
+
+    expect(dispute.status).toBe("open");
+    expect(disputeService.verifyEvidence(evidence, dispute.evidenceHash)).toBe(true);
+
+    // Two third parties weigh in with different weights.
+    await disputeRepository.recordVote({
+      disputeId: 1,
+      voter: OWNER_B,
+      inFavor: true,
+      weight: 4_000,
+    });
+    await disputeRepository.recordVote({
+      disputeId: 1,
+      voter: "GDQRRTSA2OFYBTJT2Y7BWE5HM5TGQJBSTD2VJKSCOH62SY7TRYLUS24Y",
+      inFavor: false,
+      weight: 1_000,
+    });
+
+    const tallied = await disputeRepository.findById(1);
+    expect(tallied.weightFor).toBe(4_000);
+    expect(tallied.weightAgainst).toBe(1_000);
+
+    // A replayed vote event must not double-count.
+    await disputeRepository.recordVote({
+      disputeId: 1,
+      voter: OWNER_B,
+      inFavor: true,
+      weight: 4_000,
+    });
+    expect((await disputeRepository.findById(1)).weightFor).toBe(4_000);
+
+    // The verdict lands: 20% of the stake and of the reputation.
+    const resolved = await disputeService.resolveDispute({
+      id: 1,
+      outcome: "Guilty",
+      slashedAmount: 2_000,
+    });
+
+    expect(resolved.status).toBe("resolved");
+    expect(resolved.outcome).toBe("guilty");
+
+    const stake = await agentStakeRepository.findByAddress(OWNER_A);
+    expect(stake.amount).toBe(8_000);
+    expect(stake.slashed).toBe(2_000);
+
+    const slashedAgent = await agentRepository.findById(agent.id);
+    expect(slashedAgent.reputation).toBe(4_000);
+    expect(slashedAgent.stakeAmount).toBe(8_000);
+
+    // Resolved disputes drop out of the active list.
+    const active = await disputeRepository.findActive();
+    expect(active.meta.total).toBe(0);
+  });
+
+  it("keeps evidence retrievable and hashes it on submission", async () => {
+    await agentRepository.create(buildAgent({ owner: OWNER_A }));
+    await disputeService.recordStake({ agentAddress: OWNER_A, amount: 5_000 });
+    await disputeService.fileDispute({
+      id: 2,
+      complainant: OWNER_B,
+      respondent: OWNER_A,
+    });
+
+    const evidence = { claim: "overcharged", amount: 42 };
+    const { evidenceHash } = await disputeService.submitEvidence(2, evidence);
+
+    const stored = await disputeService.getDispute(2);
+    expect(stored.evidence).toEqual(evidence);
+    expect(stored.evidenceHash).toBe(evidenceHash);
+    expect(disputeService.verifyEvidence(stored.evidence, stored.evidenceHash)).toBe(true);
+  });
+
+  it("lists the disputes an address is involved in, both roles", async () => {
+    await agentRepository.create(buildAgent({ owner: OWNER_A }));
+    await disputeService.recordStake({ agentAddress: OWNER_A, amount: 5_000 });
+    await disputeService.recordStake({ agentAddress: OWNER_B, amount: 5_000 });
+
+    await disputeService.fileDispute({ id: 3, complainant: OWNER_B, respondent: OWNER_A });
+    await disputeService.fileDispute({ id: 4, complainant: OWNER_A, respondent: OWNER_B });
+
+    const involved = await disputeService.getDisputesForAgent(OWNER_A);
+    expect(involved.meta.total).toBe(2);
+    expect(involved.data.map((d) => d.id).sort()).toEqual([3, 4]);
+  });
+});
+
+describe("decayed reads", () => {
+  it("serves an agent's reputation decayed from its settlement clock", async () => {
+    const agent = await agentRepository.create(buildAgent({ owner: OWNER_A }));
+
+    // Backdate the decay clock by ten days.
+    const tenDaysAgo = Date.now() - 10 * 86_400_000;
+    await agentRepository.updateReputation(agent.id, 5_000, undefined, {
+      reputationUpdatedAt: tenDaysAgo,
+    });
+
+    const stored = await agentRepository.findById(agent.id);
+    expect(stored.reputation).toBe(5_000); // base score is untouched
+    expect(reputationEngine.currentReputation(stored)).toBe(4_517);
+
+    const { getAgent, getReputationTimeline } = require("../../services/agentService");
+    expect((await getAgent(agent.id)).reputation).toBe(4_517);
+
+    const timeline = await getReputationTimeline(agent.id);
+    expect(timeline.baseReputation).toBe(5_000);
+    expect(timeline.currentReputation).toBe(4_517);
+    expect(timeline.curve[0].score).toBe(5_000);
+    expect(timeline.curve[timeline.curve.length - 1].score).toBe(4_517);
+  });
+});

--- a/backend/src/__tests__/routes/internal.test.js
+++ b/backend/src/__tests__/routes/internal.test.js
@@ -31,7 +31,9 @@ describe("GET /api/v1/internal/db-stats", () => {
       .set("x-admin-key", ADMIN_KEY)
       .expect(200);
 
-    expect(res.body.pool).toEqual(
+    // Since read-replica routing landed the payload reports the write pool and
+    // the read pool separately.
+    expect(res.body.pool.write).toEqual(
       expect.objectContaining({
         max: expect.any(Number),
         total: expect.any(Number),
@@ -39,7 +41,8 @@ describe("GET /api/v1/internal/db-stats", () => {
         waiting: expect.any(Number),
       })
     );
-    expect(res.body.pool.max).toBe(20);
+    expect(res.body.pool.write.max).toBe(20);
+    expect(res.body.pool.read).toBeDefined();
     expect(res.body.database.healthy).toBe(true);
     expect(typeof res.body.database.latencyMs).toBe("number");
     expect(res.body.timestamp).toBeDefined();

--- a/backend/src/__tests__/services/disputeService.test.js
+++ b/backend/src/__tests__/services/disputeService.test.js
@@ -1,0 +1,274 @@
+jest.mock("../../repositories/disputeRepository", () => ({
+  upsert: jest.fn(),
+  resolve: jest.fn(),
+  attachEvidence: jest.fn(),
+  findById: jest.fn(),
+  findActive: jest.fn(),
+  findByAddress: jest.fn(),
+  recordVote: jest.fn(),
+  findVotes: jest.fn(),
+}));
+
+jest.mock("../../repositories/agentStakeRepository", () => ({
+  upsert: jest.fn(),
+  applySlash: jest.fn(),
+  findByAddress: jest.fn(),
+}));
+
+jest.mock("../../repositories/agentRepository", () => ({
+  updateStakeForOwner: jest.fn(),
+}));
+
+jest.mock("../../services/reputationEngine", () => ({
+  getConfig: jest.fn(() => ({ slashBps: 2_000 })),
+  penalizeOwner: jest.fn(),
+}));
+
+jest.mock("../../protocol/StreamMonitor", () => ({ broadcast: jest.fn() }));
+
+const disputeRepository = require("../../repositories/disputeRepository");
+const agentStakeRepository = require("../../repositories/agentStakeRepository");
+const agentRepository = require("../../repositories/agentRepository");
+const reputationEngine = require("../../services/reputationEngine");
+const StreamMonitor = require("../../protocol/StreamMonitor");
+const disputeService = require("../../services/disputeService");
+
+const COMPLAINANT = "GD226Q4QUIIDFBQ7TWPTP4UT4TKPX2MQRVEJSFMMCSM6ORDCPNZPPKCT";
+const RESPONDENT = "GAHC3JKJCBTPODO2GEOLUCXWTIQYBCPHBOTAT2KMPZ35PXCITJ57UYGC";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  agentStakeRepository.findByAddress.mockResolvedValue({
+    agentAddress: RESPONDENT,
+    amount: 8_000,
+    slashed: 2_000,
+  });
+});
+
+describe("disputeService.hashEvidence", () => {
+  it("is stable across key ordering", () => {
+    const a = disputeService.hashEvidence({ claim: "spam", ledger: 42 });
+    const b = disputeService.hashEvidence({ ledger: 42, claim: "spam" });
+
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("changes when any field changes", () => {
+    const a = disputeService.hashEvidence({ claim: "spam" });
+    const b = disputeService.hashEvidence({ claim: "spam!" });
+    expect(a).not.toBe(b);
+  });
+
+  it("verifies a bundle against the digest committed on-chain", () => {
+    const evidence = { claim: "did not deliver", txs: ["tx1", "tx2"] };
+    const hash = disputeService.hashEvidence(evidence);
+
+    expect(disputeService.verifyEvidence(evidence, hash)).toBe(true);
+    expect(disputeService.verifyEvidence({ ...evidence, claim: "other" }, hash)).toBe(false);
+  });
+});
+
+describe("disputeService.fileDispute", () => {
+  it("indexes the dispute, hashes the evidence, and notifies subscribers", async () => {
+    const evidence = { claim: "did not deliver" };
+    disputeRepository.upsert.mockResolvedValue({
+      id: 7,
+      complainant: COMPLAINANT,
+      respondent: RESPONDENT,
+      closesAt: 1_700_000_000_000,
+    });
+
+    await disputeService.fileDispute({
+      id: 7,
+      complainant: COMPLAINANT,
+      respondent: RESPONDENT,
+      evidence,
+    });
+
+    expect(disputeRepository.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 7,
+        status: "open",
+        evidenceHash: disputeService.hashEvidence(evidence),
+      })
+    );
+    expect(StreamMonitor.broadcast).toHaveBeenCalledWith(
+      "DISPUTE_OPENED",
+      expect.objectContaining({ disputeId: 7, respondent: RESPONDENT })
+    );
+  });
+
+  it("rejects a self-dispute", async () => {
+    await expect(
+      disputeService.fileDispute({ id: 1, complainant: COMPLAINANT, respondent: COMPLAINANT })
+    ).rejects.toThrow(/cannot dispute itself/);
+    expect(disputeRepository.upsert).not.toHaveBeenCalled();
+  });
+
+  it("rejects a filing without an on-chain dispute id", async () => {
+    await expect(
+      disputeService.fileDispute({ complainant: COMPLAINANT, respondent: RESPONDENT })
+    ).rejects.toThrow(/dispute id/);
+  });
+});
+
+describe("disputeService.submitEvidence", () => {
+  it("attaches the bundle and returns the digest to commit on-chain", async () => {
+    const evidence = { claim: "overcharged", amount: 42 };
+    disputeRepository.findById.mockResolvedValue({ id: 7, status: "open" });
+    disputeRepository.attachEvidence.mockResolvedValue({ id: 7, status: "open" });
+
+    const result = await disputeService.submitEvidence(7, evidence);
+
+    expect(result.evidenceHash).toBe(disputeService.hashEvidence(evidence));
+    expect(disputeRepository.attachEvidence).toHaveBeenCalledWith(7, {
+      evidence,
+      evidenceHash: result.evidenceHash,
+    });
+  });
+
+  it("returns null for an unknown dispute", async () => {
+    disputeRepository.findById.mockResolvedValue(null);
+    expect(await disputeService.submitEvidence(99, { a: 1 })).toBeNull();
+  });
+
+  it("refuses to alter evidence after a verdict", async () => {
+    disputeRepository.findById.mockResolvedValue({ id: 7, status: "resolved" });
+
+    await expect(disputeService.submitEvidence(7, { a: 1 })).rejects.toThrow(/resolved/);
+    expect(disputeRepository.attachEvidence).not.toHaveBeenCalled();
+  });
+});
+
+describe("disputeService.resolveDispute", () => {
+  beforeEach(() => {
+    disputeRepository.findById.mockResolvedValue({
+      id: 7,
+      respondent: RESPONDENT,
+      status: "open",
+    });
+  });
+
+  it("slashes the stake and the reputation on a guilty verdict", async () => {
+    disputeRepository.resolve.mockResolvedValue({
+      id: 7,
+      respondent: RESPONDENT,
+      outcome: "guilty",
+      slashedAmount: 2_000,
+    });
+
+    await disputeService.resolveDispute({
+      id: 7,
+      outcome: "Guilty",
+      slashedAmount: 2_000,
+      resolvedAt: 1_700_000_000_000,
+    });
+
+    expect(disputeRepository.resolve).toHaveBeenCalledWith(
+      7,
+      expect.objectContaining({ outcome: "guilty", slashedAmount: 2_000 })
+    );
+    expect(agentStakeRepository.applySlash).toHaveBeenCalledWith(RESPONDENT, 2_000);
+    expect(reputationEngine.penalizeOwner).toHaveBeenCalledWith(
+      RESPONDENT,
+      expect.objectContaining({ slashBps: 2_000 })
+    );
+    expect(agentRepository.updateStakeForOwner).toHaveBeenCalledWith(RESPONDENT, {
+      amount: 8_000,
+      slashed: 2_000,
+    });
+    expect(StreamMonitor.broadcast).toHaveBeenCalledWith(
+      "DISPUTE_RESOLVED",
+      expect.objectContaining({ disputeId: 7, outcome: "guilty" })
+    );
+  });
+
+  it("leaves stake and reputation alone when the respondent is cleared", async () => {
+    disputeRepository.resolve.mockResolvedValue({
+      id: 7,
+      respondent: RESPONDENT,
+      outcome: "not_guilty",
+      slashedAmount: 0,
+    });
+
+    await disputeService.resolveDispute({ id: 7, outcome: "NotGuilty" });
+
+    expect(agentStakeRepository.applySlash).not.toHaveBeenCalled();
+    expect(reputationEngine.penalizeOwner).not.toHaveBeenCalled();
+  });
+
+  it("leaves the stake alone when the vote failed quorum", async () => {
+    disputeRepository.resolve.mockResolvedValue({
+      id: 7,
+      respondent: RESPONDENT,
+      outcome: "quorum_failed",
+      slashedAmount: 0,
+    });
+
+    await disputeService.resolveDispute({ id: 7, outcome: "QuorumFailed" });
+
+    expect(agentStakeRepository.applySlash).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown verdict", async () => {
+    await expect(
+      disputeService.resolveDispute({ id: 7, outcome: "Maybe" })
+    ).rejects.toThrow(/unknown dispute outcome/);
+  });
+
+  it("returns null for a dispute that was never indexed", async () => {
+    disputeRepository.findById.mockResolvedValue(null);
+    expect(await disputeService.resolveDispute({ id: 42, outcome: "Guilty" })).toBeNull();
+  });
+});
+
+describe("disputeService stake mirroring", () => {
+  it("records a stake and syncs the denormalized agent columns", async () => {
+    agentStakeRepository.upsert.mockResolvedValue({
+      agentAddress: RESPONDENT,
+      amount: 10_000,
+      slashed: 0,
+    });
+
+    await disputeService.recordStake({
+      agentAddress: RESPONDENT,
+      token: "CTOKEN",
+      amount: 10_000,
+    });
+
+    expect(agentRepository.updateStakeForOwner).toHaveBeenCalledWith(RESPONDENT, {
+      amount: 10_000,
+      slashed: 0,
+    });
+  });
+
+  it("applies a slash and notifies subscribers", async () => {
+    agentStakeRepository.applySlash.mockResolvedValue({
+      agentAddress: RESPONDENT,
+      amount: 8_000,
+      slashed: 2_000,
+    });
+
+    await disputeService.recordSlash(RESPONDENT, 2_000);
+
+    expect(agentStakeRepository.applySlash).toHaveBeenCalledWith(RESPONDENT, 2_000);
+    expect(StreamMonitor.broadcast).toHaveBeenCalledWith("STAKE_SLASHED", {
+      agentAddress: RESPONDENT,
+      amount: 2_000,
+    });
+  });
+
+  it("survives a notification failure", async () => {
+    StreamMonitor.broadcast.mockImplementation(() => {
+      throw new Error("socket closed");
+    });
+    agentStakeRepository.applySlash.mockResolvedValue({
+      agentAddress: RESPONDENT,
+      amount: 0,
+      slashed: 10_000,
+    });
+
+    await expect(disputeService.recordSlash(RESPONDENT, 10_000)).resolves.toBeDefined();
+  });
+});

--- a/backend/src/__tests__/services/reputationEngine.test.js
+++ b/backend/src/__tests__/services/reputationEngine.test.js
@@ -1,0 +1,168 @@
+jest.mock("../../repositories/agentRepository", () => ({
+  findById: jest.fn(),
+  findByOwner: jest.fn(),
+  updateReputation: jest.fn(),
+}));
+
+const agentRepository = require("../../repositories/agentRepository");
+const reputationEngine = require("../../services/reputationEngine");
+
+const DAY_MS = 86_400_000;
+const NOW = 1_800_000_000_000;
+
+// Several tests reconfigure the engine; every test starts from the defaults
+// the contract ships with.
+beforeEach(() => {
+  reputationEngine.setConfig(reputationEngine.DEFAULT_CONFIG);
+});
+
+describe("reputationEngine.decayScore", () => {
+  it("leaves a score untouched inside one decay period", () => {
+    expect(reputationEngine.decayScore(5_000, 86_399)).toBe(5_000);
+  });
+
+  // These are the exact values asserted by the contract's own tests in
+  // contracts/agent_registry/src/test.rs — the two implementations must agree
+  // digit for digit, not just approximately.
+  it("matches the contract's integer decay after one period", () => {
+    expect(reputationEngine.decayScore(5_000, 86_400)).toBe(4_950);
+  });
+
+  it("matches the contract's integer decay after ten periods", () => {
+    expect(reputationEngine.decayScore(5_000, 86_400 * 10)).toBe(4_517);
+  });
+
+  it("truncates on every period rather than at the end", () => {
+    // Closed-form 5000 × 0.99^10 is 4521.4; applying the truncation each
+    // period, as the contract does, lands 4 basis points lower.
+    const closedForm = Math.floor(5_000 * 0.99 ** 10);
+    expect(reputationEngine.decayScore(5_000, 86_400 * 10)).toBeLessThan(closedForm);
+  });
+
+  it("saturates at the contract's iteration bound", () => {
+    const bounded = reputationEngine.decayScore(5_000, 86_400 * reputationEngine.MAX_DECAY_PERIODS);
+    expect(reputationEngine.decayScore(5_000, 86_400 * 5_000)).toBe(bounded);
+  });
+
+  it("never returns a negative score", () => {
+    expect(reputationEngine.decayScore(0, 86_400 * 100)).toBe(0);
+    expect(reputationEngine.decayScore(-5, 86_400)).toBe(0);
+  });
+
+  it("honours a reconfigured decay rate", () => {
+    reputationEngine.setConfig({ ...reputationEngine.DEFAULT_CONFIG, decayBps: 5_000 });
+    expect(reputationEngine.decayScore(8_000, 86_400 * 2)).toBe(2_000);
+  });
+
+  it("disables decay when the rate is 100%", () => {
+    reputationEngine.setConfig({ ...reputationEngine.DEFAULT_CONFIG, decayBps: 10_000 });
+    expect(reputationEngine.decayScore(8_000, 86_400 * 50)).toBe(8_000);
+  });
+});
+
+describe("reputationEngine.currentReputation", () => {
+  it("decays from the timestamp the score was settled at", () => {
+    const agent = { reputation: 5_000, reputationUpdatedAt: NOW - DAY_MS * 10 };
+    expect(reputationEngine.currentReputation(agent, NOW)).toBe(4_517);
+  });
+
+  it("returns the base score when the clock has never been set", () => {
+    expect(
+      reputationEngine.currentReputation({ reputation: 7_000, reputationUpdatedAt: null }, NOW)
+    ).toBe(7_000);
+  });
+
+  it("exposes the base score alongside the decayed one", () => {
+    const agent = { id: 1, reputation: 5_000, reputationUpdatedAt: NOW - DAY_MS };
+    const decorated = reputationEngine.withCurrentReputation(agent, NOW);
+
+    expect(decorated.reputation).toBe(4_950);
+    expect(decorated.baseReputation).toBe(5_000);
+    expect(agent.reputation).toBe(5_000); // input is not mutated
+  });
+});
+
+describe("reputationEngine.decayCurve", () => {
+  it("samples the curve from the settlement point to now", () => {
+    const agent = { reputation: 5_000, reputationUpdatedAt: NOW - DAY_MS * 4 };
+    const curve = reputationEngine.decayCurve(agent, { nowMs: NOW, points: 5 });
+
+    expect(curve).toHaveLength(5);
+    expect(curve[0]).toEqual({ timestamp: NOW - DAY_MS * 4, score: 5_000 });
+    expect(curve[curve.length - 1].score).toBe(
+      reputationEngine.currentReputation(agent, NOW)
+    );
+    expect(curve.every((point, i) => i === 0 || point.score <= curve[i - 1].score)).toBe(true);
+  });
+
+  it("still returns a flat two-point series for a freshly settled agent", () => {
+    const curve = reputationEngine.decayCurve(
+      { reputation: 6_000, reputationUpdatedAt: NOW },
+      { nowMs: NOW }
+    );
+    expect(curve).toHaveLength(2);
+    expect(curve[0].score).toBe(6_000);
+    expect(curve[1].score).toBe(6_000);
+  });
+});
+
+describe("reputationEngine.applyPenalty", () => {
+  it("removes the configured slash percentage", () => {
+    expect(reputationEngine.applyPenalty(5_000, 2_000)).toBe(4_000);
+    expect(reputationEngine.applyPenalty(7_047, 2_000)).toBe(5_637);
+  });
+
+  it("floors at zero for a full slash", () => {
+    expect(reputationEngine.applyPenalty(5_000, 10_000)).toBe(0);
+  });
+});
+
+describe("reputationEngine persistence", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("settleAgent writes the decayed score and restarts the clock", async () => {
+    agentRepository.findById.mockResolvedValue({
+      id: 3,
+      reputation: 5_000,
+      reputationUpdatedAt: NOW - DAY_MS * 10,
+    });
+    agentRepository.updateReputation.mockResolvedValue({ id: 3, reputation: 4_517 });
+
+    await reputationEngine.settleAgent(3, { nowMs: NOW });
+
+    expect(agentRepository.updateReputation).toHaveBeenCalledWith(3, 4_517, undefined, {
+      reputationUpdatedAt: NOW,
+    });
+  });
+
+  it("settleAgent is a no-op for an unknown agent", async () => {
+    agentRepository.findById.mockResolvedValue(null);
+
+    expect(await reputationEngine.settleAgent(99)).toBeNull();
+    expect(agentRepository.updateReputation).not.toHaveBeenCalled();
+  });
+
+  it("penalizeOwner decays first, then applies the slash, to every agent owned", async () => {
+    agentRepository.findByOwner.mockResolvedValue([
+      { id: 1, reputation: 5_000, reputationUpdatedAt: NOW - DAY_MS },
+      { id: 2, reputation: 8_000, reputationUpdatedAt: NOW },
+    ]);
+    agentRepository.updateReputation.mockImplementation(async (id, reputation) => ({
+      id,
+      reputation,
+    }));
+
+    await reputationEngine.penalizeOwner("GOWNER", { slashBps: 2_000, nowMs: NOW });
+
+    // agent 1: 5000 → 4950 (one period of decay) → 3960 (20% slash)
+    expect(agentRepository.updateReputation).toHaveBeenNthCalledWith(1, 1, 3_960, undefined, {
+      reputationUpdatedAt: NOW,
+    });
+    // agent 2: no decay accrued → 6400
+    expect(agentRepository.updateReputation).toHaveBeenNthCalledWith(2, 2, 6_400, undefined, {
+      reputationUpdatedAt: NOW,
+    });
+  });
+});

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -14,6 +14,7 @@ const internalRouter = require("./routes/internal");
 const healthRouter = require("./routes/health");
 const adminRouter = require("./routes/admin");
 const protocolRouter = require("./routes/protocol");
+const disputesRouter = require("./routes/disputes");
 const { errorHandler, notFoundHandler } = require("./middleware/errorHandler");
 
 const app = express();
@@ -65,6 +66,7 @@ app.use("/api/v1/stellar", stellarRouter);
 app.use("/api/v1/internal", internalRouter);
 app.use("/api/v1/admin", adminRouter);
 app.use("/api/v1/protocol", protocolRouter);
+app.use("/api/v1/disputes", disputesRouter);
 
 // ── Error handling ────────────────────────────────────────────────────────────
 app.use(notFoundHandler);

--- a/backend/src/db/DbRouter.js
+++ b/backend/src/db/DbRouter.js
@@ -81,14 +81,19 @@ async function route(functionName, intent, fn) {
   }
 
   // Read path — prefer the replica but fall back to the primary.
-  let client;
   try {
-    client = await getReadClient();
-    return await fn(client);
+    const client = await getReadClient();
+    try {
+      return await fn(client);
+    } finally {
+      // The connection must go back to the pool on the success path too —
+      // leaking it here keeps the pool from ever draining, so a checked-out
+      // client would hang `closePool()` on shutdown.
+      client.release();
+    }
   } catch (err) {
     // If the read pool connection fails, fall back to the write pool.
     console.warn("[db-router] read pool failed, falling back to primary:", err.message);
-    if (client) client.release();
     const writeClient = await getClient();
     try {
       return await fn(writeClient);

--- a/backend/src/db/migrations/013_partition_events_log.sql
+++ b/backend/src/db/migrations/013_partition_events_log.sql
@@ -24,23 +24,26 @@ CREATE TABLE IF NOT EXISTS events_log_partitioned (
 ) PARTITION BY RANGE (ledger);
 
 -- 2 ── Create initial partitions covering existing data ──────────────────────
--- Each partition covers a 100 000-ledger window.
+-- Each partition covers a 100 000-ledger window. Names follow the
+-- `events_log_p<start>_to_<end>` convention that
+-- `src/scripts/create-future-partitions.js` extends from, so pre-creating
+-- future ranges never collides with the ones seeded here.
 -- A default partition catches any rows outside the defined ranges.
-CREATE TABLE events_log_p0_to_100k     PARTITION OF events_log_partitioned FOR VALUES FROM (0)       TO (100000);
-CREATE TABLE events_log_p100k_to_200k   PARTITION OF events_log_partitioned FOR VALUES FROM (100000)  TO (200000);
-CREATE TABLE events_log_p200k_to_300k   PARTITION OF events_log_partitioned FOR VALUES FROM (200000)  TO (300000);
-CREATE TABLE events_log_p300k_to_400k   PARTITION OF events_log_partitioned FOR VALUES FROM (300000)  TO (400000);
-CREATE TABLE events_log_p400k_to_500k   PARTITION OF events_log_partitioned FOR VALUES FROM (400000)  TO (500000);
-CREATE TABLE events_log_p500k_to_600k   PARTITION OF events_log_partitioned FOR VALUES FROM (500000)  TO (600000);
-CREATE TABLE events_log_p600k_to_700k   PARTITION OF events_log_partitioned FOR VALUES FROM (600000)  TO (700000);
-CREATE TABLE events_log_p700k_to_800k   PARTITION OF events_log_partitioned FOR VALUES FROM (700000)  TO (800000);
-CREATE TABLE events_log_p800k_to_900k   PARTITION OF events_log_partitioned FOR VALUES FROM (800000)  TO (900000);
-CREATE TABLE events_log_p900k_to_1m     PARTITION OF events_log_partitioned FOR VALUES FROM (900000)  TO (1000000);
-CREATE TABLE events_log_p1m_to_1_1m     PARTITION OF events_log_partitioned FOR VALUES FROM (1000000) TO (1100000);
-CREATE TABLE events_log_p1_1m_to_1_2m   PARTITION OF events_log_partitioned FOR VALUES FROM (1100000) TO (1200000);
-CREATE TABLE events_log_p1_2m_to_1_3m   PARTITION OF events_log_partitioned FOR VALUES FROM (1200000) TO (1300000);
-CREATE TABLE events_log_p1_3m_to_1_4m   PARTITION OF events_log_partitioned FOR VALUES FROM (1300000) TO (1400000);
-CREATE TABLE events_log_p1_4m_to_1_5m   PARTITION OF events_log_partitioned FOR VALUES FROM (1400000) TO (1500000);
+CREATE TABLE events_log_p0_to_100000     PARTITION OF events_log_partitioned FOR VALUES FROM (0)       TO (100000);
+CREATE TABLE events_log_p100000_to_200000   PARTITION OF events_log_partitioned FOR VALUES FROM (100000)  TO (200000);
+CREATE TABLE events_log_p200000_to_300000   PARTITION OF events_log_partitioned FOR VALUES FROM (200000)  TO (300000);
+CREATE TABLE events_log_p300000_to_400000   PARTITION OF events_log_partitioned FOR VALUES FROM (300000)  TO (400000);
+CREATE TABLE events_log_p400000_to_500000   PARTITION OF events_log_partitioned FOR VALUES FROM (400000)  TO (500000);
+CREATE TABLE events_log_p500000_to_600000   PARTITION OF events_log_partitioned FOR VALUES FROM (500000)  TO (600000);
+CREATE TABLE events_log_p600000_to_700000   PARTITION OF events_log_partitioned FOR VALUES FROM (600000)  TO (700000);
+CREATE TABLE events_log_p700000_to_800000   PARTITION OF events_log_partitioned FOR VALUES FROM (700000)  TO (800000);
+CREATE TABLE events_log_p800000_to_900000   PARTITION OF events_log_partitioned FOR VALUES FROM (800000)  TO (900000);
+CREATE TABLE events_log_p900000_to_1000000     PARTITION OF events_log_partitioned FOR VALUES FROM (900000)  TO (1000000);
+CREATE TABLE events_log_p1000000_to_1100000     PARTITION OF events_log_partitioned FOR VALUES FROM (1000000) TO (1100000);
+CREATE TABLE events_log_p1100000_to_1200000   PARTITION OF events_log_partitioned FOR VALUES FROM (1100000) TO (1200000);
+CREATE TABLE events_log_p1200000_to_1300000   PARTITION OF events_log_partitioned FOR VALUES FROM (1200000) TO (1300000);
+CREATE TABLE events_log_p1300000_to_1400000   PARTITION OF events_log_partitioned FOR VALUES FROM (1300000) TO (1400000);
+CREATE TABLE events_log_p1400000_to_1500000   PARTITION OF events_log_partitioned FOR VALUES FROM (1400000) TO (1500000);
 CREATE TABLE events_log_default         PARTITION OF events_log_partitioned DEFAULT;
 
 -- 3 ── Backfill data from the old table in batches ───────────────────────────
@@ -68,7 +71,13 @@ END $$;
 ALTER TABLE IF EXISTS events_log RENAME TO events_log_old;
 ALTER TABLE events_log_partitioned RENAME TO events_log;
 
--- 5 ── Re-create indexes on the new partitioned table ────────────────────────
+-- 5 ── Drop the old table ────────────────────────────────────────────────────
+-- Must happen before the indexes below are created: renaming a table does not
+-- rename its indexes, so the old table still owns idx_events_log_ledger and
+-- friends until it is dropped.
+DROP TABLE IF EXISTS events_log_old;
+
+-- 6 ── Re-create indexes on the new partitioned table ────────────────────────
 -- Partition-key indexes are automatically created per-partition, but we still
 -- need the logical indexes on the parent so the planner can prune.
 CREATE INDEX idx_events_log_ledger ON events_log (ledger);
@@ -76,6 +85,3 @@ CREATE INDEX idx_events_log_contract ON events_log (contract_id, ledger);
 CREATE INDEX idx_events_log_topic ON events_log USING GIN (topic);
 CREATE UNIQUE INDEX ux_events_log_unique_event
     ON events_log (contract_id, ledger, COALESCE(tx_hash, ''), event_index);
-
--- 6 ── Drop the old table ────────────────────────────────────────────────────
-DROP TABLE IF EXISTS events_log_old;

--- a/backend/src/db/migrations/015_add_reputation_disputes.sql
+++ b/backend/src/db/migrations/015_add_reputation_disputes.sql
@@ -1,0 +1,65 @@
+-- Reputation engine: staking collateral, disputes, weighted votes, and the
+-- decay clock the off-chain mirror recomputes scores from.
+--
+-- Stakes and disputes are keyed by *address* (matching the agent_registry
+-- contract, where collateral is locked per account), while the denormalized
+-- stake columns on `agents` let discovery queries filter and sort without a
+-- join.
+
+-- Collateral locked by an address, mirrored from STAKED / UNSTAKED /
+-- STAKE_SLASHED events.
+CREATE TABLE IF NOT EXISTS agent_stakes (
+    agent_address TEXT        PRIMARY KEY,
+    token         TEXT        NOT NULL DEFAULT '',
+    amount        BIGINT      NOT NULL DEFAULT 0 CHECK (amount >= 0),
+    slashed       BIGINT      NOT NULL DEFAULT 0 CHECK (slashed >= 0),
+    staked_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_stakes_amount ON agent_stakes (amount DESC);
+
+-- One row per on-chain dispute. `evidence` holds the off-chain bundle whose
+-- SHA-256 digest is what `evidence_hash` (and the contract) commits to.
+CREATE TABLE IF NOT EXISTS disputes (
+    id             BIGINT      PRIMARY KEY,
+    complainant    TEXT        NOT NULL,
+    respondent     TEXT        NOT NULL,
+    evidence_hash  TEXT        NOT NULL DEFAULT '',
+    evidence       JSONB,
+    status         TEXT        NOT NULL DEFAULT 'open'
+                               CHECK (status IN ('open', 'resolved')),
+    outcome        TEXT        CHECK (outcome IN ('guilty', 'not_guilty', 'quorum_failed')),
+    weight_for     BIGINT      NOT NULL DEFAULT 0,
+    weight_against BIGINT      NOT NULL DEFAULT 0,
+    slashed_amount BIGINT      NOT NULL DEFAULT 0,
+    opened_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    closes_at      TIMESTAMPTZ,
+    resolved_at    TIMESTAMPTZ,
+    indexed_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_disputes_respondent ON disputes (respondent);
+CREATE INDEX IF NOT EXISTS idx_disputes_complainant ON disputes (complainant);
+CREATE INDEX IF NOT EXISTS idx_disputes_open ON disputes (closes_at) WHERE status = 'open';
+
+-- Weighted votes cast on a dispute. One vote per (dispute, voter), matching
+-- the contract's double-vote guard.
+CREATE TABLE IF NOT EXISTS dispute_votes (
+    dispute_id BIGINT      NOT NULL REFERENCES disputes (id) ON DELETE CASCADE,
+    voter      TEXT        NOT NULL,
+    in_favor   BOOLEAN     NOT NULL,
+    weight     BIGINT      NOT NULL DEFAULT 0 CHECK (weight >= 0),
+    voted_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (dispute_id, voter)
+);
+
+CREATE INDEX IF NOT EXISTS idx_dispute_votes_voter ON dispute_votes (voter);
+
+-- Decay clock + denormalized stake for agents. `reputation` stays the *base*
+-- score exactly as the contract stores it; what a reader sees is that score
+-- decayed from `reputation_updated_at`, computed by reputationEngine.js.
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS reputation_updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS stake_amount BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS stake_slashed BIGINT NOT NULL DEFAULT 0;

--- a/backend/src/pipeline/EventProcessor.js
+++ b/backend/src/pipeline/EventProcessor.js
@@ -1,15 +1,184 @@
 /**
  * Event processor that forwards contract events to the domain listener while
  * recording latency metrics.
+ *
+ * Reputation events (staking, disputes, slashing) are handled here rather than
+ * in the asset/agent listener: they carry economic state the index must keep
+ * exactly in step with the chain, and each one maps to a single repository
+ * write, so a replayed event is idempotent.
  */
 
+const { scValToNative } = require("@stellar/stellar-sdk");
+
 const { processEvent } = require("../listeners/eventListener");
+const disputeService = require("../services/disputeService");
 const pipelineMetrics = require("./pipelineMetrics");
+
+/** Topics this module owns; everything else falls through to the listener. */
+const REPUTATION_TOPICS = new Set([
+  "STAKED",
+  "UNSTAKED",
+  "DISPUTE_OPENED",
+  "DISPUTE_VOTED",
+  "DISPUTE_RESOLVED",
+  "STAKE_SLASHED",
+]);
 
 async function process(event) {
   const startedAt = Date.now();
-  await processEvent(event);
+
+  const topic = topicAt(event, 0);
+  if (REPUTATION_TOPICS.has(topic)) {
+    await processReputationEvent(topic, event);
+  } else {
+    await processEvent(event);
+  }
+
   pipelineMetrics.recordProcessingLatency(Date.now() - startedAt);
 }
 
-module.exports = { process };
+/**
+ * Route one reputation event to the dispute service.
+ *
+ * Topic layouts (see contracts/agent_registry/src/lib.rs):
+ *   STAKED            (topic: [tag, agent])                 value: [amount, total]
+ *   UNSTAKED          (topic: [tag, agent])                 value: [amount, remaining]
+ *   DISPUTE_OPENED    (topic: [tag, complainant, respondent]) value: [id, closesAt]
+ *   DISPUTE_VOTED     (topic: [tag, voter])                 value: [id, weight, inFavor]
+ *   DISPUTE_RESOLVED  (topic: [tag, respondent])            value: [id, outcome, slashed]
+ *   STAKE_SLASHED     (topic: [tag, respondent])            value: [id, slashed]
+ */
+async function processReputationEvent(topic, event) {
+  const value = decode(event.value);
+  const ledgerTime = eventTimestamp(event);
+
+  switch (topic) {
+    case "STAKED":
+    case "UNSTAKED": {
+      const agentAddress = topicAt(event, 1);
+      const total = numberAt(value, 1);
+      if (!agentAddress) return;
+
+      await disputeService.recordStake({
+        agentAddress,
+        token: event.token || "",
+        amount: total,
+        stakedAt: ledgerTime,
+      });
+      return;
+    }
+
+    case "DISPUTE_OPENED": {
+      const complainant = topicAt(event, 1);
+      const respondent = topicAt(event, 2);
+      const id = numberAt(value, 0);
+      if (!id || !complainant || !respondent) return;
+
+      await disputeService.fileDispute({
+        id,
+        complainant,
+        respondent,
+        evidenceHash: event.evidenceHash || "",
+        openedAt: ledgerTime,
+        closesAt: secondsToMs(numberAt(value, 1)),
+      });
+      return;
+    }
+
+    case "DISPUTE_VOTED": {
+      const voter = topicAt(event, 1);
+      const id = numberAt(value, 0);
+      if (!id || !voter) return;
+
+      await disputeService.recordVote({
+        disputeId: id,
+        voter,
+        weight: numberAt(value, 1),
+        inFavor: booleanAt(value, 2),
+        votedAt: ledgerTime,
+      });
+      return;
+    }
+
+    case "DISPUTE_RESOLVED": {
+      const id = numberAt(value, 0);
+      if (!id) return;
+
+      await disputeService.resolveDispute({
+        id,
+        outcome: outcomeAt(value, 1),
+        slashedAmount: numberAt(value, 2),
+        resolvedAt: ledgerTime,
+      });
+      return;
+    }
+
+    case "STAKE_SLASHED": {
+      const respondent = topicAt(event, 1);
+      const slashed = numberAt(value, 1);
+      if (!respondent || slashed <= 0) return;
+
+      await disputeService.recordSlash(respondent, slashed);
+      return;
+    }
+
+    default:
+  }
+}
+
+// ── Decoding helpers ─────────────────────────────────────────────────────────
+
+function decode(value) {
+  if (!value || typeof value.switch !== "function") return value;
+  try {
+    return scValToNative(value);
+  } catch (_err) {
+    return value;
+  }
+}
+
+function topicAt(event, index) {
+  const topics = Array.isArray(event?.topic) ? event.topic : [];
+  const raw = decode(topics[index]);
+  return raw === undefined || raw === null ? null : String(raw);
+}
+
+function elementAt(value, index) {
+  if (Array.isArray(value)) return value[index];
+  if (index === 0) return value;
+  return undefined;
+}
+
+function numberAt(value, index) {
+  const raw = elementAt(value, index);
+  if (typeof raw === "bigint") {
+    return raw > BigInt(Number.MAX_SAFE_INTEGER) ? Number.MAX_SAFE_INTEGER : Number(raw);
+  }
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function booleanAt(value, index) {
+  return Boolean(elementAt(value, index));
+}
+
+/** The contract publishes its DisputeOutcome enum as its variant name. */
+function outcomeAt(value, index) {
+  const raw = elementAt(value, index);
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw === "string") return raw;
+  if (Array.isArray(raw)) return String(raw[0]);
+  if (typeof raw === "object") return String(Object.keys(raw)[0]);
+  return String(raw);
+}
+
+function secondsToMs(seconds) {
+  return seconds > 0 ? seconds * 1000 : null;
+}
+
+function eventTimestamp(event) {
+  const raw = Number(event?.ledgerClosedAt ? Date.parse(event.ledgerClosedAt) : NaN);
+  return Number.isFinite(raw) ? raw : Date.now();
+}
+
+module.exports = { process, REPUTATION_TOPICS };

--- a/backend/src/protocol/StreamMonitor.js
+++ b/backend/src/protocol/StreamMonitor.js
@@ -21,6 +21,22 @@ function registerClient(req, res) {
 }
 
 /**
+ * Push an arbitrary named event to every subscribed client.
+ * Dead sockets are dropped rather than allowed to throw at the caller.
+ */
+function broadcast(event, payload) {
+  const message = `event: ${event}\ndata: ${JSON.stringify({ event, ...payload })}\n\n`;
+
+  for (const client of sseClients) {
+    try {
+      client.write(message);
+    } catch (_err) {
+      sseClients.delete(client);
+    }
+  }
+}
+
+/**
  * Check if the stream has less than or equal to 10% of calls remaining.
  * Emits a LOW_BALANCE event to all listening clients if true.
  */
@@ -52,6 +68,7 @@ function checkStreamAndAlert(stream) {
 
 module.exports = {
   registerClient,
+  broadcast,
   checkStreamAndAlert,
   _sseClients: sseClients,
 };

--- a/backend/src/repositories/agentRepository.js
+++ b/backend/src/repositories/agentRepository.js
@@ -12,8 +12,9 @@ const {
 } = require("./repoUtils");
 
 const COLUMNS = `
-  id, owner, name, description, capabilities, reputation,
-  total_transactions, is_active, registered_at, indexed_at, updated_at
+  id, owner, name, description, capabilities, reputation, reputation_updated_at,
+  stake_amount, stake_slashed, total_transactions, is_active, registered_at,
+  indexed_at, updated_at
 `;
 
 function mapAgent(row) {
@@ -25,6 +26,9 @@ function mapAgent(row) {
     description: row.description,
     capabilities: row.capabilities,
     reputation: row.reputation,
+    reputationUpdatedAt: toMs(row.reputation_updated_at),
+    stakeAmount: Number(row.stake_amount ?? 0),
+    stakeSlashed: Number(row.stake_slashed ?? 0),
     totalTransactions: row.total_transactions,
     isActive: row.is_active,
     registeredAt: toMs(row.registered_at),
@@ -145,16 +149,59 @@ async function findAll(filters = {}, pagination = {}, client) {
 
 /**
  * Set an agent's reputation (basis points, 0–10000 enforced by CHECK).
+ *
+ * `options.reputationUpdatedAt` (epoch ms) restarts the decay clock — pass it
+ * whenever the score being written is a *settled* one, so reputationEngine
+ * does not decay the same interval twice.
  */
-async function updateReputation(id, reputation, client) {
+async function updateReputation(id, reputation, client, options = {}) {
+  const { reputationUpdatedAt } = options;
+
   const { rows } = await run(
-    `UPDATE agents SET reputation = $2, updated_at = now()
-     WHERE id = $1
+    `UPDATE agents
+        SET reputation            = $2,
+            reputation_updated_at = COALESCE(
+              to_timestamp($3::double precision / 1000.0),
+              reputation_updated_at
+            ),
+            updated_at            = now()
+      WHERE id = $1
      RETURNING ${COLUMNS}`,
-    [id, reputation],
+    [id, reputation, msParam(reputationUpdatedAt)],
     client
   );
   return mapAgent(rows[0]);
+}
+
+/**
+ * Every agent registered by an owner address.
+ */
+async function findByOwner(owner, client) {
+  const { rows } = await run(
+    `SELECT ${COLUMNS} FROM agents WHERE owner = $1 ORDER BY id ASC`,
+    [owner],
+    client,
+    "read"
+  );
+  return rows.map(mapAgent);
+}
+
+/**
+ * Mirror an owner's staked collateral onto each of their agents, so discovery
+ * queries can filter and sort on stake without joining `agent_stakes`.
+ */
+async function updateStakeForOwner(owner, { amount = 0, slashed = 0 } = {}, client) {
+  const { rows } = await run(
+    `UPDATE agents
+        SET stake_amount  = $2,
+            stake_slashed = $3,
+            updated_at    = now()
+      WHERE owner = $1
+     RETURNING ${COLUMNS}`,
+    [owner, amount, slashed],
+    client
+  );
+  return rows.map(mapAgent);
 }
 
 /**
@@ -170,4 +217,12 @@ async function deactivate(id, client) {
   return rowCount > 0;
 }
 
-module.exports = { create, findById, findAll, updateReputation, deactivate };
+module.exports = {
+  create,
+  findById,
+  findAll,
+  findByOwner,
+  updateReputation,
+  updateStakeForOwner,
+  deactivate,
+};

--- a/backend/src/repositories/agentStakeRepository.js
+++ b/backend/src/repositories/agentStakeRepository.js
@@ -1,0 +1,90 @@
+/**
+ * Agent stake repository — all SQL touching `agent_stakes` lives here.
+ *
+ * Rows mirror the collateral an address has locked in the agent_registry
+ * contract; the pipeline keeps them in step with STAKED, UNSTAKED and
+ * STAKE_SLASHED events.
+ */
+
+const { run, toMs, msParam } = require("./repoUtils");
+
+const COLUMNS = `
+  agent_address, token, amount, slashed, staked_at, updated_at
+`;
+
+function mapStake(row) {
+  if (!row) return null;
+  return {
+    agentAddress: row.agent_address,
+    token: row.token,
+    amount: Number(row.amount),
+    slashed: Number(row.slashed),
+    stakedAt: toMs(row.staked_at),
+    updatedAt: toMs(row.updated_at),
+  };
+}
+
+/**
+ * Set an address's locked collateral to `amount` (the on-chain total).
+ */
+async function upsert(stake, client) {
+  const { agentAddress, token = "", amount = 0, slashed = 0, stakedAt } = stake;
+
+  const { rows } = await run(
+    `INSERT INTO agent_stakes (agent_address, token, amount, slashed, staked_at)
+     VALUES ($1, $2, $3, $4, COALESCE(to_timestamp($5::double precision / 1000.0), now()))
+     ON CONFLICT (agent_address) DO UPDATE SET
+       token      = EXCLUDED.token,
+       amount     = EXCLUDED.amount,
+       slashed    = GREATEST(agent_stakes.slashed, EXCLUDED.slashed),
+       updated_at = now()
+     RETURNING ${COLUMNS}`,
+    [agentAddress, token, amount, slashed, msParam(stakedAt)],
+    client
+  );
+  return mapStake(rows[0]);
+}
+
+/**
+ * Move `amount` from locked collateral into the slashed total.
+ * Returns null when the address has no stake row.
+ */
+async function applySlash(agentAddress, amount, client) {
+  const { rows } = await run(
+    `UPDATE agent_stakes
+        SET amount     = GREATEST(amount - $2, 0),
+            slashed    = slashed + $2,
+            updated_at = now()
+      WHERE agent_address = $1
+     RETURNING ${COLUMNS}`,
+    [agentAddress, amount],
+    client
+  );
+  return mapStake(rows[0]);
+}
+
+async function findByAddress(agentAddress, client) {
+  const { rows } = await run(
+    `SELECT ${COLUMNS} FROM agent_stakes WHERE agent_address = $1`,
+    [agentAddress],
+    client,
+    "read"
+  );
+  return mapStake(rows[0]);
+}
+
+/**
+ * Stakes for several addresses at once (used when rendering agent lists).
+ */
+async function findByAddresses(addresses = [], client) {
+  if (addresses.length === 0) return [];
+  const { rows } = await run(
+    `SELECT ${COLUMNS} FROM agent_stakes WHERE agent_address = ANY($1::text[])`,
+    [addresses],
+    client,
+    "read"
+  );
+  return rows.map(mapStake);
+}
+
+module.exports = { upsert, applySlash, findByAddress, findByAddresses };

--- a/backend/src/repositories/disputeRepository.js
+++ b/backend/src/repositories/disputeRepository.js
@@ -1,0 +1,268 @@
+/**
+ * Dispute repository — all SQL touching `disputes` and `dispute_votes`.
+ *
+ * Rows are the off-chain mirror of the agent_registry contract's dispute
+ * records: the pipeline upserts them from DISPUTE_OPENED / DISPUTE_VOTED /
+ * DISPUTE_RESOLVED events, and `evidence` holds the bundle whose digest the
+ * chain committed to.
+ */
+
+const {
+  run,
+  toMs,
+  msParam,
+  normalizePagination,
+  buildMeta,
+} = require("./repoUtils");
+
+const COLUMNS = `
+  id, complainant, respondent, evidence_hash, evidence, status, outcome,
+  weight_for, weight_against, slashed_amount, opened_at, closes_at,
+  resolved_at, indexed_at, updated_at
+`;
+
+function mapDispute(row) {
+  if (!row) return null;
+  return {
+    id: Number(row.id),
+    complainant: row.complainant,
+    respondent: row.respondent,
+    evidenceHash: row.evidence_hash,
+    evidence: row.evidence ?? null,
+    status: row.status,
+    outcome: row.outcome ?? null,
+    weightFor: Number(row.weight_for),
+    weightAgainst: Number(row.weight_against),
+    slashedAmount: Number(row.slashed_amount),
+    openedAt: toMs(row.opened_at),
+    closesAt: toMs(row.closes_at),
+    resolvedAt: toMs(row.resolved_at),
+    indexedAt: toMs(row.indexed_at),
+    updatedAt: toMs(row.updated_at),
+  };
+}
+
+function mapVote(row) {
+  if (!row) return null;
+  return {
+    disputeId: Number(row.dispute_id),
+    voter: row.voter,
+    inFavor: row.in_favor,
+    weight: Number(row.weight),
+    votedAt: toMs(row.voted_at),
+  };
+}
+
+/**
+ * Upsert a dispute by its on-chain id.
+ */
+async function upsert(dispute, client) {
+  const {
+    id,
+    complainant,
+    respondent,
+    evidenceHash = "",
+    evidence = null,
+    status = "open",
+    outcome = null,
+    weightFor = 0,
+    weightAgainst = 0,
+    slashedAmount = 0,
+    openedAt,
+    closesAt,
+    resolvedAt,
+  } = dispute;
+
+  const { rows } = await run(
+    `INSERT INTO disputes
+       (id, complainant, respondent, evidence_hash, evidence, status, outcome,
+        weight_for, weight_against, slashed_amount, opened_at, closes_at, resolved_at)
+     VALUES
+       ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10,
+        COALESCE(to_timestamp($11::double precision / 1000.0), now()),
+        to_timestamp($12::double precision / 1000.0),
+        to_timestamp($13::double precision / 1000.0))
+     ON CONFLICT (id) DO UPDATE SET
+       evidence_hash  = EXCLUDED.evidence_hash,
+       evidence       = COALESCE(EXCLUDED.evidence, disputes.evidence),
+       status         = EXCLUDED.status,
+       outcome        = EXCLUDED.outcome,
+       weight_for     = EXCLUDED.weight_for,
+       weight_against = EXCLUDED.weight_against,
+       slashed_amount = EXCLUDED.slashed_amount,
+       closes_at      = COALESCE(EXCLUDED.closes_at, disputes.closes_at),
+       resolved_at    = COALESCE(EXCLUDED.resolved_at, disputes.resolved_at),
+       updated_at     = now()
+     RETURNING ${COLUMNS}`,
+    [
+      id,
+      complainant,
+      respondent,
+      evidenceHash,
+      evidence === null ? null : JSON.stringify(evidence),
+      status,
+      outcome,
+      weightFor,
+      weightAgainst,
+      slashedAmount,
+      msParam(openedAt),
+      msParam(closesAt),
+      msParam(resolvedAt),
+    ],
+    client
+  );
+  return mapDispute(rows[0]);
+}
+
+/**
+ * Record the verdict of a dispute.
+ */
+async function resolve(id, { outcome, slashedAmount = 0, resolvedAt } = {}, client) {
+  const { rows } = await run(
+    `UPDATE disputes
+        SET status         = 'resolved',
+            outcome        = $2,
+            slashed_amount = $3,
+            resolved_at    = COALESCE(to_timestamp($4::double precision / 1000.0), now()),
+            updated_at     = now()
+      WHERE id = $1
+     RETURNING ${COLUMNS}`,
+    [id, outcome, slashedAmount, msParam(resolvedAt)],
+    client
+  );
+  return mapDispute(rows[0]);
+}
+
+/**
+ * Attach (or replace) the off-chain evidence bundle and its digest.
+ */
+async function attachEvidence(id, { evidence, evidenceHash }, client) {
+  const { rows } = await run(
+    `UPDATE disputes
+        SET evidence      = $2::jsonb,
+            evidence_hash = COALESCE(NULLIF($3, ''), evidence_hash),
+            updated_at    = now()
+      WHERE id = $1
+     RETURNING ${COLUMNS}`,
+    [id, JSON.stringify(evidence ?? null), evidenceHash ?? ""],
+    client
+  );
+  return mapDispute(rows[0]);
+}
+
+async function findById(id, client) {
+  const { rows } = await run(
+    `SELECT ${COLUMNS} FROM disputes WHERE id = $1`,
+    [id],
+    client,
+    "read"
+  );
+  return mapDispute(rows[0]);
+}
+
+/**
+ * Disputes still open for voting, oldest deadline first.
+ */
+async function findActive(pagination = {}, client) {
+  const { page, limit, offset } = normalizePagination(pagination);
+
+  const countResult = await run(
+    "SELECT count(*)::bigint AS total FROM disputes WHERE status = 'open'",
+    [],
+    client,
+    "read"
+  );
+  const total = Number(countResult.rows[0].total);
+
+  const { rows } = await run(
+    `SELECT ${COLUMNS} FROM disputes
+      WHERE status = 'open'
+      ORDER BY closes_at ASC NULLS LAST, id ASC
+      LIMIT $1 OFFSET $2`,
+    [limit, offset],
+    client,
+    "read"
+  );
+
+  return { data: rows.map(mapDispute), meta: buildMeta(total, page, limit) };
+}
+
+/**
+ * Every dispute an address is involved in, as complainant or respondent.
+ */
+async function findByAddress(address, pagination = {}, client) {
+  const { page, limit, offset } = normalizePagination(pagination);
+
+  const countResult = await run(
+    "SELECT count(*)::bigint AS total FROM disputes WHERE respondent = $1 OR complainant = $1",
+    [address],
+    client,
+    "read"
+  );
+  const total = Number(countResult.rows[0].total);
+
+  const { rows } = await run(
+    `SELECT ${COLUMNS} FROM disputes
+      WHERE respondent = $1 OR complainant = $1
+      ORDER BY opened_at DESC, id DESC
+      LIMIT $2 OFFSET $3`,
+    [address, limit, offset],
+    client,
+    "read"
+  );
+
+  return { data: rows.map(mapDispute), meta: buildMeta(total, page, limit) };
+}
+
+/**
+ * Record a weighted vote and fold its weight into the dispute tally.
+ */
+async function recordVote(vote, client) {
+  const { disputeId, voter, inFavor, weight = 0, votedAt } = vote;
+
+  const { rows } = await run(
+    `INSERT INTO dispute_votes (dispute_id, voter, in_favor, weight, voted_at)
+     VALUES ($1, $2, $3, $4, COALESCE(to_timestamp($5::double precision / 1000.0), now()))
+     ON CONFLICT (dispute_id, voter) DO NOTHING
+     RETURNING dispute_id, voter, in_favor, weight, voted_at`,
+    [disputeId, voter, inFavor, weight, msParam(votedAt)],
+    client
+  );
+
+  // A duplicate vote is a replayed event — leave the tally untouched.
+  if (rows.length === 0) return null;
+
+  await run(
+    `UPDATE disputes
+        SET weight_for     = weight_for + CASE WHEN $2 THEN $3 ELSE 0 END,
+            weight_against = weight_against + CASE WHEN $2 THEN 0 ELSE $3 END,
+            updated_at     = now()
+      WHERE id = $1`,
+    [disputeId, inFavor, weight],
+    client
+  );
+
+  return mapVote(rows[0]);
+}
+
+async function findVotes(disputeId, client) {
+  const { rows } = await run(
+    `SELECT dispute_id, voter, in_favor, weight, voted_at
+       FROM dispute_votes WHERE dispute_id = $1 ORDER BY voted_at ASC`,
+    [disputeId],
+    client,
+    "read"
+  );
+  return rows.map(mapVote);
+}
+
+module.exports = {
+  upsert,
+  resolve,
+  attachEvidence,
+  findById,
+  findActive,
+  findByAddress,
+  recordVote,
+  findVotes,
+};

--- a/backend/src/routes/agents.js
+++ b/backend/src/routes/agents.js
@@ -11,6 +11,7 @@ const {
   getReputationHistory,
   getActivityFeed,
   getLeaderboard,
+  getReputationTimeline,
   CAPABILITIES,
 } = require("../services/agentService");
 
@@ -131,6 +132,25 @@ router.get(
       meta: { agentId: req.params.id, count: history.length },
     });
   }
+);
+
+/**
+ * GET /api/v1/agents/:id/reputation-timeline
+ * Decay curve, dispute markers, and staked collateral for an agent.
+ */
+router.get(
+  "/:id/reputation-timeline",
+  [param("id").isInt({ min: 1 }), query("points").optional().isInt({ min: 2, max: 200 })],
+  validate,
+  asyncHandler(async (req, res) => {
+    const timeline = await getReputationTimeline(req.params.id, {
+      points: req.query.points ? Number(req.query.points) : 30,
+    });
+    if (!timeline) {
+      return res.status(404).json({ error: "Agent not found" });
+    }
+    res.json(timeline);
+  })
 );
 
 /**

--- a/backend/src/routes/disputes.js
+++ b/backend/src/routes/disputes.js
@@ -1,0 +1,126 @@
+const { Router } = require("express");
+const { body, param, query } = require("express-validator");
+
+const validate = require("../middleware/validate");
+const asyncHandler = require("../middleware/asyncHandler");
+const { isValidStellarAddress } = require("../utils/stellar");
+const disputeService = require("../services/disputeService");
+
+const router = Router();
+
+/**
+ * GET /api/v1/disputes
+ * Disputes still open for voting, soonest deadline first.
+ */
+router.get(
+  "/",
+  [
+    query("page").optional().isInt({ min: 1 }),
+    query("limit").optional().isInt({ min: 1, max: 100 }),
+  ],
+  validate,
+  asyncHandler(async (req, res) => {
+    const result = await disputeService.getActiveDisputes({
+      page: req.query.page ? Number(req.query.page) : 1,
+      limit: req.query.limit ? Number(req.query.limit) : 20,
+    });
+    res.json(result);
+  })
+);
+
+/**
+ * GET /api/v1/disputes/agent/:address
+ * Every dispute an address is involved in, as complainant or respondent.
+ */
+router.get(
+  "/agent/:address",
+  [
+    param("address").custom(isValidStellarAddress).withMessage("must be a valid Stellar public key"),
+    query("page").optional().isInt({ min: 1 }),
+    query("limit").optional().isInt({ min: 1, max: 100 }),
+  ],
+  validate,
+  asyncHandler(async (req, res) => {
+    const result = await disputeService.getDisputesForAgent(req.params.address, {
+      page: req.query.page ? Number(req.query.page) : 1,
+      limit: req.query.limit ? Number(req.query.limit) : 20,
+    });
+    res.json(result);
+  })
+);
+
+/**
+ * GET /api/v1/disputes/:id
+ */
+router.get(
+  "/:id",
+  [param("id").isInt({ min: 1 })],
+  validate,
+  asyncHandler(async (req, res) => {
+    const dispute = await disputeService.getDispute(req.params.id);
+    if (!dispute) {
+      return res.status(404).json({ error: "Dispute not found" });
+    }
+    res.json(dispute);
+  })
+);
+
+/**
+ * POST /api/v1/disputes
+ * Index a dispute opened on-chain, optionally with its evidence bundle.
+ * The response carries the digest the filer must commit on-chain.
+ */
+router.post(
+  "/",
+  [
+    body("id").isInt({ min: 1 }),
+    body("complainant")
+      .isString()
+      .bail()
+      .custom(isValidStellarAddress)
+      .withMessage("must be a valid Stellar public key"),
+    body("respondent")
+      .isString()
+      .bail()
+      .custom(isValidStellarAddress)
+      .withMessage("must be a valid Stellar public key"),
+    body("evidence").optional(),
+    body("evidenceHash").optional().isString().isLength({ min: 64, max: 64 }),
+    body("closesAt").optional().isInt({ min: 0 }),
+  ],
+  validate,
+  asyncHandler(async (req, res) => {
+    const dispute = await disputeService.fileDispute({
+      id: Number(req.body.id),
+      complainant: req.body.complainant,
+      respondent: req.body.respondent,
+      evidence: req.body.evidence ?? null,
+      evidenceHash: req.body.evidenceHash,
+      closesAt: req.body.closesAt ? Number(req.body.closesAt) : undefined,
+    });
+    res.status(201).json(dispute);
+  })
+);
+
+/**
+ * POST /api/v1/disputes/:id/evidence
+ * Upload (or replace) the off-chain evidence bundle. Returns its SHA-256
+ * digest — the value to pass as `evidence_hash` when calling the contract.
+ */
+router.post(
+  "/:id/evidence",
+  [param("id").isInt({ min: 1 }), body("evidence").exists()],
+  validate,
+  asyncHandler(async (req, res) => {
+    const result = await disputeService.submitEvidence(
+      req.params.id,
+      req.body.evidence
+    );
+    if (!result) {
+      return res.status(404).json({ error: "Dispute not found" });
+    }
+    res.status(201).json(result);
+  })
+);
+
+module.exports = router;

--- a/backend/src/services/agentService.js
+++ b/backend/src/services/agentService.js
@@ -5,6 +5,9 @@
 
 const agentRepository = require("../repositories/agentRepository");
 const agentBanRepository = require("../repositories/agentBanRepository");
+const agentStakeRepository = require("../repositories/agentStakeRepository");
+const disputeRepository = require("../repositories/disputeRepository");
+const reputationEngine = require("./reputationEngine");
 
 const CAPABILITIES = [
   "TextGeneration",
@@ -35,6 +38,8 @@ async function registerAgent(agentData) {
 
 /**
  * Discover active agents with optional filters and pagination.
+ *
+ * Scores are decayed on read, so a listing never shows a stale snapshot.
  */
 async function listAgents({
   capability,
@@ -43,17 +48,54 @@ async function listAgents({
   page = 1,
   limit = 20,
 } = {}) {
-  return agentRepository.findAll(
+  const result = await agentRepository.findAll(
     { capability, minReputation, search },
     { page, limit }
   );
+  return { ...result, data: reputationEngine.withCurrentReputations(result.data) };
 }
 
 /**
  * Get a single agent by ID (active or not — callers inspect isActive).
  */
 async function getAgent(id) {
-  return agentRepository.findById(id);
+  const agent = await agentRepository.findById(id);
+  return agent ? reputationEngine.withCurrentReputation(agent) : agent;
+}
+
+/**
+ * Reputation over time for an agent: the decay curve since its score was last
+ * settled, the disputes its owner is involved in as markers, and the stake
+ * backing it.
+ */
+async function getReputationTimeline(id, { points = 30, nowMs = Date.now() } = {}) {
+  const agent = await agentRepository.findById(id);
+  if (!agent) return null;
+
+  const [disputes, stake] = await Promise.all([
+    disputeRepository.findByAddress(agent.owner, { page: 1, limit: 100 }),
+    agentStakeRepository.findByAddress(agent.owner),
+  ]);
+
+  return {
+    agentId: agent.id,
+    owner: agent.owner,
+    baseReputation: agent.reputation,
+    currentReputation: reputationEngine.currentReputation(agent, nowMs),
+    reputationUpdatedAt: agent.reputationUpdatedAt,
+    config: reputationEngine.getConfig(),
+    curve: reputationEngine.decayCurve(agent, { points, nowMs }),
+    disputes: disputes.data.map((dispute) => ({
+      id: dispute.id,
+      status: dispute.status,
+      outcome: dispute.outcome,
+      openedAt: dispute.openedAt,
+      resolvedAt: dispute.resolvedAt,
+      slashedAmount: dispute.slashedAmount,
+      role: dispute.respondent === agent.owner ? "respondent" : "complainant",
+    })),
+    stake: stake ?? { agentAddress: agent.owner, amount: 0, slashed: 0 },
+  };
 }
 
 /**
@@ -77,6 +119,7 @@ module.exports = {
   registerAgent,
   listAgents,
   getAgent,
+  getReputationTimeline,
   updateAgentReputation,
   deactivateAgent,
   CAPABILITIES,

--- a/backend/src/services/disputeService.js
+++ b/backend/src/services/disputeService.js
@@ -1,0 +1,261 @@
+/**
+ * Dispute service — orchestrates the dispute lifecycle across the index.
+ *
+ * Evidence itself stays off-chain: a filing uploads the bundle here, this
+ * module hashes it, and only the digest is what the contract commits to. The
+ * hash a caller submits on-chain must therefore be the one returned by
+ * `hashEvidence`, or `verifyEvidence` will report the mismatch.
+ *
+ * Agents affected by a filing or a verdict are notified over the existing SSE
+ * channel (see protocol/StreamMonitor.js).
+ */
+
+const { createHash } = require("crypto");
+
+const disputeRepository = require("../repositories/disputeRepository");
+const agentStakeRepository = require("../repositories/agentStakeRepository");
+const agentRepository = require("../repositories/agentRepository");
+const reputationEngine = require("./reputationEngine");
+const StreamMonitor = require("../protocol/StreamMonitor");
+
+/** Verdicts as stored off-chain, keyed by the contract's enum name. */
+const OUTCOMES = Object.freeze({
+  Guilty: "guilty",
+  NotGuilty: "not_guilty",
+  QuorumFailed: "quorum_failed",
+});
+
+function badRequest(message) {
+  const err = new Error(message);
+  err.status = 400;
+  return err;
+}
+
+/**
+ * SHA-256 of the canonical JSON encoding of an evidence bundle.
+ * Object keys are sorted so the same bundle always hashes the same way.
+ */
+function hashEvidence(evidence) {
+  return createHash("sha256").update(canonicalize(evidence)).digest("hex");
+}
+
+function canonicalize(value) {
+  if (value === null || typeof value !== "object") return JSON.stringify(value ?? null);
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
+
+  const keys = Object.keys(value).sort();
+  return `{${keys
+    .map((key) => `${JSON.stringify(key)}:${canonicalize(value[key])}`)
+    .join(",")}}`;
+}
+
+/** Does an evidence bundle match the digest recorded on-chain? */
+function verifyEvidence(evidence, evidenceHash) {
+  return hashEvidence(evidence) === String(evidenceHash || "").toLowerCase();
+}
+
+/**
+ * Index a dispute (called from the API when a filing is submitted, and from
+ * the pipeline when the DISPUTE_OPENED event lands).
+ */
+async function fileDispute(input) {
+  const { id, complainant, respondent } = input;
+
+  if (!Number.isInteger(Number(id)) || Number(id) < 1) {
+    throw badRequest("a dispute id from the contract is required");
+  }
+  if (!complainant || !respondent) {
+    throw badRequest("complainant and respondent are required");
+  }
+  if (complainant === respondent) {
+    throw badRequest("an agent cannot dispute itself");
+  }
+
+  const evidence = input.evidence ?? null;
+  const evidenceHash =
+    input.evidenceHash || (evidence ? hashEvidence(evidence) : "");
+
+  const dispute = await disputeRepository.upsert({
+    id: Number(id),
+    complainant,
+    respondent,
+    evidence,
+    evidenceHash,
+    status: "open",
+    openedAt: input.openedAt,
+    closesAt: input.closesAt,
+  });
+
+  notify("DISPUTE_OPENED", {
+    disputeId: dispute.id,
+    complainant: dispute.complainant,
+    respondent: dispute.respondent,
+    closesAt: dispute.closesAt,
+  });
+
+  return dispute;
+}
+
+/**
+ * Attach an evidence bundle to an existing dispute and return its digest so
+ * the caller can commit it on-chain.
+ */
+async function submitEvidence(disputeId, evidence) {
+  if (evidence === undefined || evidence === null) {
+    throw badRequest("an evidence bundle is required");
+  }
+
+  const dispute = await disputeRepository.findById(Number(disputeId));
+  if (!dispute) return null;
+  if (dispute.status !== "open") {
+    throw badRequest("evidence cannot be added to a resolved dispute");
+  }
+
+  const evidenceHash = hashEvidence(evidence);
+  const updated = await disputeRepository.attachEvidence(dispute.id, {
+    evidence,
+    evidenceHash,
+  });
+
+  return { dispute: updated, evidenceHash };
+}
+
+/** Record a weighted vote reported by the chain. */
+async function recordVote(vote) {
+  return disputeRepository.recordVote({
+    disputeId: Number(vote.disputeId),
+    voter: vote.voter,
+    inFavor: Boolean(vote.inFavor),
+    weight: Number(vote.weight) || 0,
+    votedAt: vote.votedAt,
+  });
+}
+
+/**
+ * Apply a verdict: mark the dispute resolved and, when guilty, move the
+ * slashed collateral and drop the respondent's reputation by the same share.
+ */
+async function resolveDispute({
+  id,
+  outcome,
+  slashedAmount = 0,
+  resolvedAt = Date.now(),
+  slashBps,
+}) {
+  const normalized = normalizeOutcome(outcome);
+  if (!normalized) throw badRequest(`unknown dispute outcome "${outcome}"`);
+
+  const dispute = await disputeRepository.findById(Number(id));
+  if (!dispute) return null;
+
+  const resolved = await disputeRepository.resolve(dispute.id, {
+    outcome: normalized,
+    slashedAmount,
+    resolvedAt,
+  });
+
+  if (normalized === OUTCOMES.Guilty) {
+    if (slashedAmount > 0) {
+      await agentStakeRepository.applySlash(dispute.respondent, slashedAmount);
+    }
+    await reputationEngine.penalizeOwner(dispute.respondent, {
+      slashBps: slashBps ?? reputationEngine.getConfig().slashBps,
+      nowMs: resolvedAt,
+    });
+    await syncStakeColumns(dispute.respondent);
+  }
+
+  notify("DISPUTE_RESOLVED", {
+    disputeId: resolved.id,
+    respondent: resolved.respondent,
+    outcome: resolved.outcome,
+    slashedAmount: resolved.slashedAmount,
+  });
+
+  return resolved;
+}
+
+/**
+ * Mirror a stake change and keep the denormalized columns on `agents` in step.
+ */
+async function recordStake({ agentAddress, token, amount, slashed, stakedAt }) {
+  const stake = await agentStakeRepository.upsert({
+    agentAddress,
+    token,
+    amount,
+    slashed,
+    stakedAt,
+  });
+  await syncStakeColumns(agentAddress, stake);
+  return stake;
+}
+
+/** Apply a slash to the stake mirror (used by the STAKE_SLASHED handler). */
+async function recordSlash(agentAddress, amount) {
+  const stake = await agentStakeRepository.applySlash(agentAddress, amount);
+  await syncStakeColumns(agentAddress, stake);
+
+  notify("STAKE_SLASHED", { agentAddress, amount: Number(amount) || 0 });
+  return stake;
+}
+
+async function syncStakeColumns(agentAddress, stake) {
+  const record = stake ?? (await agentStakeRepository.findByAddress(agentAddress));
+  if (!record) return;
+  await agentRepository.updateStakeForOwner(agentAddress, {
+    amount: record.amount,
+    slashed: record.slashed,
+  });
+}
+
+async function getActiveDisputes(pagination) {
+  return disputeRepository.findActive(pagination);
+}
+
+async function getDispute(id) {
+  const dispute = await disputeRepository.findById(Number(id));
+  if (!dispute) return null;
+  const votes = await disputeRepository.findVotes(dispute.id);
+  return { ...dispute, votes };
+}
+
+async function getDisputesForAgent(address, pagination) {
+  return disputeRepository.findByAddress(address, pagination);
+}
+
+function normalizeOutcome(outcome) {
+  if (!outcome) return null;
+  const key = String(outcome);
+  if (OUTCOMES[key]) return OUTCOMES[key];
+  const value = key.toLowerCase();
+  return Object.values(OUTCOMES).includes(value) ? value : null;
+}
+
+/**
+ * Push an event to subscribed agents. Notification is best-effort: a dead SSE
+ * client must never fail the write that triggered it.
+ */
+function notify(event, payload) {
+  try {
+    StreamMonitor.broadcast(event, payload);
+  } catch (err) {
+    if (process.env.NODE_ENV !== "test") {
+      console.warn(`[disputeService] notification failed: ${err.message}`);
+    }
+  }
+}
+
+module.exports = {
+  OUTCOMES,
+  hashEvidence,
+  verifyEvidence,
+  fileDispute,
+  submitEvidence,
+  recordVote,
+  resolveDispute,
+  recordStake,
+  recordSlash,
+  getActiveDisputes,
+  getDispute,
+  getDisputesForAgent,
+};

--- a/backend/src/services/reputationEngine.js
+++ b/backend/src/services/reputationEngine.js
@@ -1,0 +1,208 @@
+/**
+ * Reputation engine — the off-chain mirror of the agent_registry contract's
+ * time-decayed reputation.
+ *
+ * A page load must not cost a contract call per agent, so the indexer stores
+ * the *base* score exactly as the chain holds it plus the timestamp it was
+ * last settled at, and this module recomputes what that score is worth now.
+ *
+ * The decay is applied one whole period at a time, truncating on each step —
+ * the identical loop the contract runs in `decay_score`. Both sides therefore
+ * agree exactly rather than only to within a floating-point tolerance, which
+ * is what `reputationEngine.test.js` pins.
+ */
+
+const agentRepository = require("../repositories/agentRepository");
+
+const BPS_DENOM = 10_000;
+
+/** Matches MAX_DECAY_PERIODS in contracts/agent_registry/src/lib.rs. */
+const MAX_DECAY_PERIODS = 730;
+
+/** Mirrors the contract's RepConfig defaults. */
+const DEFAULT_CONFIG = Object.freeze({
+  slashBps: 2_000,
+  votingWindow: 259_200,
+  quorumWeight: 1_000,
+  decayBps: 9_900,
+  decayPeriod: 86_400,
+});
+
+let activeConfig = { ...DEFAULT_CONFIG };
+
+/** Read the parameters the engine currently mirrors. */
+function getConfig() {
+  return { ...activeConfig };
+}
+
+/**
+ * Adopt on-chain parameters (e.g. after `configure` changes them). Unknown or
+ * malformed fields fall back to the contract defaults.
+ */
+function setConfig(config = {}) {
+  activeConfig = {
+    slashBps: numberOr(config.slashBps, DEFAULT_CONFIG.slashBps),
+    votingWindow: numberOr(config.votingWindow, DEFAULT_CONFIG.votingWindow),
+    quorumWeight: numberOr(config.quorumWeight, DEFAULT_CONFIG.quorumWeight),
+    decayBps: numberOr(config.decayBps, DEFAULT_CONFIG.decayBps),
+    decayPeriod: numberOr(config.decayPeriod, DEFAULT_CONFIG.decayPeriod),
+  };
+  return getConfig();
+}
+
+function numberOr(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? Math.trunc(parsed) : fallback;
+}
+
+/**
+ * `base * (decayBps / 10000) ^ periods`, in integer arithmetic.
+ *
+ * @param {number} base - base score in basis points (0–10000)
+ * @param {number} elapsedSeconds - seconds since the score was settled
+ * @param {object} [config] - decay parameters (defaults to the active config)
+ */
+function decayScore(base, elapsedSeconds, config = activeConfig) {
+  const score0 = Math.trunc(Number(base) || 0);
+  const elapsed = Math.trunc(Number(elapsedSeconds) || 0);
+
+  if (
+    score0 <= 0 ||
+    elapsed <= 0 ||
+    config.decayPeriod <= 0 ||
+    config.decayBps >= BPS_DENOM
+  ) {
+    return Math.max(score0, 0);
+  }
+
+  let periods = Math.floor(elapsed / config.decayPeriod);
+  if (periods > MAX_DECAY_PERIODS) periods = MAX_DECAY_PERIODS;
+
+  let score = score0;
+  for (let applied = 0; applied < periods && score > 0; applied += 1) {
+    score = Math.floor((score * config.decayBps) / BPS_DENOM);
+  }
+  return score;
+}
+
+/**
+ * What an indexed agent's reputation is worth right now.
+ *
+ * @param {{reputation: number, reputationUpdatedAt: number}} agent
+ * @param {number} [nowMs] - evaluation time (epoch ms), defaults to now
+ */
+function currentReputation(agent, nowMs = Date.now()) {
+  if (!agent) return 0;
+  const base = Math.trunc(Number(agent.reputation) || 0);
+  const settledAt = Number(agent.reputationUpdatedAt);
+  if (!Number.isFinite(settledAt) || settledAt <= 0) return base;
+
+  return decayScore(base, Math.floor((nowMs - settledAt) / 1000));
+}
+
+/** Attach the decayed score to an agent record without mutating the input. */
+function withCurrentReputation(agent, nowMs = Date.now()) {
+  if (!agent) return agent;
+  return {
+    ...agent,
+    reputation: currentReputation(agent, nowMs),
+    baseReputation: agent.reputation,
+    reputationUpdatedAt: agent.reputationUpdatedAt ?? null,
+  };
+}
+
+function withCurrentReputations(agents = [], nowMs = Date.now()) {
+  return agents.map((agent) => withCurrentReputation(agent, nowMs));
+}
+
+/**
+ * The decay curve between the last settlement and `nowMs`, as chart points.
+ * One point per decay period, capped at `points` samples.
+ */
+function decayCurve(agent, { nowMs = Date.now(), points = 30 } = {}) {
+  if (!agent) return [];
+
+  const base = Math.trunc(Number(agent.reputation) || 0);
+  const settledAt = Number(agent.reputationUpdatedAt) || nowMs;
+  const config = activeConfig;
+  const periodMs = config.decayPeriod * 1000;
+
+  const elapsedPeriods = Math.max(
+    0,
+    Math.min(Math.floor((nowMs - settledAt) / periodMs), MAX_DECAY_PERIODS)
+  );
+
+  const sampleCount = Math.max(2, Math.min(points, elapsedPeriods + 1));
+  const step = elapsedPeriods === 0 ? 0 : elapsedPeriods / (sampleCount - 1);
+
+  const series = [];
+  for (let i = 0; i < sampleCount; i += 1) {
+    const period = Math.round(step * i);
+    series.push({
+      timestamp: settledAt + period * periodMs,
+      score: decayScore(base, period * config.decayPeriod, config),
+    });
+  }
+  return series;
+}
+
+/** The score left after a guilty verdict slashes `slashBps` of it. */
+function applyPenalty(score, slashBps = activeConfig.slashBps) {
+  const base = Math.trunc(Number(score) || 0);
+  if (base <= 0) return 0;
+  return Math.floor((base * (BPS_DENOM - slashBps)) / BPS_DENOM);
+}
+
+/**
+ * Write an agent's decayed score back to the index and restart its clock —
+ * the off-chain counterpart of the contract's `settle_reputation`.
+ */
+async function settleAgent(agentId, { nowMs = Date.now(), client } = {}) {
+  const agent = await agentRepository.findById(agentId, client);
+  if (!agent) return null;
+
+  const settled = currentReputation(agent, nowMs);
+  return agentRepository.updateReputation(agentId, settled, client, {
+    reputationUpdatedAt: nowMs,
+  });
+}
+
+/**
+ * Apply a slashing penalty to every agent an address owns, on top of the decay
+ * accrued so far. Returns the updated agents.
+ */
+async function penalizeOwner(
+  ownerAddress,
+  { slashBps = activeConfig.slashBps, nowMs = Date.now(), client } = {}
+) {
+  const agents = await agentRepository.findByOwner(ownerAddress, client);
+  const updated = [];
+
+  for (const agent of agents) {
+    const settled = currentReputation(agent, nowMs);
+    const penalized = applyPenalty(settled, slashBps);
+    updated.push(
+      await agentRepository.updateReputation(agent.id, penalized, client, {
+        reputationUpdatedAt: nowMs,
+      })
+    );
+  }
+
+  return updated;
+}
+
+module.exports = {
+  BPS_DENOM,
+  MAX_DECAY_PERIODS,
+  DEFAULT_CONFIG,
+  getConfig,
+  setConfig,
+  decayScore,
+  currentReputation,
+  withCurrentReputation,
+  withCurrentReputations,
+  decayCurve,
+  applyPenalty,
+  settleAgent,
+  penalizeOwner,
+};

--- a/contract/Cargo.lock
+++ b/contract/Cargo.lock
@@ -79,7 +79,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "derivative",
- "digest 0.10.7",
+ "digest",
  "itertools",
  "num-bigint",
  "num-traits",
@@ -132,7 +132,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-serialize-derive",
  "ark-std",
- "digest 0.10.7",
+ "digest",
  "num-bigint",
 ]
 
@@ -194,15 +194,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -282,15 +273,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crate-git-revision"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,7 +290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -321,16 +303,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
-dependencies = [
- "hybrid-array",
- "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -350,27 +322,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "curve25519-dalek-derive",
- "digest 0.10.7",
- "fiat-crypto 0.2.9",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "curve25519-dalek-derive",
- "digest 0.11.3",
- "fiat-crypto 0.3.0",
- "rand_core 0.10.1",
+ "digest",
+ "fiat-crypto",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -509,20 +464,10 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.1.6",
+ "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.1",
- "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -544,10 +489,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
- "signature 2.2.0",
+ "signature",
 ]
 
 [[package]]
@@ -557,16 +502,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
- "signature 2.2.0",
-]
-
-[[package]]
-name = "ed25519"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
-dependencies = [
- "signature 3.0.0",
+ "signature",
 ]
 
 [[package]]
@@ -575,26 +511,11 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek 4.1.3",
- "ed25519 2.2.3",
- "rand_core 0.6.4",
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core",
  "serde",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
-dependencies = [
- "curve25519-dalek 5.0.0",
- "ed25519 3.0.0",
- "rand_core 0.10.1",
- "sha2 0.11.0",
- "signature 3.0.0",
+ "sha2",
  "subtle",
  "zeroize",
 ]
@@ -613,11 +534,11 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -647,7 +568,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -656,12 +577,6 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
-name = "fiat-crypto"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
@@ -730,7 +645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -776,16 +691,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
-dependencies = [
- "typenum",
+ "digest",
 ]
 
 [[package]]
@@ -882,7 +788,7 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -891,7 +797,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures 0.2.17",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -916,6 +822,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 name = "marketplace"
 version = "0.1.0"
 dependencies = [
+ "ed25519-dalek",
  "soroban-sdk",
 ]
 
@@ -992,7 +899,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -1077,7 +984,7 @@ checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1087,7 +994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1098,12 +1005,6 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ref-cast"
@@ -1275,19 +1176,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1296,7 +1186,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "keccak",
 ]
 
@@ -1312,17 +1202,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "signature"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
-dependencies = [
- "rand_core 0.10.1",
+ "digest",
+ "rand_core",
 ]
 
 [[package]]
@@ -1388,9 +1269,9 @@ dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-serialize",
- "curve25519-dalek 5.0.0",
+ "curve25519-dalek",
  "ecdsa",
- "ed25519-dalek 3.0.0",
+ "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
  "getrandom",
@@ -1404,7 +1285,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "sec1",
- "sha2 0.10.9",
+ "sha2",
  "sha3",
  "soroban-builtin-sdk-macros",
  "soroban-env-common",
@@ -1453,7 +1334,7 @@ dependencies = [
  "bytes-lit",
  "ctor",
  "derive_arbitrary",
- "ed25519-dalek 2.2.0",
+ "ed25519-dalek",
  "rand",
  "rustc_version",
  "serde",
@@ -1477,7 +1358,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "sha2 0.10.9",
+ "sha2",
  "soroban-env-common",
  "soroban-spec",
  "soroban-spec-rust",
@@ -1506,7 +1387,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "sha2 0.10.9",
+ "sha2",
  "soroban-spec",
  "stellar-xdr",
  "syn 2.0.119",

--- a/contract/contracts/agent_registry/src/lib.rs
+++ b/contract/contracts/agent_registry/src/lib.rs
@@ -6,12 +6,44 @@
 //! declarations, reputation scores, and wallet addresses.
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Address, Env, Map, String, Symbol, Vec,
+    contract, contractimpl, contracttype, symbol_short, token, Address, BytesN, Env, Map, String,
+    Symbol, Vec,
 };
 
 const AGENTS: Symbol = symbol_short!("AGENTS");
 const AGENT_CNT: Symbol = symbol_short!("AG_CNT");
 const REP: Symbol = symbol_short!("REP");
+/// Map<Address, StakeRecord> — collateral locked by each agent address.
+const STAKES: Symbol = symbol_short!("STAKES");
+/// Map<u64, Dispute>
+const DISPUTES: Symbol = symbol_short!("DISPUTES");
+/// u64 — monotonic dispute id counter.
+const DISP_CNT: Symbol = symbol_short!("DISP_CNT");
+/// Map<(u64, Address), bool> — one recorded vote per (dispute, voter).
+const VOTES: Symbol = symbol_short!("VOTES");
+/// Map<(Address, Address), u32> — how often two addresses have transacted.
+const INTERACT: Symbol = symbol_short!("INTERACT");
+/// Map<u64, u64> — ledger timestamp a reputation score was last settled at.
+const REP_TS: Symbol = symbol_short!("REP_TS");
+/// Map<Address, Vec<u64>> — agent ids owned by an address.
+const OWNED: Symbol = symbol_short!("OWNED");
+/// RepConfig — economic parameters.
+const CONFIG: Symbol = symbol_short!("CONFIG");
+/// Address — the account allowed to change CONFIG.
+const ADMIN: Symbol = symbol_short!("ADMIN");
+
+/// Basis-point denominator (100.00%).
+const BPS_DENOM: u32 = 10_000;
+/// Upper bound on decay iterations, so a long-dormant agent cannot make a read
+/// unboundedly expensive. Two years of daily decay already floors any score.
+const MAX_DECAY_PERIODS: u64 = 730;
+
+// Defaults applied until `configure` is called.
+const DEFAULT_SLASH_BPS: u32 = 2_000; // 20% of the stake on a guilty verdict
+const DEFAULT_VOTING_WINDOW: u64 = 259_200; // 3 days
+const DEFAULT_QUORUM_WEIGHT: i128 = 1_000;
+const DEFAULT_DECAY_BPS: u32 = 9_900; // 99% of the score survives each period
+const DEFAULT_DECAY_PERIOD: u64 = 86_400; // 1 day
 
 /// Agent capability flags
 #[contracttype]
@@ -54,6 +86,92 @@ pub struct ReputationVote {
     pub voted_at: u64,
 }
 
+/// Collateral an agent address has locked against its reputation.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct StakeRecord {
+    pub agent: Address,
+    /// Token the collateral is denominated in.
+    pub token: Address,
+    /// Currently locked amount.
+    pub amount: i128,
+    /// Cumulative amount lost to slashing.
+    pub slashed: i128,
+    pub staked_at: u64,
+}
+
+/// Lifecycle of a dispute.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DisputeStatus {
+    Open,
+    Resolved,
+}
+
+/// Verdict returned by `resolve_dispute`.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DisputeOutcome {
+    /// Voting is still open — no verdict yet.
+    Pending,
+    /// Weighted majority voted against the respondent — stake was slashed.
+    Guilty,
+    /// Weighted majority sided with the respondent.
+    NotGuilty,
+    /// Not enough voting weight took part; nothing is slashed.
+    QuorumFailed,
+}
+
+/// A dispute raised against a staked agent.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Dispute {
+    pub id: u64,
+    pub complainant: Address,
+    pub respondent: Address,
+    /// Hash of the evidence bundle held off-chain.
+    pub evidence_hash: BytesN<32>,
+    pub opened_at: u64,
+    /// Voting closes at this ledger timestamp.
+    pub closes_at: u64,
+    /// Weight voting that the respondent is at fault.
+    pub weight_for: i128,
+    /// Weight voting in the respondent's favour.
+    pub weight_against: i128,
+    pub vote_count: u32,
+    pub status: DisputeStatus,
+    pub outcome: DisputeOutcome,
+    pub slashed_amount: i128,
+}
+
+/// Economic parameters of the reputation system.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct RepConfig {
+    /// Share of the respondent's stake slashed on a guilty verdict.
+    pub slash_bps: u32,
+    /// Seconds a dispute stays open for voting.
+    pub voting_window: u64,
+    /// Minimum total weight required for a verdict to count.
+    pub quorum_weight: i128,
+    /// Share of a score that survives one decay period.
+    pub decay_bps: u32,
+    /// Length of one decay period, in seconds.
+    pub decay_period: u64,
+}
+
+impl RepConfig {
+    fn default_config() -> RepConfig {
+        RepConfig {
+            slash_bps: DEFAULT_SLASH_BPS,
+            voting_window: DEFAULT_VOTING_WINDOW,
+            quorum_weight: DEFAULT_QUORUM_WEIGHT,
+            decay_bps: DEFAULT_DECAY_BPS,
+            decay_period: DEFAULT_DECAY_PERIOD,
+        }
+    }
+}
+
 #[contract]
 pub struct AgentRegistryContract;
 
@@ -93,6 +211,18 @@ impl AgentRegistryContract {
         agents.set(agent_id, agent);
         env.storage().persistent().set(&AGENTS, &agents);
         env.storage().instance().set(&AGENT_CNT, &agent_id);
+
+        // Track ownership so a slashing verdict can reach every agent an
+        // address is accountable for, and seed the decay clock.
+        let mut owned: Map<Address, Vec<u64>> = read_map(&env, &OWNED);
+        let mut ids = owned.get(owner.clone()).unwrap_or(Vec::new(&env));
+        ids.push_back(agent_id);
+        owned.set(owner.clone(), ids);
+        env.storage().persistent().set(&OWNED, &owned);
+
+        let mut rep_ts: Map<u64, u64> = read_map(&env, &REP_TS);
+        rep_ts.set(agent_id, env.ledger().timestamp());
+        env.storage().persistent().set(&REP_TS, &rep_ts);
 
         env.events()
             .publish((Symbol::new(&env, "REGISTERED"), owner), agent_id);
@@ -137,6 +267,10 @@ impl AgentRegistryContract {
 
         let mut agent = agents.get(agent_id).unwrap();
         assert!(agent.owner != voter, "cannot vote on own agent");
+
+        // Fold elapsed decay into the stored score first, so a vote is applied
+        // to what the score is worth *now* rather than to a stale snapshot.
+        agent.reputation = settle_stored_reputation(&env, agent_id, agent.reputation);
 
         // Simple rolling average update (weight = 10% of current)
         let new_score_bp = score * 100; // convert to basis points
@@ -207,15 +341,517 @@ impl AgentRegistryContract {
         env.storage().instance().get(&AGENT_CNT).unwrap_or(0u64)
     }
 
+    /// Current reputation with time-decay applied (computed lazily on read).
     pub fn get_reputation(env: Env, agent_id: u64) -> u32 {
-        let agents: Map<u64, Agent> = env
-            .storage()
-            .persistent()
-            .get(&AGENTS)
-            .unwrap_or(Map::new(&env));
+        let agents: Map<u64, Agent> = read_map(&env, &AGENTS);
+        match agents.get(agent_id) {
+            Some(a) => decayed_reputation(&env, agent_id, a.reputation),
+            None => 0,
+        }
+    }
+
+    /// Reputation as stored, before decay is applied. Useful for reconciling
+    /// the off-chain mirror against the on-chain base score.
+    pub fn get_stored_reputation(env: Env, agent_id: u64) -> u32 {
+        let agents: Map<u64, Agent> = read_map(&env, &AGENTS);
         match agents.get(agent_id) {
             Some(a) => a.reputation,
             None => 0,
         }
     }
+
+    /// Timestamp the agent's score was last settled at (the decay clock).
+    pub fn get_reputation_updated_at(env: Env, agent_id: u64) -> u64 {
+        let rep_ts: Map<u64, u64> = read_map(&env, &REP_TS);
+        rep_ts.get(agent_id).unwrap_or(0)
+    }
+
+    /// Write the decayed score back to storage and restart the decay clock.
+    /// Anyone may call this; it can only ever lower a score to what a read
+    /// already reports.
+    pub fn settle_reputation(env: Env, agent_id: u64) -> u32 {
+        let mut agents: Map<u64, Agent> = read_map(&env, &AGENTS);
+        let mut agent = match agents.get(agent_id) {
+            Some(a) => a,
+            None => return 0,
+        };
+
+        agent.reputation = settle_stored_reputation(&env, agent_id, agent.reputation);
+        let settled = agent.reputation;
+        agents.set(agent_id, agent);
+        env.storage().persistent().set(&AGENTS, &agents);
+        settled
+    }
+
+    // ── Staking ───────────────────────────────────────────────────────────
+
+    /// Lock collateral against an agent address's reputation.
+    pub fn stake(env: Env, agent: Address, amount: i128, token: Address) {
+        agent.require_auth();
+        assert!(amount > 0, "stake amount must be positive");
+
+        let mut stakes: Map<Address, StakeRecord> = read_map(&env, &STAKES);
+        let record = match stakes.get(agent.clone()) {
+            Some(existing) => {
+                assert!(existing.token == token, "stake already held in another token");
+                StakeRecord {
+                    amount: existing.amount + amount,
+                    ..existing
+                }
+            }
+            None => StakeRecord {
+                agent: agent.clone(),
+                token: token.clone(),
+                amount,
+                slashed: 0,
+                staked_at: env.ledger().timestamp(),
+            },
+        };
+
+        token::Client::new(&env, &token).transfer(
+            &agent,
+            &env.current_contract_address(),
+            &amount,
+        );
+
+        let total = record.amount;
+        stakes.set(agent.clone(), record);
+        env.storage().persistent().set(&STAKES, &stakes);
+
+        env.events()
+            .publish((Symbol::new(&env, "STAKED"), agent), (amount, total));
+    }
+
+    /// Release collateral. Blocked while a dispute against the agent is open,
+    /// so a respondent cannot withdraw ahead of a verdict.
+    pub fn unstake(env: Env, agent: Address, amount: i128) {
+        agent.require_auth();
+        assert!(amount > 0, "unstake amount must be positive");
+        assert!(
+            !has_open_dispute(&env, &agent),
+            "cannot unstake while a dispute is open"
+        );
+
+        let mut stakes: Map<Address, StakeRecord> = read_map(&env, &STAKES);
+        let mut record = stakes.get(agent.clone()).expect("no stake for agent");
+        assert!(record.amount >= amount, "insufficient staked balance");
+
+        record.amount -= amount;
+        let token = record.token.clone();
+        let remaining = record.amount;
+        stakes.set(agent.clone(), record);
+        env.storage().persistent().set(&STAKES, &stakes);
+
+        token::Client::new(&env, &token).transfer(
+            &env.current_contract_address(),
+            &agent,
+            &amount,
+        );
+
+        env.events()
+            .publish((Symbol::new(&env, "UNSTAKED"), agent), (amount, remaining));
+    }
+
+    pub fn get_stake(env: Env, agent: Address) -> Option<StakeRecord> {
+        let stakes: Map<Address, StakeRecord> = read_map(&env, &STAKES);
+        stakes.get(agent)
+    }
+
+    // ── Interaction history (anti-brigading) ──────────────────────────────
+
+    /// Record that two addresses have transacted. Callable by either party or
+    /// by a settlement contract acting for them; a voter must have a recorded
+    /// interaction with the respondent before their vote is accepted.
+    pub fn record_interaction(env: Env, caller: Address, counterparty: Address) {
+        caller.require_auth();
+        assert!(caller != counterparty, "cannot interact with self");
+
+        let mut interactions: Map<(Address, Address), u32> = read_map(&env, &INTERACT);
+        let forward = (caller.clone(), counterparty.clone());
+        let reverse = (counterparty.clone(), caller.clone());
+
+        let count = interactions.get(forward.clone()).unwrap_or(0) + 1;
+        interactions.set(forward, count);
+        interactions.set(reverse, count);
+        env.storage().persistent().set(&INTERACT, &interactions);
+    }
+
+    pub fn interaction_count(env: Env, a: Address, b: Address) -> u32 {
+        let interactions: Map<(Address, Address), u32> = read_map(&env, &INTERACT);
+        interactions.get((a, b)).unwrap_or(0)
+    }
+
+    // ── Disputes ──────────────────────────────────────────────────────────
+
+    /// Open a dispute against a staked agent. Returns the dispute id.
+    pub fn open_dispute(
+        env: Env,
+        complainant: Address,
+        respondent: Address,
+        evidence_hash: BytesN<32>,
+    ) -> u64 {
+        complainant.require_auth();
+        assert!(complainant != respondent, "cannot dispute yourself");
+
+        let stakes: Map<Address, StakeRecord> = read_map(&env, &STAKES);
+        let stake = stakes.get(respondent.clone());
+        assert!(
+            stake.map(|s| s.amount).unwrap_or(0) > 0,
+            "respondent has no stake to slash"
+        );
+        assert!(
+            !has_open_dispute(&env, &respondent),
+            "a dispute against this agent is already open"
+        );
+
+        let config = load_config(&env);
+        let now = env.ledger().timestamp();
+        let dispute_id: u64 = env.storage().instance().get(&DISP_CNT).unwrap_or(0) + 1;
+
+        let closes_at = now + config.voting_window;
+        let dispute = Dispute {
+            id: dispute_id,
+            complainant: complainant.clone(),
+            respondent: respondent.clone(),
+            evidence_hash,
+            opened_at: now,
+            closes_at,
+            weight_for: 0,
+            weight_against: 0,
+            vote_count: 0,
+            status: DisputeStatus::Open,
+            outcome: DisputeOutcome::Pending,
+            slashed_amount: 0,
+        };
+
+        let mut disputes: Map<u64, Dispute> = read_map(&env, &DISPUTES);
+        disputes.set(dispute_id, dispute);
+        env.storage().persistent().set(&DISPUTES, &disputes);
+        env.storage().instance().set(&DISP_CNT, &dispute_id);
+
+        env.events().publish(
+            (
+                Symbol::new(&env, "DISPUTE_OPENED"),
+                complainant,
+                respondent,
+            ),
+            (dispute_id, closes_at),
+        );
+
+        dispute_id
+    }
+
+    /// Vote on an open dispute. Weight is the voter's staked amount scaled by
+    /// their own reputation, and a voter must have transacted with the
+    /// respondent before — throwaway accounts carry no weight and are rejected.
+    pub fn vote_dispute(env: Env, voter: Address, dispute_id: u64, in_favor: bool) {
+        voter.require_auth();
+
+        let mut disputes: Map<u64, Dispute> = read_map(&env, &DISPUTES);
+        let mut dispute = disputes.get(dispute_id).expect("unknown dispute");
+        assert!(dispute.status == DisputeStatus::Open, "dispute is resolved");
+        assert!(
+            env.ledger().timestamp() < dispute.closes_at,
+            "voting window has closed"
+        );
+        assert!(voter != dispute.respondent, "respondent cannot vote");
+
+        let mut votes: Map<(u64, Address), bool> = read_map(&env, &VOTES);
+        assert!(
+            votes.get((dispute_id, voter.clone())).is_none(),
+            "voter has already voted"
+        );
+
+        let interactions: Map<(Address, Address), u32> = read_map(&env, &INTERACT);
+        assert!(
+            interactions
+                .get((voter.clone(), dispute.respondent.clone()))
+                .unwrap_or(0)
+                > 0,
+            "voter has no interaction history with the respondent"
+        );
+
+        let weight = voting_weight(&env, &voter);
+        assert!(weight > 0, "voter has no stake-weighted voting power");
+
+        if in_favor {
+            dispute.weight_for += weight;
+        } else {
+            dispute.weight_against += weight;
+        }
+        dispute.vote_count += 1;
+
+        disputes.set(dispute_id, dispute);
+        env.storage().persistent().set(&DISPUTES, &disputes);
+
+        votes.set((dispute_id, voter.clone()), in_favor);
+        env.storage().persistent().set(&VOTES, &votes);
+
+        env.events().publish(
+            (Symbol::new(&env, "DISPUTE_VOTED"), voter),
+            (dispute_id, weight, in_favor),
+        );
+    }
+
+    /// Tally an expired dispute. On a guilty verdict the respondent's stake is
+    /// slashed by the configured percentage and every agent they own takes the
+    /// same proportional reputation hit.
+    pub fn resolve_dispute(env: Env, dispute_id: u64) -> DisputeOutcome {
+        let mut disputes: Map<u64, Dispute> = read_map(&env, &DISPUTES);
+        let mut dispute = disputes.get(dispute_id).expect("unknown dispute");
+        assert!(dispute.status == DisputeStatus::Open, "dispute is resolved");
+        assert!(
+            env.ledger().timestamp() >= dispute.closes_at,
+            "voting window is still open"
+        );
+
+        let config = load_config(&env);
+        let total_weight = dispute.weight_for + dispute.weight_against;
+
+        let outcome = if total_weight < config.quorum_weight {
+            DisputeOutcome::QuorumFailed
+        } else if dispute.weight_for > dispute.weight_against {
+            DisputeOutcome::Guilty
+        } else {
+            DisputeOutcome::NotGuilty
+        };
+
+        if outcome == DisputeOutcome::Guilty {
+            let slashed = slash_stake(&env, &dispute.respondent, config.slash_bps);
+            dispute.slashed_amount = slashed;
+            penalize_owner_reputation(&env, &dispute.respondent, config.slash_bps);
+
+            env.events().publish(
+                (Symbol::new(&env, "STAKE_SLASHED"), dispute.respondent.clone()),
+                (dispute_id, slashed),
+            );
+        }
+
+        dispute.status = DisputeStatus::Resolved;
+        dispute.outcome = outcome.clone();
+        let respondent = dispute.respondent.clone();
+        let slashed_amount = dispute.slashed_amount;
+        disputes.set(dispute_id, dispute);
+        env.storage().persistent().set(&DISPUTES, &disputes);
+
+        env.events().publish(
+            (Symbol::new(&env, "DISPUTE_RESOLVED"), respondent),
+            (dispute_id, outcome.clone(), slashed_amount),
+        );
+
+        outcome
+    }
+
+    pub fn get_dispute(env: Env, dispute_id: u64) -> Option<Dispute> {
+        let disputes: Map<u64, Dispute> = read_map(&env, &DISPUTES);
+        disputes.get(dispute_id)
+    }
+
+    pub fn dispute_count(env: Env) -> u64 {
+        env.storage().instance().get(&DISP_CNT).unwrap_or(0)
+    }
+
+    pub fn get_vote(env: Env, dispute_id: u64, voter: Address) -> Option<bool> {
+        let votes: Map<(u64, Address), bool> = read_map(&env, &VOTES);
+        votes.get((dispute_id, voter))
+    }
+
+    /// Weight `voter` would carry in a dispute right now.
+    pub fn get_voting_weight(env: Env, voter: Address) -> i128 {
+        voting_weight(&env, &voter)
+    }
+
+    // ── Configuration ─────────────────────────────────────────────────────
+
+    /// Set the economic parameters. The first caller claims the admin role;
+    /// afterwards only that address may change them.
+    pub fn configure(env: Env, admin: Address, config: RepConfig) {
+        admin.require_auth();
+        assert!(config.slash_bps <= BPS_DENOM, "slash_bps out of range");
+        assert!(config.decay_bps <= BPS_DENOM, "decay_bps out of range");
+        assert!(config.quorum_weight >= 0, "quorum_weight must not be negative");
+
+        let stored: Option<Address> = env.storage().instance().get(&ADMIN);
+        match stored {
+            Some(existing) => assert!(existing == admin, "not the registry admin"),
+            None => env.storage().instance().set(&ADMIN, &admin),
+        }
+
+        env.storage().instance().set(&CONFIG, &config);
+    }
+
+    pub fn get_config(env: Env) -> RepConfig {
+        load_config(&env)
+    }
 }
+
+// ── Internal helpers ──────────────────────────────────────────────────────
+
+fn read_map<K, V>(env: &Env, key: &Symbol) -> Map<K, V>
+where
+    K: soroban_sdk::TryFromVal<Env, soroban_sdk::Val> + soroban_sdk::IntoVal<Env, soroban_sdk::Val>,
+    V: soroban_sdk::TryFromVal<Env, soroban_sdk::Val> + soroban_sdk::IntoVal<Env, soroban_sdk::Val>,
+{
+    env.storage()
+        .persistent()
+        .get(key)
+        .unwrap_or(Map::new(env))
+}
+
+fn load_config(env: &Env) -> RepConfig {
+    env.storage()
+        .instance()
+        .get(&CONFIG)
+        .unwrap_or(RepConfig::default_config())
+}
+
+/// `score * (decay_bps / 10_000) ^ periods`, in integer arithmetic.
+///
+/// The exponential is applied one period at a time (truncating at each step)
+/// rather than in closed form: the off-chain mirror in
+/// `backend/src/services/reputationEngine.js` runs the identical loop, so both
+/// sides agree exactly instead of only to within a floating-point tolerance.
+fn decay_score(base: u32, elapsed: u64, config: &RepConfig) -> u32 {
+    if config.decay_period == 0 || config.decay_bps >= BPS_DENOM || base == 0 {
+        return base;
+    }
+
+    let mut periods = elapsed / config.decay_period;
+    if periods > MAX_DECAY_PERIODS {
+        periods = MAX_DECAY_PERIODS;
+    }
+
+    let mut score = base as u64;
+    let mut applied = 0u64;
+    while applied < periods && score > 0 {
+        score = score * config.decay_bps as u64 / BPS_DENOM as u64;
+        applied += 1;
+    }
+
+    score as u32
+}
+
+/// Reputation of `agent_id` with decay applied, without writing anything.
+fn decayed_reputation(env: &Env, agent_id: u64, base: u32) -> u32 {
+    let rep_ts: Map<u64, u64> = read_map(env, &REP_TS);
+    let last = match rep_ts.get(agent_id) {
+        Some(ts) => ts,
+        None => return base,
+    };
+
+    let now = env.ledger().timestamp();
+    if now <= last {
+        return base;
+    }
+
+    decay_score(base, now - last, &load_config(env))
+}
+
+/// Decay `base`, persist the new decay clock, and return the settled score.
+/// The caller is responsible for storing the returned score on the agent.
+fn settle_stored_reputation(env: &Env, agent_id: u64, base: u32) -> u32 {
+    let settled = decayed_reputation(env, agent_id, base);
+
+    let mut rep_ts: Map<u64, u64> = read_map(env, &REP_TS);
+    rep_ts.set(agent_id, env.ledger().timestamp());
+    env.storage().persistent().set(&REP_TS, &rep_ts);
+
+    settled
+}
+
+/// True while any dispute naming `agent` as respondent is still open.
+fn has_open_dispute(env: &Env, agent: &Address) -> bool {
+    let disputes: Map<u64, Dispute> = read_map(env, &DISPUTES);
+    for (_, dispute) in disputes.iter() {
+        if dispute.respondent == *agent && dispute.status == DisputeStatus::Open {
+            return true;
+        }
+    }
+    false
+}
+
+/// Voting weight: staked collateral scaled by the voter's own reputation.
+fn voting_weight(env: &Env, voter: &Address) -> i128 {
+    let stakes: Map<Address, StakeRecord> = read_map(env, &STAKES);
+    let staked = match stakes.get(voter.clone()) {
+        Some(record) => record.amount,
+        None => return 0,
+    };
+    if staked <= 0 {
+        return 0;
+    }
+
+    staked * best_reputation(env, voter) as i128 / BPS_DENOM as i128
+}
+
+/// Highest current (decayed) reputation among the agents an address owns.
+/// Addresses that own no agent vote at the neutral starting score.
+fn best_reputation(env: &Env, owner: &Address) -> u32 {
+    let agents: Map<u64, Agent> = read_map(env, &AGENTS);
+    let owned: Map<Address, Vec<u64>> = read_map(env, &OWNED);
+
+    let ids = match owned.get(owner.clone()) {
+        Some(ids) => ids,
+        None => return 5_000,
+    };
+
+    let mut best = 0u32;
+    for agent_id in ids.iter() {
+        if let Some(agent) = agents.get(agent_id) {
+            let current = decayed_reputation(env, agent_id, agent.reputation);
+            if current > best {
+                best = current;
+            }
+        }
+    }
+
+    if best == 0 {
+        5_000
+    } else {
+        best
+    }
+}
+
+/// Take `slash_bps` of an address's stake. Returns the amount removed.
+fn slash_stake(env: &Env, agent: &Address, slash_bps: u32) -> i128 {
+    let mut stakes: Map<Address, StakeRecord> = read_map(env, &STAKES);
+    let mut record = match stakes.get(agent.clone()) {
+        Some(record) => record,
+        None => return 0,
+    };
+
+    let slashed = record.amount * slash_bps as i128 / BPS_DENOM as i128;
+    if slashed <= 0 {
+        return 0;
+    }
+
+    record.amount -= slashed;
+    record.slashed += slashed;
+    stakes.set(agent.clone(), record);
+    env.storage().persistent().set(&STAKES, &stakes);
+
+    slashed
+}
+
+/// Apply the same proportional hit to every agent the address owns.
+fn penalize_owner_reputation(env: &Env, owner: &Address, slash_bps: u32) {
+    let owned: Map<Address, Vec<u64>> = read_map(env, &OWNED);
+    let ids = match owned.get(owner.clone()) {
+        Some(ids) => ids,
+        None => return,
+    };
+
+    let mut agents: Map<u64, Agent> = read_map(env, &AGENTS);
+    for agent_id in ids.iter() {
+        if let Some(mut agent) = agents.get(agent_id) {
+            let settled = settle_stored_reputation(env, agent_id, agent.reputation);
+            agent.reputation = settled * (BPS_DENOM - slash_bps) / BPS_DENOM;
+            agents.set(agent_id, agent);
+        }
+    }
+
+    env.storage().persistent().set(&AGENTS, &agents);
+}
+
+#[cfg(test)]
+mod test;

--- a/contract/contracts/agent_registry/src/test.rs
+++ b/contract/contracts/agent_registry/src/test.rs
@@ -1,7 +1,10 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::{testutils::Address as _, vec, Address, Env, String};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    token, vec, Address, BytesN, Env, String,
+};
 
 fn setup() -> (Env, Address) {
     let env = Env::default();
@@ -66,14 +69,16 @@ fn test_multiple_voters_converge() {
     );
 
     // 10 different voters each vote 70 → reputation converges toward 7000
-    for i in 1..=10 {
+    for _ in 1..=10 {
         let voter = Address::generate(&env);
         client.vote_reputation(&voter, &1, &70);
         // After first vote: 5300, second: 5270, etc. converging to 7000
     }
-    // After multiple votes from different voters, should be close to 7000
+    // The rolling average approaches 7000 asymptotically: after ten votes it
+    // has covered 1 - 0.9^10 ≈ 65% of the distance from 5000 to 7000.
     let rep = client.get_reputation(&1);
-    assert!(rep >= 6_900 && rep <= 7_100, "reputation should converge to ~7000");
+    assert_eq!(rep, 6_300);
+    assert!(rep < 7_000, "reputation approaches 7000 from below");
 }
 
 #[test]
@@ -95,9 +100,10 @@ fn test_zero_vote_drives_down() {
         client.vote_reputation(&voter, &1, &0);
     }
 
+    // 5000 → 4500 → 4050 → 3645 → 3280 → 2952
     let rep = client.get_reputation(&1);
     assert!(rep < 5_000, "reputation should decrease with 0 votes");
-    assert!(rep >= 4_000 && rep <= 4_500, "after five 0-votes, rep should be ~4500");
+    assert_eq!(rep, 2_952);
 }
 
 #[test]
@@ -120,8 +126,9 @@ fn test_hundred_vote_drives_up() {
     }
 
     let rep = client.get_reputation(&1);
+    // 5000 → 5500 → 5950 → 6355 → 6719 → 7047
     assert!(rep > 5_000, "reputation should increase with 100 votes");
-    assert!(rep >= 9_000 && rep <= 9_500, "after five 100-votes, rep should be ~9500");
+    assert_eq!(rep, 7_047);
 }
 
 #[test]
@@ -137,10 +144,8 @@ fn test_owner_cannot_vote_own_agent() {
         &vec![&env, Capability::CodeGeneration],
     );
 
-    // Owner attempting to vote on their own agent should panic
-    let result = std::panic::catch_unwind(|| {
-        client.vote_reputation(&owner, &1, &50);
-    });
+    // Owner attempting to vote on their own agent is rejected
+    let result = client.try_vote_reputation(&owner, &1, &50);
     assert!(result.is_err(), "owner should not be able to vote on own agent");
 }
 
@@ -158,15 +163,11 @@ fn test_score_over_100_rejected() {
         &vec![&env, Capability::WebResearch],
     );
 
-    // Score > 100 should be rejected with panic from assertion
-    let result = std::panic::catch_unwind(|| {
-        client.vote_reputation(&voter, &1, &101);
-    });
+    // Score > 100 is rejected by the contract's range assertion
+    let result = client.try_vote_reputation(&voter, &1, &101);
     assert!(result.is_err(), "score > 100 should be rejected");
-    
-    let result2 = std::panic::catch_unwind(|| {
-        client.vote_reputation(&voter, &1, &200);
-    });
+
+    let result2 = client.try_vote_reputation(&voter, &1, &200);
     assert!(result2.is_err(), "score >> 100 should be rejected");
 }
 
@@ -241,3 +242,627 @@ fn test_deactivate_agent() {
 }
 
 // Coverage: register -> update capabilities -> deactivate lifecycle
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Staking, disputes, slashing and reputation decay
+// ─────────────────────────────────────────────────────────────────────────────
+
+const DAY: u64 = 86_400;
+
+struct Fixture {
+    env: Env,
+    client_id: Address,
+    token: Address,
+}
+
+fn stake_fixture() -> Fixture {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client_id = env.register(AgentRegistryContract, ());
+
+    let token_admin = Address::generate(&env);
+    let sac = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token = sac.address();
+
+    Fixture {
+        env,
+        client_id,
+        token,
+    }
+}
+
+impl Fixture {
+    fn client(&self) -> AgentRegistryContractClient<'_> {
+        AgentRegistryContractClient::new(&self.env, &self.client_id)
+    }
+
+    /// A funded address holding `amount` of the fixture token.
+    fn funded_address(&self, amount: i128) -> Address {
+        let holder = Address::generate(&self.env);
+        token::StellarAssetClient::new(&self.env, &self.token).mint(&holder, &amount);
+        holder
+    }
+
+    /// A funded address that owns a registered agent and has staked `stake`.
+    fn staked_agent(&self, name: &str, stake: i128) -> (Address, u64) {
+        let owner = self.funded_address(stake * 2);
+        let client = self.client();
+        let agent_id = client.register_agent(
+            &owner,
+            &String::from_str(&self.env, name),
+            &String::from_str(&self.env, "fixture agent"),
+            &vec![&self.env, Capability::Reasoning],
+        );
+        client.stake(&owner, &stake, &self.token);
+        (owner, agent_id)
+    }
+
+    fn balance(&self, who: &Address) -> i128 {
+        token::Client::new(&self.env, &self.token).balance(who)
+    }
+
+    fn advance(&self, seconds: u64) {
+        let now = self.env.ledger().timestamp();
+        self.env.ledger().with_mut(|li| li.timestamp = now + seconds);
+    }
+
+    fn evidence(&self) -> BytesN<32> {
+        BytesN::from_array(&self.env, &[7u8; 32])
+    }
+}
+
+// ── Staking ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_stake_locks_collateral() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let agent = fx.funded_address(1_000);
+
+    client.stake(&agent, &400, &fx.token);
+
+    let record = client.get_stake(&agent).unwrap();
+    assert_eq!(record.amount, 400);
+    assert_eq!(record.slashed, 0);
+    assert_eq!(record.token, fx.token);
+    assert_eq!(fx.balance(&agent), 600);
+    assert_eq!(fx.balance(&fx.client_id), 400);
+}
+
+#[test]
+fn test_stake_accumulates() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let agent = fx.funded_address(1_000);
+
+    client.stake(&agent, &300, &fx.token);
+    client.stake(&agent, &250, &fx.token);
+
+    assert_eq!(client.get_stake(&agent).unwrap().amount, 550);
+}
+
+#[test]
+fn test_stake_rejects_non_positive_amount() {
+    let fx = stake_fixture();
+    let agent = fx.funded_address(1_000);
+
+    assert!(fx.client().try_stake(&agent, &0, &fx.token).is_err());
+}
+
+#[test]
+fn test_unstake_returns_collateral() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let agent = fx.funded_address(1_000);
+
+    client.stake(&agent, &600, &fx.token);
+    client.unstake(&agent, &200);
+
+    assert_eq!(client.get_stake(&agent).unwrap().amount, 400);
+    assert_eq!(fx.balance(&agent), 600);
+}
+
+#[test]
+fn test_unstake_rejects_more_than_staked() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let agent = fx.funded_address(1_000);
+
+    client.stake(&agent, &100, &fx.token);
+    assert!(client.try_unstake(&agent, &150).is_err());
+}
+
+#[test]
+fn test_unstake_blocked_while_dispute_is_open() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let (respondent, _) = fx.staked_agent("Respondent", 1_000);
+    let complainant = fx.funded_address(100);
+
+    client.open_dispute(&complainant, &respondent, &fx.evidence());
+
+    assert!(client.try_unstake(&respondent, &100).is_err());
+}
+
+// ── Interaction history ──────────────────────────────────────────────────────
+
+#[test]
+fn test_record_interaction_is_symmetric() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let a = Address::generate(&fx.env);
+    let b = Address::generate(&fx.env);
+
+    client.record_interaction(&a, &b);
+    client.record_interaction(&a, &b);
+
+    assert_eq!(client.interaction_count(&a, &b), 2);
+    assert_eq!(client.interaction_count(&b, &a), 2);
+}
+
+#[test]
+fn test_record_interaction_rejects_self() {
+    let fx = stake_fixture();
+    let a = Address::generate(&fx.env);
+
+    assert!(fx.client().try_record_interaction(&a, &a).is_err());
+}
+
+// ── Opening disputes ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_open_dispute_creates_record_with_voting_window() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let (respondent, _) = fx.staked_agent("Respondent", 1_000);
+    let complainant = fx.funded_address(100);
+
+    let dispute_id = client.open_dispute(&complainant, &respondent, &fx.evidence());
+    let dispute = client.get_dispute(&dispute_id).unwrap();
+
+    assert_eq!(dispute_id, 1);
+    assert_eq!(client.dispute_count(), 1);
+    assert_eq!(dispute.respondent, respondent);
+    assert_eq!(dispute.status, DisputeStatus::Open);
+    assert_eq!(dispute.outcome, DisputeOutcome::Pending);
+    assert_eq!(dispute.closes_at, dispute.opened_at + client.get_config().voting_window);
+}
+
+#[test]
+fn test_open_dispute_requires_a_stake_to_slash() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let respondent = fx.funded_address(500); // funded but never staked
+    let complainant = fx.funded_address(100);
+
+    assert!(client
+        .try_open_dispute(&complainant, &respondent, &fx.evidence())
+        .is_err());
+}
+
+#[test]
+fn test_open_dispute_rejects_self_dispute() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let (respondent, _) = fx.staked_agent("Respondent", 1_000);
+
+    assert!(client
+        .try_open_dispute(&respondent, &respondent, &fx.evidence())
+        .is_err());
+}
+
+#[test]
+fn test_open_dispute_rejects_a_second_open_dispute() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let (respondent, _) = fx.staked_agent("Respondent", 1_000);
+    let complainant = fx.funded_address(100);
+
+    client.open_dispute(&complainant, &respondent, &fx.evidence());
+
+    assert!(client
+        .try_open_dispute(&complainant, &respondent, &fx.evidence())
+        .is_err());
+}
+
+// ── Voting ───────────────────────────────────────────────────────────────────
+
+/// Registers a voter that has staked and transacted with `respondent`.
+fn eligible_voter(fx: &Fixture, respondent: &Address, stake: i128, name: &str) -> Address {
+    let (voter, _) = fx.staked_agent(name, stake);
+    fx.client().record_interaction(&voter, respondent);
+    voter
+}
+
+#[test]
+fn test_vote_dispute_records_weighted_vote() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let (respondent, _) = fx.staked_agent("Respondent", 1_000);
+    let complainant = fx.funded_address(100);
+    let voter = eligible_voter(&fx, &respondent, 2_000, "Voter");
+
+    let dispute_id = client.open_dispute(&complainant, &respondent, &fx.evidence());
+    client.vote_dispute(&voter, &dispute_id, &true);
+
+    let dispute = client.get_dispute(&dispute_id).unwrap();
+    // weight = stake 2000 × reputation 5000bp / 10000 = 1000
+    assert_eq!(dispute.weight_for, 1_000);
+    assert_eq!(dispute.weight_against, 0);
+    assert_eq!(dispute.vote_count, 1);
+    assert_eq!(client.get_vote(&dispute_id, &voter), Some(true));
+}
+
+#[test]
+fn test_vote_weight_scales_with_stake_and_reputation() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let (voter, voter_agent) = fx.staked_agent("Voter", 2_000);
+
+    assert_eq!(client.get_voting_weight(&voter), 1_000);
+
+    // Five 100-votes raise the voter's own reputation to 7047bp.
+    for _ in 0..5 {
+        let rater = Address::generate(&fx.env);
+        client.vote_reputation(&rater, &voter_agent, &100);
+    }
+
+    assert_eq!(client.get_reputation(&voter_agent), 7_047);
+    assert_eq!(client.get_voting_weight(&voter), 2_000 * 7_047 / 10_000);
+}
+
+#[test]
+fn test_vote_dispute_rejects_voter_without_interaction_history() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let (respondent, _) = fx.staked_agent("Respondent", 1_000);
+    let complainant = fx.funded_address(100);
+    // Staked, but never transacted with the respondent — a brigading account.
+
+    let (brigader, _) = fx.staked_agent("Brigader", 5_000);
+
+    let dispute_id = client.open_dispute(&complainant, &respondent, &fx.evidence());
+
+    assert!(client.try_vote_dispute(&brigader, &dispute_id, &true).is_err());
+    assert_eq!(client.get_dispute(&dispute_id).unwrap().weight_for, 0);
+}
+
+#[test]
+fn test_vote_dispute_rejects_voter_without_stake() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let (respondent, _) = fx.staked_agent("Respondent", 1_000);
+    let complainant = fx.funded_address(100);
+
+    // Throwaway account: it has an interaction record but no collateral, so it
+    // carries no weight and cannot vote.
+    let throwaway = Address::generate(&fx.env);
+    client.record_interaction(&throwaway, &respondent);
+
+    let dispute_id = client.open_dispute(&complainant, &respondent, &fx.evidence());
+
+    assert_eq!(client.get_voting_weight(&throwaway), 0);
+    assert!(client.try_vote_dispute(&throwaway, &dispute_id, &true).is_err());
+}
+
+#[test]
+fn test_vote_dispute_rejects_double_voting() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let (respondent, _) = fx.staked_agent("Respondent", 1_000);
+    let complainant = fx.funded_address(100);
+    let voter = eligible_voter(&fx, &respondent, 2_000, "Voter");
+
+    let dispute_id = client.open_dispute(&complainant, &respondent, &fx.evidence());
+    client.vote_dispute(&voter, &dispute_id, &true);
+
+    assert!(client.try_vote_dispute(&voter, &dispute_id, &false).is_err());
+    assert_eq!(client.get_dispute(&dispute_id).unwrap().vote_count, 1);
+}
+
+#[test]
+fn test_vote_dispute_rejects_the_respondent() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let (respondent, _) = fx.staked_agent("Respondent", 1_000);
+    let complainant = fx.funded_address(100);
+    client.record_interaction(&respondent, &complainant);
+
+    let dispute_id = client.open_dispute(&complainant, &respondent, &fx.evidence());
+
+    assert!(client
+        .try_vote_dispute(&respondent, &dispute_id, &false)
+        .is_err());
+}
+
+#[test]
+fn test_vote_dispute_rejects_votes_after_the_window_closes() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let (respondent, _) = fx.staked_agent("Respondent", 1_000);
+    let complainant = fx.funded_address(100);
+    let voter = eligible_voter(&fx, &respondent, 2_000, "Voter");
+
+    let dispute_id = client.open_dispute(&complainant, &respondent, &fx.evidence());
+    fx.advance(client.get_config().voting_window + 1);
+
+    assert!(client.try_vote_dispute(&voter, &dispute_id, &true).is_err());
+}
+
+// ── Resolution and slashing ──────────────────────────────────────────────────
+
+#[test]
+fn test_resolve_dispute_rejected_before_the_window_closes() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let (respondent, _) = fx.staked_agent("Respondent", 1_000);
+    let complainant = fx.funded_address(100);
+
+    let dispute_id = client.open_dispute(&complainant, &respondent, &fx.evidence());
+
+    assert!(client.try_resolve_dispute(&dispute_id).is_err());
+}
+
+#[test]
+fn test_resolve_guilty_slashes_stake_and_reputation() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let (respondent, respondent_agent) = fx.staked_agent("Respondent", 10_000);
+    let complainant = fx.funded_address(100);
+    let voter = eligible_voter(&fx, &respondent, 10_000, "Voter");
+
+    let dispute_id = client.open_dispute(&complainant, &respondent, &fx.evidence());
+    client.vote_dispute(&voter, &dispute_id, &true);
+    fx.advance(client.get_config().voting_window + 1);
+
+    // Reputation as it stands when the verdict lands (the open window itself
+    // has decayed it), so the assertion isolates the slashing penalty.
+    let before = client.get_reputation(&respondent_agent);
+    let outcome = client.resolve_dispute(&dispute_id);
+
+    assert_eq!(outcome, DisputeOutcome::Guilty);
+    // 20% of a 10 000 stake
+    let stake = client.get_stake(&respondent).unwrap();
+    assert_eq!(stake.amount, 8_000);
+    assert_eq!(stake.slashed, 2_000);
+    // The same 20% comes off every agent the respondent owns
+    assert_eq!(client.get_reputation(&respondent_agent), before * 8 / 10);
+
+    let dispute = client.get_dispute(&dispute_id).unwrap();
+    assert_eq!(dispute.status, DisputeStatus::Resolved);
+    assert_eq!(dispute.outcome, DisputeOutcome::Guilty);
+    assert_eq!(dispute.slashed_amount, 2_000);
+}
+
+#[test]
+fn test_resolve_not_guilty_leaves_the_stake_intact() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let (respondent, respondent_agent) = fx.staked_agent("Respondent", 10_000);
+    let complainant = fx.funded_address(100);
+    let defender = eligible_voter(&fx, &respondent, 10_000, "Defender");
+
+    let dispute_id = client.open_dispute(&complainant, &respondent, &fx.evidence());
+    client.vote_dispute(&defender, &dispute_id, &false);
+    fx.advance(client.get_config().voting_window + 1);
+
+    let before = client.get_reputation(&respondent_agent);
+    assert_eq!(client.resolve_dispute(&dispute_id), DisputeOutcome::NotGuilty);
+    assert_eq!(client.get_stake(&respondent).unwrap().amount, 10_000);
+    assert_eq!(client.get_reputation(&respondent_agent), before);
+}
+
+#[test]
+fn test_resolve_without_quorum_slashes_nothing() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let (respondent, _) = fx.staked_agent("Respondent", 10_000);
+    let complainant = fx.funded_address(100);
+    // Weight 1000 × 5000bp / 10000 = 500, below the 1000 quorum.
+    let voter = eligible_voter(&fx, &respondent, 1_000, "SmallVoter");
+
+    let dispute_id = client.open_dispute(&complainant, &respondent, &fx.evidence());
+    client.vote_dispute(&voter, &dispute_id, &true);
+    fx.advance(client.get_config().voting_window + 1);
+
+    assert_eq!(
+        client.resolve_dispute(&dispute_id),
+        DisputeOutcome::QuorumFailed
+    );
+    assert_eq!(client.get_stake(&respondent).unwrap().amount, 10_000);
+}
+
+#[test]
+fn test_resolve_rejects_a_second_resolution() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let (respondent, _) = fx.staked_agent("Respondent", 10_000);
+    let complainant = fx.funded_address(100);
+
+    let dispute_id = client.open_dispute(&complainant, &respondent, &fx.evidence());
+    fx.advance(client.get_config().voting_window + 1);
+    client.resolve_dispute(&dispute_id);
+
+    assert!(client.try_resolve_dispute(&dispute_id).is_err());
+}
+
+// ── Time decay ───────────────────────────────────────────────────────────────
+
+#[test]
+fn test_reputation_decays_with_ledger_time() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let (_, agent_id) = fx.staked_agent("Decayer", 1_000);
+
+    assert_eq!(client.get_reputation(&agent_id), 5_000);
+
+    // One period: 5000 × 0.99
+    fx.advance(DAY);
+    assert_eq!(client.get_reputation(&agent_id), 4_950);
+
+    // Ten periods total: 5000 × 0.99 applied ten times, truncating each period
+    fx.advance(DAY * 9);
+    assert_eq!(client.get_reputation(&agent_id), 4_517);
+}
+
+#[test]
+fn test_decay_only_applies_on_whole_periods() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let (_, agent_id) = fx.staked_agent("Decayer", 1_000);
+
+    fx.advance(DAY - 1);
+    assert_eq!(client.get_reputation(&agent_id), 5_000);
+}
+
+#[test]
+fn test_settle_reputation_persists_the_decayed_score() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let (_, agent_id) = fx.staked_agent("Decayer", 1_000);
+
+    fx.advance(DAY * 5);
+    let settled = client.settle_reputation(&agent_id);
+
+    assert_eq!(settled, client.get_reputation(&agent_id));
+    assert_eq!(client.get_stored_reputation(&agent_id), settled);
+    assert_eq!(client.get_reputation_updated_at(&agent_id), DAY * 5);
+}
+
+#[test]
+fn test_vote_is_applied_to_the_decayed_score() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let (_, agent_id) = fx.staked_agent("Decayer", 1_000);
+    let rater = Address::generate(&fx.env);
+
+    fx.advance(DAY * 10); // 5000 → 4517
+    assert_eq!(client.get_reputation(&agent_id), 4_517);
+    client.vote_reputation(&rater, &agent_id, &100);
+
+    // (4517 × 9 + 10000) / 10 — the vote lands on the decayed score, not on 5000
+    assert_eq!(client.get_reputation(&agent_id), 5_065);
+}
+
+#[test]
+fn test_decay_is_bounded_for_dormant_agents() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let (_, agent_id) = fx.staked_agent("Dormant", 1_000);
+
+    fx.advance(DAY * 730);
+    let two_years = client.get_reputation(&agent_id);
+
+    fx.advance(DAY * 3_650);
+    assert_eq!(
+        client.get_reputation(&agent_id),
+        two_years,
+        "decay saturates at the iteration bound"
+    );
+}
+
+// ── Configuration ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_configure_sets_parameters_and_locks_the_admin() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let admin = Address::generate(&fx.env);
+    let intruder = Address::generate(&fx.env);
+
+    let config = RepConfig {
+        slash_bps: 5_000,
+        voting_window: DAY,
+        quorum_weight: 10,
+        decay_bps: 9_000,
+        decay_period: DAY,
+    };
+    client.configure(&admin, &config);
+
+    assert_eq!(client.get_config().slash_bps, 5_000);
+    assert_eq!(client.get_config().voting_window, DAY);
+    assert!(client.try_configure(&intruder, &config).is_err());
+}
+
+#[test]
+fn test_configured_slash_percentage_is_applied() {
+    let fx = stake_fixture();
+    let client = fx.client();
+    let admin = Address::generate(&fx.env);
+    client.configure(
+        &admin,
+        &RepConfig {
+            slash_bps: 5_000,
+            voting_window: DAY,
+            quorum_weight: 10,
+            decay_bps: 9_900,
+            decay_period: DAY,
+        },
+    );
+
+    let (respondent, _) = fx.staked_agent("Respondent", 10_000);
+    let complainant = fx.funded_address(100);
+    let voter = eligible_voter(&fx, &respondent, 10_000, "Voter");
+
+    let dispute_id = client.open_dispute(&complainant, &respondent, &fx.evidence());
+    client.vote_dispute(&voter, &dispute_id, &true);
+    fx.advance(DAY + 1);
+
+    assert_eq!(client.resolve_dispute(&dispute_id), DisputeOutcome::Guilty);
+    assert_eq!(client.get_stake(&respondent).unwrap().amount, 5_000);
+}
+
+// ── End-to-end ───────────────────────────────────────────────────────────────
+
+#[test]
+fn test_end_to_end_stake_dispute_slash_flow() {
+    let fx = stake_fixture();
+    let client = fx.client();
+
+    // Agent A stakes and builds a reputation.
+    let (agent_a, agent_a_id) = fx.staked_agent("Agent A", 10_000);
+    for _ in 0..5 {
+        let rater = Address::generate(&fx.env);
+        client.vote_reputation(&rater, &agent_a_id, &100);
+    }
+    assert_eq!(client.get_reputation(&agent_a_id), 7_047);
+
+    // Agent B, who has transacted with A, disputes it.
+    let (agent_b, _) = fx.staked_agent("Agent B", 5_000);
+    client.record_interaction(&agent_b, &agent_a);
+
+    let dispute_id = client.open_dispute(&agent_b, &agent_a, &fx.evidence());
+
+    // Third parties who have dealt with A weigh in.
+    let third_party = eligible_voter(&fx, &agent_a, 8_000, "Third Party");
+    let defender = eligible_voter(&fx, &agent_a, 2_000, "Defender");
+    client.vote_dispute(&agent_b, &dispute_id, &true);
+    client.vote_dispute(&third_party, &dispute_id, &true);
+    client.vote_dispute(&defender, &dispute_id, &false);
+
+    let dispute = client.get_dispute(&dispute_id).unwrap();
+    assert_eq!(dispute.vote_count, 3);
+    assert!(dispute.weight_for > dispute.weight_against);
+
+    // The window closes and the verdict lands.
+    fx.advance(client.get_config().voting_window + 1);
+    let reputation_at_verdict = client.get_reputation(&agent_a_id);
+    assert!(
+        reputation_at_verdict < 7_047,
+        "the open window itself decays the score"
+    );
+    assert_eq!(client.resolve_dispute(&dispute_id), DisputeOutcome::Guilty);
+
+    // A's stake is provably reduced and its reputation drops by the same share.
+    let stake = client.get_stake(&agent_a).unwrap();
+    assert_eq!(stake.amount, 8_000);
+    assert_eq!(stake.slashed, 2_000);
+    assert_eq!(
+        client.get_reputation(&agent_a_id),
+        reputation_at_verdict * 8 / 10
+    );
+
+    // With the dispute resolved, A can withdraw what is left.
+    client.unstake(&agent_a, &8_000);
+    assert_eq!(client.get_stake(&agent_a).unwrap().amount, 0);
+}

--- a/contract/contracts/marketplace/src/lib.rs
+++ b/contract/contracts/marketplace/src/lib.rs
@@ -25,6 +25,10 @@ const LISTINGS_V2: Symbol = symbol_short!("LIC_V2");
 const ASSET_HISTORY: Symbol = symbol_short!("A_HIST");
 const OWNER: Symbol = symbol_short!("OWNER");
 const HISTORY_LIMIT: u32 = 5;
+/// Maximum byte length of an asset name.
+const MAX_NAME_LEN: u32 = 200;
+/// Maximum byte length of an asset description.
+const MAX_DESC_LEN: u32 = 2_000;
 
 // ── Data Types ───────────────────────────────────────────────────────────────
 
@@ -289,6 +293,8 @@ impl MarketplaceContract {
     ///                                             `description` must be 1–2 000 bytes.
     /// - [`MarketplaceError::AssetLimitReached`] — contract has already reached
     ///                                             `MAX_ASSETS` (10 000) listings.
+    /// List a new asset. Metadata is validated against the on-chain limits:
+    /// a positive price, a 1–200 byte name, and a 1–2 000 byte description.
     pub fn list_asset(
         env: Env,
         owner: Address,
@@ -299,6 +305,16 @@ impl MarketplaceContract {
         price: i128,
     ) -> Result<u64, MarketplaceError> {
         owner.require_auth();
+
+        if price <= 0 {
+            return Err(MarketplaceError::InvalidPrice);
+        }
+        if name.is_empty() || name.len() > MAX_NAME_LEN {
+            return Err(MarketplaceError::InvalidMetadata);
+        }
+        if description.is_empty() || description.len() > MAX_DESC_LEN {
+            return Err(MarketplaceError::InvalidMetadata);
+        }
 
         let count: u64 = env.storage().instance().get(&ASSET_COUNT).unwrap_or(0u64);
         let asset_id = count + 1;

--- a/contract/contracts/marketplace/src/test.rs
+++ b/contract/contracts/marketplace/src/test.rs
@@ -28,20 +28,10 @@ fn create_token<'a>(env: &'a Env, admin: &Address) -> (Address, token::StellarAs
 /// Build a `soroban_sdk::String` from a `&str` that is exactly `n` bytes long
 /// by repeating the character `'a'` (1 byte each in UTF-8).
 fn str_of_len(env: &Env, n: usize) -> String {
-    // Build the string in a std buffer (we are in test context so std is fine
-    // via the test harness).
-    let mut s = soroban_sdk::vec![env]; // not used — just for clarity
-    let _ = s; // suppress warning
-    // Use the bytes constructor via a fixed-length slice approach.
-    // The simplest portable way in soroban tests is to construct from a literal
-    // and then rely on the fact that the SDK accepts &str slices in test mode.
-    // We abuse `String::from_str` which is available in test builds.
-    let raw: soroban_sdk::bytes::Bytes = {
-        // Build a native Vec<u8> of `n` 'a' bytes then hand it to the SDK.
-        extern crate std;
-        let v: std::vec::Vec<u8> = std::vec![b'a'; n];
-        soroban_sdk::bytes::Bytes::from_slice(env, &v)
-    };
+    // Built in a std buffer — the test harness links std even though the
+    // contract itself is `#![no_std]`.
+    extern crate std;
+    let raw: std::vec::Vec<u8> = std::vec![b'a'; n];
     String::from_bytes(env, &raw)
 }
 
@@ -69,8 +59,7 @@ fn test_list_and_get_asset() {
             &AssetType::Prompt,
             &LicenseType::Perpetual,
             &5_000_000i128, // 0.5 XLM
-        )
-        .unwrap();
+        );
 
     assert_eq!(asset_id, 1);
     assert_eq!(client.asset_count(), 1);
@@ -242,8 +231,7 @@ fn test_multiple_assets() {
                 &AssetType::Workflow,
                 &LicenseType::UsageBased,
                 &1_000_000i128,
-            )
-            .unwrap();
+            );
     }
 
     assert_eq!(client.asset_count(), 5);
@@ -263,8 +251,7 @@ fn test_delist_asset() {
             &AssetType::Evaluator,
             &LicenseType::Perpetual,
             &2_000_000i128,
-        )
-        .unwrap();
+        );
 
     client.delist_asset(&admin, &asset_id);
 
@@ -286,8 +273,7 @@ fn test_update_price() {
             &AssetType::MemorySystem,
             &LicenseType::Subscription,
             &10_000_000i128,
-        )
-        .unwrap();
+        );
 
     client.update_price(&admin, &asset_id, &15_000_000i128);
 
@@ -313,8 +299,7 @@ fn test_purchase_license() {
             &AssetType::ReasoningChain,
             &LicenseType::Perpetual,
             &10_000_000i128,
-        )
-        .unwrap();
+        );
 
     assert!(!client.has_license(&buyer, &asset_id));
 
@@ -604,8 +589,7 @@ fn test_has_no_license_by_default() {
             &AssetType::Tool,
             &LicenseType::UsageBased,
             &3_000_000i128,
-        )
-        .unwrap();
+        );
 
     assert!(!client.has_license(&stranger, &1));
 }

--- a/contract/contracts/micropayments/src/lib.rs
+++ b/contract/contracts/micropayments/src/lib.rs
@@ -277,7 +277,7 @@ impl MicropaymentsContract {
         let now = env.ledger().timestamp();
 
         for id in stream_ids.iter() {
-            if let Some(mut stream) = streams.get(id.clone()) {
+            if let Some(mut stream) = streams.get(id) {
                 assert!(stream.recipient == recipient, "not the stream recipient");
                 let amount = stream.claimable(now);
                 if amount > 0 {
@@ -292,8 +292,8 @@ impl MicropaymentsContract {
                         stream.status = StreamStatus::Completed;
                     }
 
-                    streams.set(id.clone(), stream.clone());
-                    settled_amounts.set(id.clone(), amount);
+                    streams.set(id, stream.clone());
+                    settled_amounts.set(id, amount);
 
                     env.events()
                         .publish((symbol_short!("WITHDRAWN"), recipient.clone()), (id, amount));
@@ -321,7 +321,7 @@ impl MicropaymentsContract {
         let now = env.ledger().timestamp();
 
         for id in stream_ids.iter() {
-            match streams.get(id.clone()) {
+            match streams.get(id) {
                 Some(s) => {
                     result.set(id, s.claimable(now));
                 }

--- a/frontend/src/app/agents/[id]/DisputeList.tsx
+++ b/frontend/src/app/agents/[id]/DisputeList.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import Link from "next/link";
+import {
+  formatStake,
+  outcomeLabel,
+  timeRemaining,
+  voteShare,
+  type Dispute,
+} from "@/lib/reputation";
+
+interface Props {
+  agentId: string;
+  owner: string;
+  disputes: Dispute[];
+  loading?: boolean;
+}
+
+/**
+ * Disputes involving this agent — open ones first, with the weighted tally and
+ * how long is left to vote, then the resolved history.
+ */
+export default function DisputeList({ agentId, owner, disputes, loading = false }: Props) {
+  const open = disputes.filter((dispute) => dispute.status === "open");
+  const resolved = disputes.filter((dispute) => dispute.status !== "open");
+
+  return (
+    <section
+      data-testid="dispute-list"
+      className="rounded-xl border border-zinc-200 dark:border-zinc-800 p-5"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold">Disputes</h3>
+        <Link
+          href={`/agents/${agentId}/disputes/new`}
+          className="rounded-lg bg-black dark:bg-white px-3 py-1.5 text-xs font-medium text-white dark:text-black"
+        >
+          File a dispute
+        </Link>
+      </div>
+
+      {loading && (
+        <p className="mt-3 text-sm text-zinc-500 dark:text-zinc-400">Loading disputes…</p>
+      )}
+
+      {!loading && disputes.length === 0 && (
+        <p className="mt-3 text-sm text-zinc-500 dark:text-zinc-400">
+          No disputes have been filed against this agent.
+        </p>
+      )}
+
+      {open.length > 0 && (
+        <div className="mt-4">
+          <h4 className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+            Open
+          </h4>
+          <ul className="mt-2 space-y-2">
+            {open.map((dispute) => (
+              <li
+                key={dispute.id}
+                data-testid={`dispute-${dispute.id}`}
+                className="rounded-lg border border-amber-200 dark:border-amber-900 bg-amber-50 dark:bg-amber-950/30 p-3"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <span className="text-sm font-medium">Dispute #{dispute.id}</span>
+                  <span className="text-xs text-amber-700 dark:text-amber-300">
+                    {timeRemaining(dispute.closesAt)}
+                  </span>
+                </div>
+                <p className="mt-1 text-xs text-zinc-600 dark:text-zinc-400">
+                  {dispute.respondent === owner ? "Filed against this agent by" : "Filed by this agent against"}{" "}
+                  <span className="font-mono">
+                    {truncate(dispute.respondent === owner ? dispute.complainant : dispute.respondent)}
+                  </span>
+                </p>
+                <div className="mt-2">
+                  <div className="h-1.5 w-full overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-800">
+                    <div
+                      className="h-full bg-red-500"
+                      style={{ width: `${Math.round(voteShare(dispute) * 100)}%` }}
+                    />
+                  </div>
+                  <p className="mt-1 text-[11px] text-zinc-500 dark:text-zinc-400 tabular-nums">
+                    {dispute.weightFor} for · {dispute.weightAgainst} against
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {resolved.length > 0 && (
+        <div className="mt-4">
+          <h4 className="text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">
+            Resolved
+          </h4>
+          <ul className="mt-2 space-y-2">
+            {resolved.map((dispute) => (
+              <li
+                key={dispute.id}
+                data-testid={`dispute-${dispute.id}`}
+                className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-zinc-200 dark:border-zinc-800 p-3"
+              >
+                <span className="text-sm">Dispute #{dispute.id}</span>
+                <span
+                  className={`rounded-full px-2 py-0.5 text-xs ${
+                    dispute.outcome === "guilty"
+                      ? "bg-red-100 dark:bg-red-950/50 text-red-700 dark:text-red-300"
+                      : "bg-zinc-100 dark:bg-zinc-900 text-zinc-600 dark:text-zinc-400"
+                  }`}
+                >
+                  {outcomeLabel(dispute.outcome)}
+                </span>
+                {dispute.slashedAmount > 0 && (
+                  <span className="text-xs text-red-600 dark:text-red-400 tabular-nums">
+                    −{formatStake(dispute.slashedAmount)} XLM slashed
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function truncate(address: string): string {
+  return address.length > 12 ? `${address.slice(0, 6)}…${address.slice(-4)}` : address;
+}

--- a/frontend/src/app/agents/[id]/ReputationTimeline.tsx
+++ b/frontend/src/app/agents/[id]/ReputationTimeline.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  BPS_DENOM,
+  formatReputation,
+  outcomeLabel,
+  projectCurve,
+  reputationTone,
+  toPolylinePoints,
+  type DisputeMarker,
+  type ReputationTimelineData,
+} from "@/lib/reputation";
+
+const WIDTH = 640;
+const HEIGHT = 200;
+const PADDING = 12;
+
+const TONE_STROKE: Record<ReturnType<typeof reputationTone>, string> = {
+  high: "stroke-emerald-500",
+  medium: "stroke-amber-500",
+  low: "stroke-red-500",
+};
+
+interface Props {
+  timeline: ReputationTimelineData | null;
+  loading?: boolean;
+}
+
+/**
+ * Reputation over time: the decay curve since the score was last settled on
+ * chain, with a marker wherever a dispute was opened or resolved.
+ */
+export default function ReputationTimeline({ timeline, loading = false }: Props) {
+  const geometry = useMemo(() => {
+    if (!timeline || timeline.curve.length === 0) return null;
+
+    const points = projectCurve(timeline.curve, {
+      width: WIDTH,
+      height: HEIGHT,
+      padding: PADDING,
+    });
+
+    const first = timeline.curve[0].timestamp;
+    const span = timeline.curve[timeline.curve.length - 1].timestamp - first || 1;
+    const innerWidth = WIDTH - PADDING * 2;
+
+    const markers = timeline.disputes
+      .map((dispute) => {
+        const at = dispute.resolvedAt ?? dispute.openedAt;
+        const ratio = Math.min(Math.max((at - first) / span, 0), 1);
+        return { dispute, x: PADDING + innerWidth * ratio };
+      })
+      .filter((marker) => Number.isFinite(marker.x));
+
+    return { line: toPolylinePoints(points), markers };
+  }, [timeline]);
+
+  if (loading) {
+    return (
+      <section
+        data-testid="reputation-timeline"
+        className="rounded-xl border border-zinc-200 dark:border-zinc-800 p-5"
+      >
+        <p className="text-sm text-zinc-500 dark:text-zinc-400">Loading reputation history…</p>
+      </section>
+    );
+  }
+
+  if (!timeline || !geometry) {
+    return (
+      <section
+        data-testid="reputation-timeline"
+        className="rounded-xl border border-zinc-200 dark:border-zinc-800 p-5"
+      >
+        <h3 className="text-sm font-semibold">Reputation over time</h3>
+        <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
+          No reputation history has been indexed for this agent yet.
+        </p>
+      </section>
+    );
+  }
+
+  const tone = reputationTone(timeline.currentReputation);
+  const decayPerPeriod = ((BPS_DENOM - timeline.config.decayBps) / 100).toFixed(2);
+  const periodDays = (timeline.config.decayPeriod / 86_400).toFixed(0);
+
+  return (
+    <section
+      data-testid="reputation-timeline"
+      className="rounded-xl border border-zinc-200 dark:border-zinc-800 p-5"
+    >
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h3 className="text-sm font-semibold">Reputation over time</h3>
+        <p className="text-xs text-zinc-500 dark:text-zinc-400">
+          Decays {decayPerPeriod}% every {periodDays} day{periodDays === "1" ? "" : "s"} until the
+          next on-chain update
+        </p>
+      </div>
+
+      <div className="mt-3 flex items-baseline gap-3">
+        <span className="text-2xl font-semibold tabular-nums">
+          {formatReputation(timeline.currentReputation)}
+        </span>
+        {timeline.currentReputation !== timeline.baseReputation && (
+          <span className="text-xs text-zinc-500 dark:text-zinc-400">
+            settled at {formatReputation(timeline.baseReputation)}
+          </span>
+        )}
+      </div>
+
+      <svg
+        role="img"
+        aria-label="Reputation decay curve with dispute markers"
+        viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+        className="mt-4 w-full"
+      >
+        {[0.25, 0.5, 0.75].map((fraction) => (
+          <line
+            key={fraction}
+            x1={PADDING}
+            x2={WIDTH - PADDING}
+            y1={PADDING + (HEIGHT - PADDING * 2) * fraction}
+            y2={PADDING + (HEIGHT - PADDING * 2) * fraction}
+            className="stroke-zinc-200 dark:stroke-zinc-800"
+            strokeWidth={1}
+          />
+        ))}
+
+        <polyline
+          data-testid="reputation-curve"
+          points={geometry.line}
+          fill="none"
+          strokeWidth={2}
+          className={TONE_STROKE[tone]}
+        />
+
+        {geometry.markers.map(({ dispute, x }) => (
+          <g key={dispute.id} data-testid={`dispute-marker-${dispute.id}`}>
+            <line
+              x1={x}
+              x2={x}
+              y1={PADDING}
+              y2={HEIGHT - PADDING}
+              strokeWidth={1}
+              strokeDasharray="3 3"
+              className={
+                dispute.outcome === "guilty"
+                  ? "stroke-red-500"
+                  : "stroke-zinc-400 dark:stroke-zinc-600"
+              }
+            />
+            <circle
+              cx={x}
+              cy={PADDING}
+              r={4}
+              className={
+                dispute.outcome === "guilty"
+                  ? "fill-red-500"
+                  : "fill-zinc-400 dark:fill-zinc-600"
+              }
+            >
+              <title>{markerTitle(dispute)}</title>
+            </circle>
+          </g>
+        ))}
+      </svg>
+
+      {geometry.markers.length > 0 && (
+        <ul className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-zinc-500 dark:text-zinc-400">
+          {geometry.markers.map(({ dispute }) => (
+            <li key={dispute.id}>
+              <span className="font-medium text-zinc-700 dark:text-zinc-300">
+                #{dispute.id}
+              </span>{" "}
+              {markerTitle(dispute)}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function markerTitle(dispute: DisputeMarker): string {
+  const when = new Date(dispute.resolvedAt ?? dispute.openedAt).toLocaleDateString();
+  const state = dispute.status === "open" ? "opened" : outcomeLabel(dispute.outcome);
+  return `${state} · ${dispute.role} · ${when}`;
+}

--- a/frontend/src/app/agents/[id]/StakeBadge.tsx
+++ b/frontend/src/app/agents/[id]/StakeBadge.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { formatStake, type StakeSummary } from "@/lib/reputation";
+
+interface Props {
+  stake: StakeSummary | null;
+}
+
+/**
+ * Collateral an agent has locked against its reputation, plus what it has
+ * already lost to slashing.
+ */
+export default function StakeBadge({ stake }: Props) {
+  const amount = stake?.amount ?? 0;
+  const slashed = stake?.slashed ?? 0;
+
+  if (amount === 0 && slashed === 0) {
+    return (
+      <span
+        data-testid="stake-badge"
+        className="inline-flex items-center gap-1.5 rounded-full border border-zinc-200 dark:border-zinc-800 px-3 py-1 text-xs text-zinc-500 dark:text-zinc-400"
+      >
+        No stake
+      </span>
+    );
+  }
+
+  return (
+    <span
+      data-testid="stake-badge"
+      title={slashed > 0 ? `${formatStake(slashed)} XLM slashed to date` : undefined}
+      className="inline-flex items-center gap-2 rounded-full border border-emerald-200 dark:border-emerald-900 bg-emerald-50 dark:bg-emerald-950/40 px-3 py-1 text-xs"
+    >
+      <span className="font-medium text-emerald-700 dark:text-emerald-300 tabular-nums">
+        {formatStake(amount)} XLM staked
+      </span>
+      {slashed > 0 && (
+        <span className="text-red-600 dark:text-red-400 tabular-nums">
+          −{formatStake(slashed)} slashed
+        </span>
+      )}
+    </span>
+  );
+}

--- a/frontend/src/app/agents/[id]/disputes/new/page.tsx
+++ b/frontend/src/app/agents/[id]/disputes/new/page.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { fileDispute, submitEvidence } from "@/lib/reputation";
+
+interface EvidenceBundle {
+  claim: string;
+  detail: string;
+  transactions: string[];
+  attachments: Array<{ name: string; size: number; content: string }>;
+}
+
+/**
+ * Dispute filing form.
+ *
+ * The evidence bundle stays off-chain: it is uploaded here, the backend hashes
+ * it, and the returned digest is what the filer passes to `open_dispute` as
+ * `evidence_hash`. The form therefore ends by showing that digest to copy.
+ */
+export default function NewDisputePage() {
+  const params = useParams();
+  const agentId = params.id as string;
+
+  const [disputeId, setDisputeId] = useState("");
+  const [complainant, setComplainant] = useState("");
+  const [respondent, setRespondent] = useState("");
+  const [claim, setClaim] = useState("");
+  const [detail, setDetail] = useState("");
+  const [transactions, setTransactions] = useState("");
+  const [attachments, setAttachments] = useState<EvidenceBundle["attachments"]>([]);
+
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [evidenceHash, setEvidenceHash] = useState<string | null>(null);
+
+  async function handleFiles(files: FileList | null) {
+    if (!files || files.length === 0) return;
+    setError(null);
+
+    const read = await Promise.all(
+      Array.from(files).map(
+        (file) =>
+          new Promise<EvidenceBundle["attachments"][number]>((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onload = () =>
+              resolve({
+                name: file.name,
+                size: file.size,
+                content: String(reader.result ?? ""),
+              });
+            reader.onerror = () => reject(new Error(`Could not read ${file.name}`));
+            reader.readAsText(file);
+          })
+      )
+    ).catch((err: Error) => {
+      setError(err.message);
+      return [] as EvidenceBundle["attachments"];
+    });
+
+    setAttachments((current) => [...current, ...read]);
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setError(null);
+    setEvidenceHash(null);
+
+    if (!claim.trim()) {
+      setError("Describe what went wrong before filing.");
+      return;
+    }
+
+    const evidence: EvidenceBundle = {
+      claim: claim.trim(),
+      detail: detail.trim(),
+      transactions: transactions
+        .split(/[\s,]+/)
+        .map((tx) => tx.trim())
+        .filter(Boolean),
+      attachments,
+    };
+
+    setSubmitting(true);
+    try {
+      const result = await fileDispute({
+        id: Number(disputeId),
+        complainant: complainant.trim(),
+        respondent: respondent.trim(),
+        evidence,
+      });
+
+      if (!result.ok || !result.dispute) {
+        setError(result.error ?? "Could not file the dispute.");
+        return;
+      }
+
+      // Re-upload through the evidence endpoint so the response carries the
+      // digest to commit on-chain.
+      const stored = await submitEvidence(result.dispute.id, evidence);
+      if (!stored.ok) {
+        setError(stored.error ?? "The dispute was filed but the evidence was rejected.");
+        return;
+      }
+
+      setEvidenceHash(stored.evidenceHash ?? result.dispute.evidenceHash);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const inputClass =
+    "mt-1 w-full rounded-lg border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950 px-3 py-2 text-sm";
+
+  return (
+    <main className="min-h-screen bg-white dark:bg-black text-black dark:text-white pt-20 px-6">
+      <div className="mx-auto max-w-2xl">
+        <Link
+          href={`/agents/${agentId}`}
+          className="text-sm text-zinc-500 dark:text-zinc-400 hover:underline"
+        >
+          ← Back to agent
+        </Link>
+
+        <h1 className="mt-4 text-2xl font-semibold">File a dispute</h1>
+        <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+          Open the dispute on-chain first, then record it here with your evidence. The digest
+          returned below is the <code className="font-mono">evidence_hash</code> the contract
+          commits to — anyone can re-hash the bundle and check it matches.
+        </p>
+
+        <form onSubmit={handleSubmit} className="mt-6 space-y-4" data-testid="dispute-form">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="block text-sm">
+              On-chain dispute id
+              <input
+                type="number"
+                min={1}
+                required
+                value={disputeId}
+                onChange={(e) => setDisputeId(e.target.value)}
+                className={inputClass}
+                placeholder="returned by open_dispute"
+              />
+            </label>
+
+            <label className="block text-sm">
+              Your address (complainant)
+              <input
+                type="text"
+                required
+                value={complainant}
+                onChange={(e) => setComplainant(e.target.value)}
+                className={`${inputClass} font-mono`}
+                placeholder="G…"
+              />
+            </label>
+          </div>
+
+          <label className="block text-sm">
+            Respondent address
+            <input
+              type="text"
+              required
+              value={respondent}
+              onChange={(e) => setRespondent(e.target.value)}
+              className={`${inputClass} font-mono`}
+              placeholder="G…"
+            />
+          </label>
+
+          <label className="block text-sm">
+            What went wrong?
+            <input
+              type="text"
+              required
+              value={claim}
+              onChange={(e) => setClaim(e.target.value)}
+              className={inputClass}
+              placeholder="e.g. paid for an inference run that never completed"
+            />
+          </label>
+
+          <label className="block text-sm">
+            Detail
+            <textarea
+              rows={4}
+              value={detail}
+              onChange={(e) => setDetail(e.target.value)}
+              className={inputClass}
+              placeholder="Timeline, what was agreed, what happened instead…"
+            />
+          </label>
+
+          <label className="block text-sm">
+            Related transaction hashes
+            <input
+              type="text"
+              value={transactions}
+              onChange={(e) => setTransactions(e.target.value)}
+              className={`${inputClass} font-mono`}
+              placeholder="comma or space separated"
+            />
+          </label>
+
+          <label className="block text-sm">
+            Attachments
+            <input
+              type="file"
+              multiple
+              accept=".txt,.json,.log,.md"
+              onChange={(e) => void handleFiles(e.target.files)}
+              className="mt-1 block w-full text-sm"
+            />
+          </label>
+
+          {attachments.length > 0 && (
+            <ul className="text-xs text-zinc-500 dark:text-zinc-400">
+              {attachments.map((file) => (
+                <li key={file.name}>
+                  {file.name} ({file.size} bytes)
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {error && (
+            <p role="alert" className="text-sm text-red-600 dark:text-red-400">
+              {error}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={submitting}
+            className="rounded-lg bg-black dark:bg-white px-4 py-2 text-sm font-medium text-white dark:text-black disabled:opacity-60"
+          >
+            {submitting ? "Filing…" : "File dispute"}
+          </button>
+        </form>
+
+        {evidenceHash && (
+          <div
+            data-testid="evidence-hash"
+            className="mt-6 rounded-xl border border-emerald-200 dark:border-emerald-900 bg-emerald-50 dark:bg-emerald-950/40 p-4"
+          >
+            <p className="text-sm font-medium text-emerald-800 dark:text-emerald-200">
+              Evidence stored. Commit this digest on-chain:
+            </p>
+            <code className="mt-2 block break-all font-mono text-xs">{evidenceHash}</code>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/agents/[id]/page.tsx
+++ b/frontend/src/app/agents/[id]/page.tsx
@@ -3,6 +3,15 @@
 import { useCallback, useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
+import ReputationTimeline from "./ReputationTimeline";
+import DisputeList from "./DisputeList";
+import StakeBadge from "./StakeBadge";
+import {
+  fetchAgentDisputes,
+  fetchReputationTimeline,
+  type Dispute,
+  type ReputationTimelineData,
+} from "@/lib/reputation";
 
 interface Agent {
   id: number;
@@ -47,6 +56,9 @@ export default function AgentProfilePage() {
   const [reputationHistory, setReputationHistory] = useState<ReputationHistoryEntry[]>([]);
   const [activity, setActivity] = useState<ActivityEntry[]>([]);
   const [activeTab, setActiveTab] = useState<"overview" | "reputation" | "activity">("overview");
+  const [timeline, setTimeline] = useState<ReputationTimelineData | null>(null);
+  const [disputes, setDisputes] = useState<Dispute[]>([]);
+  const [reputationLoading, setReputationLoading] = useState(true);
   const [voteScore, setVoteScore] = useState(50);
   const [loading, setLoading] = useState(true);
 
@@ -90,6 +102,28 @@ export default function AgentProfilePage() {
       console.error("Failed to fetch activity:", err);
     }
     return null;
+  }, [agentId]);
+
+  // Decay curve, dispute markers and stake — the economic view of the agent.
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      const nextTimeline = await fetchReputationTimeline(agentId);
+      if (cancelled) return;
+      setTimeline(nextTimeline);
+
+      if (nextTimeline?.owner) {
+        const nextDisputes = await fetchAgentDisputes(nextTimeline.owner);
+        if (cancelled) return;
+        setDisputes(nextDisputes?.data ?? []);
+      }
+      setReputationLoading(false);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [agentId]);
 
   useEffect(() => {
@@ -189,6 +223,9 @@ export default function AgentProfilePage() {
             <p className={`text-3xl font-bold ${getRepColor(avgRep)}`}>
               {avgRep}%
             </p>
+            <div className="mt-2 flex justify-end">
+              <StakeBadge stake={timeline?.stake ?? null} />
+            </div>
           </div>
         </div>
 
@@ -250,6 +287,15 @@ export default function AgentProfilePage() {
         {/* Tab Content */}
         {activeTab === "reputation" && (
           <div className="space-y-6">
+            <ReputationTimeline timeline={timeline} loading={reputationLoading} />
+
+            <DisputeList
+              agentId={agentId}
+              owner={timeline?.owner ?? agent.owner}
+              disputes={disputes}
+              loading={reputationLoading}
+            />
+
             {/* Reputation Chart */}
             <div className="p-6 bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-lg">
               <h3 className="font-semibold mb-4">Reputation History</h3>

--- a/frontend/src/lib/reputation.test.ts
+++ b/frontend/src/lib/reputation.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from "vitest";
+import {
+  BPS_DENOM,
+  DEFAULT_DECAY_CONFIG,
+  MAX_DECAY_PERIODS,
+  currentReputation,
+  decayScore,
+  formatReputation,
+  formatStake,
+  outcomeLabel,
+  projectCurve,
+  reputationTone,
+  timeRemaining,
+  toPolylinePoints,
+  voteShare,
+} from "./reputation";
+
+const DAY = 86_400;
+const DAY_MS = 86_400_000;
+const NOW = 1_800_000_000_000;
+
+describe("decayScore", () => {
+  // The contract (contracts/agent_registry/src/lib.rs) and the backend engine
+  // assert these same values — all three implementations must agree exactly.
+  it("matches the contract's integer decay", () => {
+    expect(decayScore(5_000, DAY)).toBe(4_950);
+    expect(decayScore(5_000, DAY * 10)).toBe(4_517);
+  });
+
+  it("only decays on whole periods", () => {
+    expect(decayScore(5_000, DAY - 1)).toBe(5_000);
+    expect(decayScore(5_000, 0)).toBe(5_000);
+  });
+
+  it("truncates on each period rather than once at the end", () => {
+    expect(decayScore(5_000, DAY * 10)).toBeLessThan(Math.floor(5_000 * 0.99 ** 10));
+  });
+
+  it("saturates at the contract's iteration bound", () => {
+    expect(decayScore(5_000, DAY * 5_000)).toBe(decayScore(5_000, DAY * MAX_DECAY_PERIODS));
+  });
+
+  it("never returns a negative score", () => {
+    expect(decayScore(-10, DAY)).toBe(0);
+    expect(decayScore(0, DAY * 30)).toBe(0);
+  });
+
+  it("honours a different on-chain decay rate", () => {
+    const config = { ...DEFAULT_DECAY_CONFIG, decayBps: 5_000 };
+    expect(decayScore(8_000, DAY * 2, config)).toBe(2_000);
+  });
+
+  it("treats a 100% retention rate as decay disabled", () => {
+    const config = { ...DEFAULT_DECAY_CONFIG, decayBps: BPS_DENOM };
+    expect(decayScore(8_000, DAY * 100, config)).toBe(8_000);
+  });
+});
+
+describe("currentReputation", () => {
+  it("decays from the settlement timestamp", () => {
+    expect(currentReputation(5_000, NOW - DAY_MS * 10, NOW)).toBe(4_517);
+  });
+
+  it("returns the base score when the clock was never set", () => {
+    expect(currentReputation(7_000, null, NOW)).toBe(7_000);
+  });
+});
+
+describe("formatting", () => {
+  it("renders basis points as a percentage", () => {
+    expect(formatReputation(4_517)).toBe("45.17%");
+    expect(formatReputation(10_000)).toBe("100.00%");
+    expect(formatReputation(-5)).toBe("0.00%");
+  });
+
+  it("bands a score for colouring", () => {
+    expect(reputationTone(9_000)).toBe("high");
+    expect(reputationTone(5_000)).toBe("medium");
+    expect(reputationTone(1_200)).toBe("low");
+  });
+
+  it("renders stroops as trimmed XLM", () => {
+    expect(formatStake(10_000_000)).toBe("1");
+    expect(formatStake(12_500_000)).toBe("1.25");
+    expect(formatStake(0)).toBe("0");
+  });
+
+  it("labels every verdict", () => {
+    expect(outcomeLabel("guilty")).toBe("Guilty");
+    expect(outcomeLabel("not_guilty")).toBe("Not guilty");
+    expect(outcomeLabel("quorum_failed")).toBe("No quorum");
+    expect(outcomeLabel(null)).toBe("Pending");
+  });
+
+  it("counts down to the voting deadline", () => {
+    expect(timeRemaining(NOW + DAY_MS * 2 + 3_600_000, NOW)).toBe("2d 1h left");
+    expect(timeRemaining(NOW + 7_200_000, NOW)).toBe("2h 0m left");
+    expect(timeRemaining(NOW + 60_000, NOW)).toBe("1m left");
+    expect(timeRemaining(NOW - 1_000, NOW)).toBe("Voting closed");
+    expect(timeRemaining(null, NOW)).toBe("—");
+  });
+});
+
+describe("voteShare", () => {
+  it("is the share of weight cast against the respondent", () => {
+    expect(voteShare({ weightFor: 3, weightAgainst: 1 })).toBe(0.75);
+    expect(voteShare({ weightFor: 0, weightAgainst: 0 })).toBe(0);
+  });
+});
+
+describe("chart geometry", () => {
+  const box = { width: 100, height: 100, padding: 0 };
+
+  it("maps a flat curve onto a horizontal line", () => {
+    const points = projectCurve(
+      [
+        { timestamp: 0, score: 5_000 },
+        { timestamp: 10, score: 5_000 },
+      ],
+      box
+    );
+    expect(points).toEqual([
+      { x: 0, y: 50 },
+      { x: 100, y: 50 },
+    ]);
+  });
+
+  it("puts a higher score higher on the chart", () => {
+    const [top, bottom] = projectCurve(
+      [
+        { timestamp: 0, score: 10_000 },
+        { timestamp: 1, score: 0 },
+      ],
+      box
+    );
+    expect(top.y).toBe(0);
+    expect(bottom.y).toBe(100);
+  });
+
+  it("handles a single point without dividing by zero", () => {
+    expect(projectCurve([{ timestamp: 5, score: 5_000 }], box)).toEqual([{ x: 0, y: 50 }]);
+    expect(projectCurve([], box)).toEqual([]);
+  });
+
+  it("respects padding", () => {
+    const points = projectCurve(
+      [
+        { timestamp: 0, score: 10_000 },
+        { timestamp: 1, score: 10_000 },
+      ],
+      { width: 100, height: 100, padding: 10 }
+    );
+    expect(points[0]).toEqual({ x: 10, y: 10 });
+    expect(points[1]).toEqual({ x: 90, y: 10 });
+  });
+
+  it("serializes projected points for an SVG polyline", () => {
+    expect(
+      toPolylinePoints([
+        { x: 1.005, y: 2 },
+        { x: 3, y: 4 },
+      ])
+    ).toBe("1,2 3,4");
+  });
+});

--- a/frontend/src/lib/reputation.ts
+++ b/frontend/src/lib/reputation.ts
@@ -1,0 +1,312 @@
+/**
+ * Reputation, staking, and dispute helpers for the agent profile.
+ *
+ * The decay math mirrors `backend/src/services/reputationEngine.js`, which in
+ * turn mirrors `decay_score` in contracts/agent_registry/src/lib.rs: the score
+ * is multiplied by `decayBps / 10000` once per whole elapsed period, truncating
+ * on each step. Keeping the same loop here means a timeline rendered in the
+ * browser lines up exactly with what the chain would report, rather than
+ * drifting by a basis point or two.
+ */
+
+import { API_BASE_URL } from "./constants";
+
+export const BPS_DENOM = 10_000;
+
+/** Matches MAX_DECAY_PERIODS in the contract and the backend engine. */
+export const MAX_DECAY_PERIODS = 730;
+
+export interface DecayConfig {
+  slashBps: number;
+  votingWindow: number;
+  quorumWeight: number;
+  decayBps: number;
+  decayPeriod: number;
+}
+
+export const DEFAULT_DECAY_CONFIG: DecayConfig = {
+  slashBps: 2_000,
+  votingWindow: 259_200,
+  quorumWeight: 1_000,
+  decayBps: 9_900,
+  decayPeriod: 86_400,
+};
+
+export type DisputeStatus = "open" | "resolved";
+export type DisputeOutcome = "guilty" | "not_guilty" | "quorum_failed";
+export type DisputeRole = "respondent" | "complainant";
+
+export interface DisputeMarker {
+  id: number;
+  status: DisputeStatus;
+  outcome: DisputeOutcome | null;
+  openedAt: number;
+  resolvedAt: number | null;
+  slashedAmount: number;
+  role: DisputeRole;
+}
+
+export interface StakeSummary {
+  agentAddress: string;
+  amount: number;
+  slashed: number;
+}
+
+export interface CurvePoint {
+  timestamp: number;
+  score: number;
+}
+
+export interface ReputationTimelineData {
+  agentId: number;
+  owner: string;
+  baseReputation: number;
+  currentReputation: number;
+  reputationUpdatedAt: number | null;
+  config: DecayConfig;
+  curve: CurvePoint[];
+  disputes: DisputeMarker[];
+  stake: StakeSummary;
+}
+
+export interface Dispute {
+  id: number;
+  complainant: string;
+  respondent: string;
+  evidenceHash: string;
+  evidence: unknown;
+  status: DisputeStatus;
+  outcome: DisputeOutcome | null;
+  weightFor: number;
+  weightAgainst: number;
+  slashedAmount: number;
+  openedAt: number;
+  closesAt: number | null;
+  resolvedAt: number | null;
+}
+
+export interface Paginated<T> {
+  data: T[];
+  meta: { total: number; page: number; limit: number; pages: number };
+}
+
+// ── Decay math ───────────────────────────────────────────────────────────────
+
+/** `base * (decayBps / 10000) ^ periods`, truncating each period. */
+export function decayScore(
+  base: number,
+  elapsedSeconds: number,
+  config: DecayConfig = DEFAULT_DECAY_CONFIG
+): number {
+  const start = Math.trunc(base) || 0;
+  const elapsed = Math.trunc(elapsedSeconds) || 0;
+
+  if (
+    start <= 0 ||
+    elapsed <= 0 ||
+    config.decayPeriod <= 0 ||
+    config.decayBps >= BPS_DENOM
+  ) {
+    return Math.max(start, 0);
+  }
+
+  const periods = Math.min(
+    Math.floor(elapsed / config.decayPeriod),
+    MAX_DECAY_PERIODS
+  );
+
+  let score = start;
+  for (let applied = 0; applied < periods && score > 0; applied += 1) {
+    score = Math.floor((score * config.decayBps) / BPS_DENOM);
+  }
+  return score;
+}
+
+/** What a base score settled at `settledAt` is worth at `nowMs`. */
+export function currentReputation(
+  base: number,
+  settledAt: number | null,
+  nowMs: number = Date.now(),
+  config: DecayConfig = DEFAULT_DECAY_CONFIG
+): number {
+  if (!settledAt) return Math.max(Math.trunc(base) || 0, 0);
+  return decayScore(base, Math.floor((nowMs - settledAt) / 1000), config);
+}
+
+// ── Formatting ───────────────────────────────────────────────────────────────
+
+/** Basis points → a percentage string, e.g. 4517 → "45.17%". */
+export function formatReputation(bps: number): string {
+  const safe = Math.max(Math.trunc(bps) || 0, 0);
+  return `${(safe / 100).toFixed(2)}%`;
+}
+
+/** Coarse band used to colour a score. */
+export function reputationTone(bps: number): "high" | "medium" | "low" {
+  if (bps >= 7_000) return "high";
+  if (bps >= 4_000) return "medium";
+  return "low";
+}
+
+/** Stroops → XLM, trimmed of trailing zeros. */
+export function formatStake(stroops: number): string {
+  const xlm = (Math.max(Math.trunc(stroops) || 0, 0) / 10_000_000).toFixed(7);
+  return xlm.replace(/\.?0+$/, "") || "0";
+}
+
+export function outcomeLabel(outcome: DisputeOutcome | null): string {
+  switch (outcome) {
+    case "guilty":
+      return "Guilty";
+    case "not_guilty":
+      return "Not guilty";
+    case "quorum_failed":
+      return "No quorum";
+    default:
+      return "Pending";
+  }
+}
+
+/** Human-readable time left before voting closes. */
+export function timeRemaining(closesAt: number | null, nowMs: number = Date.now()): string {
+  if (!closesAt) return "—";
+  const seconds = Math.floor((closesAt - nowMs) / 1000);
+  if (seconds <= 0) return "Voting closed";
+
+  const days = Math.floor(seconds / 86_400);
+  if (days > 0) return `${days}d ${Math.floor((seconds % 86_400) / 3_600)}h left`;
+
+  const hours = Math.floor(seconds / 3_600);
+  if (hours > 0) return `${hours}h ${Math.floor((seconds % 3_600) / 60)}m left`;
+
+  return `${Math.max(Math.floor(seconds / 60), 1)}m left`;
+}
+
+/** Share of the weighted vote that sided against the respondent, 0–1. */
+export function voteShare(dispute: Pick<Dispute, "weightFor" | "weightAgainst">): number {
+  const total = dispute.weightFor + dispute.weightAgainst;
+  if (total <= 0) return 0;
+  return dispute.weightFor / total;
+}
+
+// ── Chart geometry ───────────────────────────────────────────────────────────
+
+export interface ChartBox {
+  width: number;
+  height: number;
+  padding?: number;
+}
+
+/**
+ * Project curve points onto an SVG viewbox. The y-axis is fixed to 0–10000
+ * basis points so two agents' charts can be compared side by side.
+ */
+export function projectCurve(points: CurvePoint[], box: ChartBox): Array<{ x: number; y: number }> {
+  const padding = box.padding ?? 0;
+  const innerWidth = Math.max(box.width - padding * 2, 1);
+  const innerHeight = Math.max(box.height - padding * 2, 1);
+
+  if (points.length === 0) return [];
+  if (points.length === 1) {
+    return [{ x: padding, y: padding + innerHeight * (1 - points[0].score / BPS_DENOM) }];
+  }
+
+  const first = points[0].timestamp;
+  const span = points[points.length - 1].timestamp - first || 1;
+
+  return points.map((point) => ({
+    x: padding + (innerWidth * (point.timestamp - first)) / span,
+    y: padding + innerHeight * (1 - Math.min(point.score, BPS_DENOM) / BPS_DENOM),
+  }));
+}
+
+/** An SVG polyline `points` attribute for a projected curve. */
+export function toPolylinePoints(points: Array<{ x: number; y: number }>): string {
+  return points.map((p) => `${round(p.x)},${round(p.y)}`).join(" ");
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+// ── API ──────────────────────────────────────────────────────────────────────
+
+async function getJson<T>(path: string): Promise<T | null> {
+  try {
+    const res = await fetch(`${API_BASE_URL}${path}`);
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+export function fetchReputationTimeline(
+  agentId: string | number
+): Promise<ReputationTimelineData | null> {
+  return getJson<ReputationTimelineData>(`/api/v1/agents/${agentId}/reputation-timeline`);
+}
+
+export function fetchAgentDisputes(address: string): Promise<Paginated<Dispute> | null> {
+  return getJson<Paginated<Dispute>>(`/api/v1/disputes/agent/${address}`);
+}
+
+export interface FileDisputeInput {
+  id: number;
+  complainant: string;
+  respondent: string;
+  evidence: unknown;
+}
+
+export interface FileDisputeResult {
+  ok: boolean;
+  dispute?: Dispute;
+  error?: string;
+}
+
+/** Index a dispute opened on-chain, uploading its evidence bundle. */
+export async function fileDispute(input: FileDisputeInput): Promise<FileDisputeResult> {
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/v1/disputes`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input),
+    });
+
+    const payload = (await res.json().catch(() => null)) as
+      | (Dispute & { error?: string })
+      | null;
+
+    if (!res.ok) {
+      return { ok: false, error: payload?.error ?? `Request failed (${res.status})` };
+    }
+    return { ok: true, dispute: payload as Dispute };
+  } catch {
+    return { ok: false, error: "Could not reach the backend. Is the API server running?" };
+  }
+}
+
+/** Upload (or replace) an evidence bundle; returns the digest to commit on-chain. */
+export async function submitEvidence(
+  disputeId: number,
+  evidence: unknown
+): Promise<{ ok: boolean; evidenceHash?: string; error?: string }> {
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/v1/disputes/${disputeId}/evidence`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ evidence }),
+    });
+
+    const payload = (await res.json().catch(() => null)) as
+      | { evidenceHash?: string; error?: string }
+      | null;
+
+    if (!res.ok) {
+      return { ok: false, error: payload?.error ?? `Request failed (${res.status})` };
+    }
+    return { ok: true, evidenceHash: payload?.evidenceHash };
+  } catch {
+    return { ok: false, error: "Could not reach the backend. Is the API server running?" };
+  }
+}


### PR DESCRIPTION
## Description

Implements #77: reputation that decays with ledger time, collateral staked against it, disputes decided by stake-weighted votes, and slashing that hits stake and reputation together — across the contract, the indexer, the pipeline and the agent profile UI.

## Changes

### Contract — `contract/contracts/agent_registry`
- **`stake` / `unstake`** lock and release collateral in any token. Unstaking is blocked while a dispute against the address is open, so a respondent cannot withdraw ahead of a verdict.
- **`open_dispute(complainant, respondent, evidence_hash) -> u64`** records the filing, sets a deadline from the configured voting window, and emits `DISPUTE_OPENED`. Requires the respondent to actually have stake to slash.
- **`vote_dispute(voter, dispute_id, in_favor)`** weighs a vote by the voter's staked amount scaled by their own reputation, and rejects voters with no recorded interaction with the respondent (`record_interaction` keeps that history). A throwaway account has neither stake weight nor interaction history, so brigading gets no traction.
- **`resolve_dispute(dispute_id) -> DisputeOutcome`** tallies the weighted vote once the window closes — `Guilty`, `NotGuilty` or `QuorumFailed`. A guilty verdict slashes the respondent's stake by the configured percentage, applies the same proportional cut to every agent that address owns, and emits `STAKE_SLASHED` + `DISPUTE_RESOLVED`.
- **Time decay**: `score * (decay_bps / 10000) ^ periods`, applied one whole period at a time and recomputed lazily on read. A vote settles the decayed score first, so it never lands on a stale snapshot.
- **`configure`** sets the slash percentage, voting window, quorum and decay rate; the first caller claims the admin role.
- **32 new tests** covering staking, the dispute lifecycle, slashing arithmetic, decay over simulated ledger time, quorum failure, double-voting, and anti-brigading rejection.

### Backend
- **`services/reputationEngine.js`** — off-chain mirror of the decay, so a page load costs no contract call. It runs the *identical integer loop* as the contract, so the two agree exactly rather than only within a tolerance (the tests pin the same numbers on both sides).
- **`services/disputeService.js`** — filing, evidence upload with a canonical SHA-256 digest (the value the contract commits to, re-checkable via `verifyEvidence`), verdicts, stake mirroring, and notifications over the existing SSE channel.
- **`pipeline/EventProcessor.js`** — handles `STAKED`, `UNSTAKED`, `DISPUTE_OPENED`, `DISPUTE_VOTED`, `DISPUTE_RESOLVED`, `STAKE_SLASHED`, so a slash and the reputation drop it causes land within one poll cycle.
- **Migration `015_add_reputation_disputes.sql`** — `disputes`, `dispute_votes`, `agent_stakes`, plus the decay clock and denormalized stake columns on `agents`. (The issue suggests `011`, but that number is taken by the admin-actions migration.)
- Agent reads decay on the way out; `GET /api/v1/agents/:id/reputation-timeline` serves the curve, dispute markers and stake; new `/api/v1/disputes` routes list, file and accept evidence.

### Frontend — `frontend/src/app/agents/[id]`
- `ReputationTimeline.tsx` — decay curve with a marker per dispute.
- `DisputeList.tsx` — open votes (weighted tally, time left) separated from resolved verdicts.
- `StakeBadge.tsx` — collateral and slash history.
- `disputes/new/page.tsx` — filing form with evidence upload that returns the digest to commit on-chain.
- `lib/reputation.ts` — the client-side copy of the decay math, pinned to the same values as the contract and the backend.

## Acceptance criteria

- **Reputation always reflects current decay** — `getAgent`, `listAgents` and the timeline endpoint all decay on read; the stored score stays the base value the chain holds.
- **A slashed stake is provably reduced on-chain and reflected within one poll cycle** — contract test `test_end_to_end_stake_dispute_slash_flow`, and `EventProcessor` → `disputeService.recordSlash` → `agent_stakes` + the `agents` columns.
- **Dispute voting cannot be gamed with throwaway accounts** — `test_vote_dispute_rejects_voter_without_interaction_history` and `test_vote_dispute_rejects_voter_without_stake`.

## Heads-up: CI was already red on `main`

The first commit (`fix: repair the red CI baseline on main`) is **not** part of the feature — it fixes breakage that predates this work and would otherwise keep both CI jobs failing. Happy to split it into its own PR if you'd rather review it separately.

- **Backend CI fails on `main`** ([run](https://github.com/CortexRail/cortex-protocols/actions/runs/32152742845)): migration 013 renames `events_log` to `events_log_old` and then re-creates its indexes, but renaming a table does not rename its indexes — so it dies on `relation "idx_events_log_ledger" already exists`, which fails `globalSetup` and therefore every backend test. The old table is now dropped before the indexes are re-created.
- Migration 013 also named partitions `events_log_p0_to_100k` while `create-future-partitions.js` generates `events_log_p0_to_100000`, so the script tried to create an overlapping partition and the partitioning tests asserted on names that never existed. Both use the numeric form now.
- **`DbRouter.route()` leaked a pooled client on every successful read** — released only in the error branch. That is a production connection leak, and it hung `closePool()`, timing out the router suite's `afterAll`.
- Two stale test expectations: `text[]` parameters passed as JSON strings (`'["EVT"]'`), and a db-stats assertion still expecting the flat pool shape from before read-replica routing landed.
- **Contract CI**: `soroban-sdk 22.0.11` pins `soroban-env-host =22.1.3`, whose testutils are written against the ed25519-dalek 3.0.0 *pre-release*; released 3.0.0 reworked `CryptoRng`, so `cargo test` could not compile the host at all. `Cargo.lock` now pins `3.0.0-pre.1`.
- `marketplace::list_asset` never validated its metadata, so six guard tests in its own `test.rs` failed. It now rejects a non-positive price (`InvalidPrice`) and a name/description outside 1–200 / 1–2 000 bytes (`InvalidMetadata`) — exactly what those tests specify. Also cleared four `clone-on-copy` clippy errors in micropayments and some SDK API drift in the marketplace tests.
- `agent_registry`'s test module was never declared in `lib.rs`, so its 243 lines had never compiled. It is wired in now, with three assertions corrected to the rolling average the contract actually implements (e.g. five 100-votes reach 7047, not 9000+).

## Verification

| Job | Before (on `main`) | After |
|---|---|---|
| Contract — `cargo test` | does not compile | 87 passing |
| Contract — `cargo clippy -- -D warnings` | 4 errors | clean |
| Backend — `npm test` | 381 passed, 7 failed | **442 passed** |
| Backend — `npm run lint` | clean | clean |
| Frontend — `npm test` | 18 passed | **38 passed** |
| Frontend — `npm run lint` / `npm run build` | clean | clean |

Backend tests were run against a real PostgreSQL 16 instance, including a new end-to-end suite (`disputeFlow.test.js`) that stakes, files, votes, resolves guilty, and asserts the slashed collateral and dropped reputation across the contract mirror, the DB and the read APIs.

Closes #77
