### PR TITLE
feat: implement cryptographic attestation and archival for metering calls

### DIFF
--- a/backend/src/__tests__/attestation/attestation.test.js
+++ b/backend/src/__tests__/attestation/attestation.test.js
@@ -1,0 +1,428 @@
+/**
+ * Unit tests for the attestation primitives.
+ *
+ * Pure crypto and pure data structures — no database, no container — so a
+ * regression in the wire format or the tree shows up immediately rather than
+ * only once the integration suite can run.
+ */
+
+const { Keypair } = require("@stellar/stellar-sdk");
+const canonical = require("../../attestation/canonical");
+const AttestationBuilder = require("../../attestation/AttestationBuilder");
+const AttestationVerifier = require("../../attestation/AttestationVerifier");
+const MerkleBatchBuilder = require("../../attestation/MerkleBatchBuilder");
+
+const { Reason } = AttestationVerifier;
+
+const SELLER = Keypair.fromRawEd25519Seed(Buffer.alloc(32, 7));
+const IMPOSTOR = Keypair.fromRawEd25519Seed(Buffer.alloc(32, 9));
+
+function newBuilder(signer = SELLER) {
+  return new AttestationBuilder({ signer, now: () => 1_700_000_000 });
+}
+
+function attestMany(builder, streamId, count, startAt = 0) {
+  if (startAt) builder.seed(streamId, startAt - 1);
+  return Array.from({ length: count }, (_, i) =>
+    builder.attest({ streamId, request: { q: i }, response: { a: i } })
+  );
+}
+
+describe("canonical encoding", () => {
+  const attestation = {
+    stream_id: 42,
+    call_index: 7,
+    request_hash: "07".repeat(32),
+    response_hash: "87".repeat(32),
+    timestamp: 1_700_000_007,
+    nonce: "07".repeat(32),
+  };
+
+  it("encodes a leaf as exactly 120 fixed-width bytes", () => {
+    const encoded = canonical.encodeLeafPreimage(attestation);
+    expect(encoded).toHaveLength(canonical.LEAF_PREIMAGE_BYTES);
+    expect(encoded.readBigUInt64BE(canonical.OFFSETS.streamId)).toBe(42n);
+    expect(encoded.readBigUInt64BE(canonical.OFFSETS.callIndex)).toBe(7n);
+  });
+
+  it("round-trips a leaf through encode/decode", () => {
+    expect(canonical.decodeLeafPreimage(canonical.encodeLeafPreimage(attestation))).toEqual(
+      attestation
+    );
+  });
+
+  /**
+   * These are the same constants asserted in the contract's attestation_test.rs.
+   * If the two encoders ever drift, both sides fail rather than quietly
+   * producing roots that no longer verify against each other.
+   */
+  it("matches the pinned cross-language vectors", () => {
+    expect(canonical.leafHash(attestation).toString("hex")).toBe(
+      "b4c1330bdbc48325bda5539652c39793f3e7f41d8d454dd87733adbf3ee04d4c"
+    );
+    expect(
+      canonical.hashInternal(Buffer.alloc(32, 0xaa), Buffer.alloc(32, 0x11)).toString("hex")
+    ).toBe("7bc00103de1206e4948808b12bd2016b6923258e43b9c23724ed104cfdd1fdea");
+    expect(
+      canonical
+        .batchCommitmentMessage({ stream_id: 42, merkle_root: "ab".repeat(32), call_count: 20 })
+        .toString("hex")
+    ).toBe(
+      "02000000000000002a" + "ab".repeat(32) + "0000000000000014"
+    );
+  });
+
+  it("orders internal-node children by byte value, not argument order", () => {
+    const a = Buffer.alloc(32, 0xaa);
+    const b = Buffer.alloc(32, 0x11);
+    expect(canonical.hashInternal(a, b)).toEqual(canonical.hashInternal(b, a));
+  });
+
+  it("separates leaf and internal hashing domains", () => {
+    // A 64-byte internal preimage and a 120-byte leaf preimage can never
+    // collide, which is what stops an internal node being replayed as a leaf.
+    const leaf = canonical.leafHash(attestation);
+    const internal = canonical.hashInternal(leaf, leaf);
+    expect(leaf.toString("hex")).not.toBe(internal.toString("hex"));
+  });
+
+  it("hashes payloads independently of key order", () => {
+    expect(canonical.hashPayload({ a: 1, b: { c: 2, d: 3 } })).toEqual(
+      canonical.hashPayload({ b: { d: 3, c: 2 }, a: 1 })
+    );
+  });
+
+  it("rejects a hash field of the wrong width", () => {
+    expect(() =>
+      canonical.encodeLeafPreimage({ ...attestation, nonce: "00".repeat(16) })
+    ).toThrow(/64 hex characters/);
+  });
+});
+
+describe("AttestationBuilder", () => {
+  it("assigns strictly increasing call indices", () => {
+    const builder = newBuilder();
+    const indices = attestMany(builder, 1, 5).map((a) => a.call_index);
+    expect(indices).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it("keeps a separate counter per stream", () => {
+    const builder = newBuilder();
+    builder.attest({ streamId: 1, request: {}, response: {} });
+    expect(builder.attest({ streamId: 2, request: {}, response: {} }).call_index).toBe(0);
+  });
+
+  it("resumes the counter after a restart via seed()", () => {
+    const builder = newBuilder();
+    builder.seed(9, 41);
+    expect(builder.attest({ streamId: 9, request: {}, response: {} }).call_index).toBe(42);
+  });
+
+  it("never repeats a nonce", () => {
+    const builder = newBuilder();
+    const nonces = new Set(attestMany(builder, 1, 200).map((a) => a.nonce));
+    expect(nonces.size).toBe(200);
+  });
+
+  it("produces attestations that verify under the signer's public key", () => {
+    const attestation = newBuilder().attest({ streamId: 3, request: { x: 1 }, response: { y: 2 } });
+    expect(new AttestationVerifier().check(attestation, { signer: SELLER.publicKey() }).valid).toBe(
+      true
+    );
+  });
+
+  describe("wrap()", () => {
+    it("attaches an attestation without disturbing the handler's response", async () => {
+      const handler = newBuilder().wrap(async (req) => ({ answer: req.n * 2 }));
+      const result = await handler({ n: 21 }, { streamId: 5 });
+
+      expect(result.answer).toBe(42);
+      expect(result.attestation.stream_id).toBe(5);
+      expect(new AttestationVerifier().check(result.attestation).valid).toBe(true);
+    });
+
+    it("moves a non-object response under `data` so there is room for the attestation", async () => {
+      const handler = newBuilder().wrap(async () => "plain text");
+      const result = await handler({}, { streamId: 5 });
+      expect(result.data).toBe("plain text");
+      expect(result.attestation).toBeDefined();
+    });
+
+    it("can derive the stream id from the request", async () => {
+      const handler = newBuilder().wrap(async () => ({ ok: true }), {
+        streamId: (req) => req.stream,
+      });
+      const result = await handler({ stream: 77 }, {});
+      expect(result.attestation.stream_id).toBe(77);
+    });
+  });
+});
+
+describe("AttestationVerifier", () => {
+  let verifier;
+  let builder;
+
+  beforeEach(() => {
+    verifier = new AttestationVerifier({ now: () => 1_700_000_000 });
+    builder = newBuilder();
+  });
+
+  it("accepts a well-formed attestation", () => {
+    const attestation = builder.attest({ streamId: 1, request: {}, response: {} });
+    expect(verifier.check(attestation, { signer: SELLER.publicKey() })).toMatchObject({
+      valid: true,
+      reason: Reason.OK,
+    });
+  });
+
+  it.each([
+    ["response_hash", { response_hash: "aa".repeat(32) }],
+    ["request_hash", { request_hash: "bb".repeat(32) }],
+    ["timestamp", { timestamp: 1_600_000_000 }],
+    ["call_index", { call_index: 99 }],
+    ["stream_id", { stream_id: 2 }],
+    ["nonce", { nonce: "cc".repeat(32) }],
+  ])("rejects an attestation whose %s was altered after signing", (_field, patch) => {
+    const attestation = { ...builder.attest({ streamId: 1, request: {}, response: {} }), ...patch };
+    expect(verifier.check(attestation, { signer: SELLER.publicKey() }).reason).toBe(
+      Reason.BAD_SIGNATURE
+    );
+  });
+
+  it("rejects an attestation signed by the wrong key", () => {
+    const attestation = newBuilder(IMPOSTOR).attest({ streamId: 1, request: {}, response: {} });
+    // The claimed signer is checked before the curve arithmetic, so this is a
+    // mismatch rather than a bad signature — both are refusals.
+    expect(verifier.check(attestation, { signer: SELLER.publicKey() }).reason).toBe(
+      Reason.SIGNER_MISMATCH
+    );
+  });
+
+  it("rejects a signature transplanted from another seller", () => {
+    const honest = builder.attest({ streamId: 1, request: {}, response: {} });
+    const forged = newBuilder(IMPOSTOR).attest({ streamId: 1, request: {}, response: {} });
+    // Same claimed signer, signature actually produced by someone else.
+    const transplanted = { ...honest, signature: forged.signature };
+    expect(verifier.check(transplanted, { signer: SELLER.publicKey() }).reason).toBe(
+      Reason.BAD_SIGNATURE
+    );
+  });
+
+  it("flags a bad signature as provable on-chain", () => {
+    const attestation = builder.attest({ streamId: 1, request: {}, response: {} });
+    const result = verifier.check(
+      { ...attestation, signature: "ab".repeat(64) },
+      { signer: SELLER.publicKey() }
+    );
+    expect(result.reason).toBe(Reason.BAD_SIGNATURE);
+    expect(result.provableOnChain).toBe(true);
+  });
+
+  it("rejects an attestation for a different stream", () => {
+    const attestation = builder.attest({ streamId: 1, request: {}, response: {} });
+    expect(verifier.check(attestation, { streamId: 2 }).reason).toBe(Reason.STREAM_MISMATCH);
+  });
+
+  it("rejects an attestation dated far in the future", () => {
+    const attestation = builder.attest({
+      streamId: 1,
+      request: {},
+      response: {},
+      timestamp: 1_700_999_999,
+    });
+    expect(verifier.check(attestation).reason).toBe(Reason.CLOCK_SKEW);
+  });
+
+  it("rejects a replayed nonce on the second presentation", async () => {
+    const attestation = builder.attest({ streamId: 1, request: {}, response: {} });
+    expect((await verifier.accept(attestation)).valid).toBe(true);
+
+    const result = await verifier.accept(attestation);
+    expect(result.reason).toBe(Reason.NONCE_REUSED);
+    expect(result.provableOnChain).toBe(true);
+  });
+
+  it("rejects a nonce replayed under a fresh call index", async () => {
+    const first = builder.attest({ streamId: 1, request: {}, response: {} });
+    await verifier.accept(first);
+
+    // A seller re-serving an old nonce as a "new" call has to re-sign it,
+    // so this is a genuinely valid signature over a spent nonce.
+    const replay = builder.attest({
+      streamId: 1,
+      request: {},
+      response: {},
+      nonce: first.nonce,
+    });
+    expect((await verifier.accept(replay)).reason).toBe(Reason.NONCE_REUSED);
+  });
+
+  it("rejects a call index that does not advance", async () => {
+    await verifier.accept(builder.attest({ streamId: 1, request: {}, response: {}, callIndex: 5 }));
+    const stale = builder.attest({ streamId: 1, request: {}, response: {}, callIndex: 3 });
+    expect((await verifier.accept(stale)).reason).toBe(Reason.INDEX_NOT_MONOTONIC);
+  });
+
+  it("keeps nonce sets separate per stream", async () => {
+    const first = builder.attest({ streamId: 1, request: {}, response: {} });
+    await verifier.accept(first);
+
+    // Same nonce, different stream: a distinct signed message, and the streams
+    // do not share a replay set.
+    const other = builder.attest({ streamId: 2, request: {}, response: {}, nonce: first.nonce });
+    expect((await verifier.accept(other)).valid).toBe(true);
+  });
+
+  describe("checkSet", () => {
+    it("accepts a clean run", () => {
+      const result = verifier.checkSet(attestMany(builder, 1, 20), {
+        signer: SELLER.publicKey(),
+        streamId: 1,
+      });
+      expect(result.valid).toBe(true);
+      expect(result.firstInvalidIndex).toBeNull();
+    });
+
+    it("pinpoints the first forged member", () => {
+      const set = attestMany(builder, 1, 10);
+      set[6] = { ...set[6], signature: "ff".repeat(64) };
+
+      const result = verifier.checkSet(set, { signer: SELLER.publicKey(), streamId: 1 });
+      expect(result.valid).toBe(false);
+      expect(result.firstInvalidIndex).toBe(6);
+      expect(result.results[6].reason).toBe(Reason.BAD_SIGNATURE);
+      expect(result.results[5].valid).toBe(true);
+    });
+
+    it("catches a nonce repeated inside one set, without any store", () => {
+      const set = attestMany(builder, 1, 5);
+      set[3] = builder.attest({
+        streamId: 1,
+        request: {},
+        response: {},
+        callIndex: 3,
+        nonce: set[0].nonce,
+      });
+
+      const result = verifier.checkSet(set, { signer: SELLER.publicKey(), streamId: 1 });
+      expect(result.results[3].reason).toBe(Reason.NONCE_REUSED);
+    });
+  });
+});
+
+describe("MerkleBatchBuilder", () => {
+  let builder;
+
+  beforeEach(() => {
+    builder = newBuilder();
+  });
+
+  // Sizes cover a perfect tree, both odd-tail shapes, and the single-leaf case
+  // where the root is the leaf and the proof is empty.
+  it.each([1, 2, 3, 5, 8, 11, 50, 64])(
+    "produces a proof for every leaf in a batch of %i",
+    (size) => {
+      const attestations = attestMany(builder, 1, size);
+      const batch = MerkleBatchBuilder.build(attestations);
+
+      expect(batch.callCount).toBe(size);
+      attestations.forEach((attestation, position) => {
+        const proof = MerkleBatchBuilder.proofForPosition(batch, position);
+        expect(MerkleBatchBuilder.verifyProof(attestation, proof, batch.root)).toBe(true);
+      });
+    }
+  );
+
+  it("keeps proof length logarithmic in batch size", () => {
+    const batch = MerkleBatchBuilder.build(attestMany(builder, 1, 128));
+    expect(MerkleBatchBuilder.proofForPosition(batch, 0)).toHaveLength(7);
+  });
+
+  it("rejects a proof for a leaf that is not in the batch", () => {
+    const attestations = attestMany(builder, 1, 8);
+    const batch = MerkleBatchBuilder.build(attestations);
+    const outsider = newBuilder().attest({ streamId: 1, request: { other: true }, response: {} });
+
+    expect(
+      MerkleBatchBuilder.verifyProof(
+        outsider,
+        MerkleBatchBuilder.proofForPosition(batch, 3),
+        batch.root
+      )
+    ).toBe(false);
+  });
+
+  it("changes the root when any single leaf changes", () => {
+    const attestations = attestMany(builder, 1, 16);
+    const original = MerkleBatchBuilder.build(attestations).root;
+
+    const tampered = [...attestations];
+    tampered[9] = { ...tampered[9], response_hash: "de".repeat(32) };
+    expect(MerkleBatchBuilder.build(tampered).root).not.toBe(original);
+  });
+
+  it("addresses a leaf by call index as well as position", () => {
+    const attestations = attestMany(builder, 1, 10, 100);
+    const batch = MerkleBatchBuilder.build(attestations);
+
+    expect(batch.firstCallIndex).toBe(100);
+    expect(MerkleBatchBuilder.proofForCallIndex(batch, 104)).toEqual(
+      MerkleBatchBuilder.proofForPosition(batch, 4)
+    );
+  });
+
+  it("refuses a batch with a gap in its call indices", () => {
+    const attestations = attestMany(builder, 1, 5);
+    attestations.splice(2, 1);
+    // The contract turns call_index into a refundable position by subtracting
+    // first_call_index; a gap would make that arithmetic wrong.
+    expect(() => MerkleBatchBuilder.build(attestations)).toThrow(/contiguous/);
+  });
+
+  it("refuses a batch that mixes streams", () => {
+    const attestations = [
+      builder.attest({ streamId: 1, request: {}, response: {} }),
+      builder.attest({ streamId: 2, request: {}, response: {}, callIndex: 1 }),
+    ];
+    expect(() => MerkleBatchBuilder.build(attestations)).toThrow(/mixes streams/);
+  });
+
+  it("refuses an empty batch", () => {
+    expect(() => MerkleBatchBuilder.build([])).toThrow(/at least one/);
+  });
+
+  describe("batch commitment signature", () => {
+    it("verifies under the signing key", () => {
+      const batch = MerkleBatchBuilder.build(attestMany(builder, 1, 20));
+      const commitment = MerkleBatchBuilder.signBatch(batch, SELLER);
+      expect(MerkleBatchBuilder.verifyBatchSignature(commitment, SELLER.publicKey())).toBe(true);
+    });
+
+    it("does not verify under any other key", () => {
+      const batch = MerkleBatchBuilder.build(attestMany(builder, 1, 20));
+      const commitment = MerkleBatchBuilder.signBatch(batch, SELLER);
+      expect(MerkleBatchBuilder.verifyBatchSignature(commitment, IMPOSTOR.publicKey())).toBe(false);
+    });
+
+    it("does not cover a different call count", () => {
+      const batch = MerkleBatchBuilder.build(attestMany(builder, 1, 20));
+      const commitment = MerkleBatchBuilder.signBatch(batch, SELLER);
+      // Inflating the count is the obvious over-billing move; the count is
+      // inside the signed bytes precisely so it fails here.
+      expect(
+        MerkleBatchBuilder.verifyBatchSignature(
+          { ...commitment, callCount: 200 },
+          SELLER.publicKey()
+        )
+      ).toBe(false);
+    });
+
+    it("does not carry across streams", () => {
+      const batch = MerkleBatchBuilder.build(attestMany(builder, 1, 20));
+      const commitment = MerkleBatchBuilder.signBatch(batch, SELLER);
+      expect(
+        MerkleBatchBuilder.verifyBatchSignature({ ...commitment, streamId: 99 }, SELLER.publicKey())
+      ).toBe(false);
+    });
+  });
+});

--- a/backend/src/__tests__/attestation/attestationE2E.test.js
+++ b/backend/src/__tests__/attestation/attestationE2E.test.js
@@ -1,0 +1,426 @@
+/**
+ * End-to-end attestation flow.
+ *
+ * The scenarios the acceptance criteria name, run against the real
+ * AttestationArchive over an in-memory repository (see
+ * helpers/memoryAttestationRepo.js — the SQL has its own suite):
+ *
+ *   1. a seller attests 50 calls, batches them into a Merkle root, and the
+ *      buyer independently verifies every attestation against the archive and
+ *      the committed root;
+ *   2. a forged attestation inside a batch is identified, and the proof needed
+ *      to void it on-chain is producible;
+ *   3. a nonce replayed across two different batches is rejected.
+ *
+ * "Independently" is the load-bearing word: the buyer path below never reads a
+ * verdict the backend computed, only the bytes it stored.
+ */
+
+const { Keypair } = require("@stellar/stellar-sdk");
+const AttestationBuilder = require("../../attestation/AttestationBuilder");
+const AttestationVerifier = require("../../attestation/AttestationVerifier");
+const AttestationArchive = require("../../attestation/AttestationArchive");
+const MerkleBatchBuilder = require("../../attestation/MerkleBatchBuilder");
+const { createMemoryAttestationRepo } = require("../helpers/memoryAttestationRepo");
+
+const { Reason } = AttestationVerifier;
+
+const SELLER = Keypair.fromRawEd25519Seed(Buffer.alloc(32, 3));
+const IMPOSTOR = Keypair.fromRawEd25519Seed(Buffer.alloc(32, 4));
+const STREAM_ID = 4242;
+
+/** A backend: archive, repository, and the verifier the metering path uses. */
+function newBackend() {
+  const repository = createMemoryAttestationRepo();
+  const verifier = new AttestationVerifier({
+    ...repository.createStores(),
+    now: () => 1_700_100_000,
+  });
+  return { repository, verifier, archive: new AttestationArchive({ repository, verifier }) };
+}
+
+function newSeller() {
+  return new AttestationBuilder({ signer: SELLER, now: () => 1_700_000_000 });
+}
+
+/**
+ * One metered call, exactly as MeteringEngine runs it: verify the seller's
+ * attestation, then archive it. Returns the verifier's verdict.
+ */
+async function meter(backend, attestation) {
+  const result = await backend.verifier.accept(attestation, {
+    signer: SELLER.publicKey(),
+    streamId: STREAM_ID,
+  });
+  if (result.valid) {
+    await backend.archive.archive({ ...attestation, signer: SELLER.publicKey() });
+  }
+  return result;
+}
+
+/** Commit the pending tail, mimicking the on-chain record_usage_batch. */
+async function commit(backend, onChainBatchId) {
+  const built = await backend.archive.buildBatch(STREAM_ID, { signer: SELLER });
+  await backend.archive.markRecorded(built.batch.id, {
+    batchId: onChainBatchId,
+    txHash: `tx-${onChainBatchId}`,
+  });
+  return built;
+}
+
+describe("attestation end-to-end", () => {
+  describe("50 attested calls, batched and independently verified", () => {
+    let backend;
+    let built;
+
+    beforeEach(async () => {
+      backend = newBackend();
+      const seller = newSeller();
+
+      for (let i = 0; i < 50; i++) {
+        const attestation = seller.attest({
+          streamId: STREAM_ID,
+          request: { query: `q-${i}` },
+          response: { answer: `a-${i}` },
+        });
+        const result = await meter(backend, attestation);
+        expect(result.valid).toBe(true);
+      }
+
+      built = await commit(backend, 1);
+    });
+
+    it("commits all 50 calls under one root", () => {
+      expect(built.batch.callCount).toBe(50);
+      expect(built.batch.firstCallIndex).toBe(0);
+      expect(built.batch.lastCallIndex).toBe(49);
+      expect(built.batch.merkleRoot).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("lets a buyer re-derive the committed root from the archive alone", async () => {
+      const { leaves } = await backend.archive.loadBatch(STREAM_ID, 1);
+      const attestations = leaves.map(AttestationArchive.toWireAttestation);
+
+      // The buyer rebuilds the tree from scratch. Nothing here reads the stored
+      // root except the final comparison.
+      const rebuilt = MerkleBatchBuilder.build(attestations);
+      expect(rebuilt.root).toBe(built.batch.merkleRoot);
+    });
+
+    it("lets a buyer verify all 50 signatures and all 50 proofs without the backend's opinion", async () => {
+      const { leaves } = await backend.archive.loadBatch(STREAM_ID, 1);
+      const attestations = leaves.map(AttestationArchive.toWireAttestation);
+      const rebuilt = MerkleBatchBuilder.build(attestations);
+      const buyerVerifier = new AttestationVerifier({ now: () => 1_700_100_000 });
+
+      expect(attestations).toHaveLength(50);
+      attestations.forEach((attestation, position) => {
+        expect(
+          buyerVerifier.check(attestation, {
+            signer: SELLER.publicKey(),
+            streamId: STREAM_ID,
+          }).valid
+        ).toBe(true);
+
+        const proof = MerkleBatchBuilder.proofForPosition(rebuilt, position);
+        expect(MerkleBatchBuilder.verifyProof(attestation, proof, built.batch.merkleRoot)).toBe(
+          true
+        );
+      });
+    });
+
+    it("reports a clean audit", async () => {
+      const audit = await backend.archive.audit(STREAM_ID, 1);
+      expect(audit).toMatchObject({
+        found: true,
+        valid: true,
+        reason: null,
+        rootMatches: true,
+        commitmentValid: true,
+        firstInvalidIndex: null,
+      });
+    });
+
+    it("catches a backend that tampers with an archived leaf after the fact", async () => {
+      // The archive is untrusted storage: rewriting a stored response hash
+      // breaks both the signature and the root, and the buyer sees it.
+      backend.repository._tamper(STREAM_ID, 20, { response_hash: "de".repeat(32) });
+
+      const audit = await backend.archive.audit(STREAM_ID, 1);
+      expect(audit.valid).toBe(false);
+      expect(audit.rootMatches).toBe(false);
+      expect(audit.leafResults[20].reason).toBe(Reason.BAD_SIGNATURE);
+    });
+
+    it("produces a usable proof for every call in the batch", async () => {
+      for (const callIndex of [0, 17, 49]) {
+        const proof = await backend.archive.getProof(STREAM_ID, 1, callIndex);
+        expect(proof.rootMatches).toBe(true);
+        expect(proof.verdict.valid).toBe(true);
+        expect(MerkleBatchBuilder.verifyProof(proof.attestation, proof.proof, proof.root)).toBe(
+          true
+        );
+      }
+    });
+  });
+
+  describe("a forged attestation inside a batch", () => {
+    let backend;
+    let built;
+    const FORGED_AT = 6;
+
+    beforeEach(async () => {
+      backend = newBackend();
+      const seller = newSeller();
+
+      // Ten calls, of which one was never actually signed by the seller — the
+      // shape of a backend or seller padding the bill.
+      for (let i = 0; i < 10; i++) {
+        const attestation = seller.attest({
+          streamId: STREAM_ID,
+          request: { q: i },
+          response: { a: i },
+        });
+
+        if (i === FORGED_AT) {
+          // Metering rejects it, so the fabrication has to be written straight
+          // into the archive — exactly what a compromised backend would do.
+          const forged = { ...attestation, signature: "ab".repeat(64) };
+          expect((await meter(backend, forged)).reason).toBe(Reason.BAD_SIGNATURE);
+          await backend.repository.burnNonce(STREAM_ID, forged.nonce, forged.call_index);
+          await backend.archive.archive({ ...forged, signer: SELLER.publicKey() });
+        } else {
+          expect((await meter(backend, attestation)).valid).toBe(true);
+        }
+      }
+
+      built = await commit(backend, 1);
+    });
+
+    it("is refused at metering time", async () => {
+      // Restated directly: the honest path never credits it.
+      const seller = newSeller();
+      const attestation = seller.attest({ streamId: STREAM_ID, request: {}, response: {} });
+      const result = await backend.verifier.accept(
+        { ...attestation, signature: "cd".repeat(64) },
+        { signer: SELLER.publicKey(), streamId: STREAM_ID }
+      );
+      expect(result.valid).toBe(false);
+      expect(result.reason).toBe(Reason.BAD_SIGNATURE);
+    });
+
+    it("is identified by the buyer's audit, at the right position", async () => {
+      const audit = await backend.archive.audit(STREAM_ID, 1);
+
+      expect(audit.valid).toBe(false);
+      expect(audit.reason).toBe(Reason.BAD_SIGNATURE);
+      expect(audit.firstInvalidIndex).toBe(FORGED_AT);
+      expect(audit.disputableCallIndex).toBe(FORGED_AT);
+      // Its neighbours are untouched — the batch is not wholesale bad.
+      expect(audit.leafResults[FORGED_AT - 1].valid).toBe(true);
+      expect(audit.leafResults[FORGED_AT + 1].valid).toBe(true);
+    });
+
+    it("still sits under the committed root, so the challenge is provable", async () => {
+      // The seller committed to the forgery. That is the whole point: they
+      // cannot now disown it, and the Merkle proof pins it to their root.
+      const proof = await backend.archive.getProof(STREAM_ID, 1, FORGED_AT);
+
+      expect(proof.rootMatches).toBe(true);
+      expect(MerkleBatchBuilder.verifyProof(proof.attestation, proof.proof, proof.root)).toBe(true);
+      expect(proof.verdict.valid).toBe(false);
+      expect(proof.verdict.provableOnChain).toBe(true);
+    });
+
+    it("prices the void as the suffix from the forged call to the end of the batch", async () => {
+      const proof = await backend.archive.getProof(STREAM_ID, 1, FORGED_AT);
+
+      // Positions 6..9 — matches challenge_usage_batch's arithmetic exactly, so
+      // the UI can show the refund before the buyer pays for the transaction.
+      expect(proof.position).toBe(6);
+      expect(proof.voidableCalls).toBe(4);
+    });
+
+    it("mirrors the on-chain void back into the archive", async () => {
+      const voided = await backend.archive.markVoided(built.batch.id, {
+        voidedCalls: 4,
+        refundedAmount: 4000,
+        txHash: "tx-challenge",
+      });
+
+      // Four of ten: challenged, not voided outright.
+      expect(voided.status).toBe("challenged");
+      expect(voided.voidedCalls).toBe(4);
+    });
+
+    it("marks a batch fully voided when the forgery is its first call", async () => {
+      const fresh = newBackend();
+      const seller = newSeller();
+      const forged = { ...seller.attest({ streamId: STREAM_ID, request: {}, response: {} }),
+        signature: "ab".repeat(64) };
+      await fresh.archive.archive({ ...forged, signer: SELLER.publicKey() });
+      for (let i = 1; i < 5; i++) {
+        await meter(fresh, seller.attest({ streamId: STREAM_ID, request: { i }, response: { i } }));
+      }
+      const freshBuilt = await commit(fresh, 1);
+
+      const proof = await fresh.archive.getProof(STREAM_ID, 1, 0);
+      expect(proof.voidableCalls).toBe(5);
+
+      const voided = await fresh.archive.markVoided(freshBuilt.batch.id, {
+        voidedCalls: 5,
+        refundedAmount: 5000,
+      });
+      expect(voided.status).toBe("voided");
+    });
+  });
+
+  describe("a nonce replayed across two different batches", () => {
+    let backend;
+    let firstBatchNonce;
+
+    beforeEach(async () => {
+      backend = newBackend();
+      const seller = newSeller();
+
+      for (let i = 0; i < 4; i++) {
+        const attestation = seller.attest({
+          streamId: STREAM_ID,
+          request: { q: i },
+          response: { a: i },
+        });
+        if (i === 0) firstBatchNonce = attestation.nonce;
+        expect((await meter(backend, attestation)).valid).toBe(true);
+      }
+
+      await commit(backend, 1);
+    });
+
+    it("is rejected when the nonce reappears in a later batch", async () => {
+      const seller = newSeller();
+      seller.seed(STREAM_ID, 3);
+
+      // Honestly signed, freshly indexed, and still fraudulent: the nonce was
+      // already spent, in a batch that is already committed on-chain.
+      const replay = seller.attest({
+        streamId: STREAM_ID,
+        request: { q: "replayed" },
+        response: { a: "replayed" },
+        nonce: firstBatchNonce,
+      });
+
+      const result = await meter(backend, replay);
+      expect(result.valid).toBe(false);
+      expect(result.reason).toBe(Reason.NONCE_REUSED);
+      expect(result.provableOnChain).toBe(true);
+    });
+
+    it("keeps the replay protection across a process restart", async () => {
+      // A fresh verifier over the same durable stores — the replay set lives in
+      // the repository, not in one process's memory.
+      const restarted = new AttestationVerifier({
+        ...backend.repository.createStores(),
+        now: () => 1_700_100_000,
+      });
+
+      const seller = newSeller();
+      seller.seed(STREAM_ID, 3);
+      const replay = seller.attest({
+        streamId: STREAM_ID,
+        request: {},
+        response: {},
+        nonce: firstBatchNonce,
+      });
+
+      const result = await restarted.accept(replay, {
+        signer: SELLER.publicKey(),
+        streamId: STREAM_ID,
+      });
+      expect(result.reason).toBe(Reason.NONCE_REUSED);
+    });
+
+    it("is caught by the buyer's audit when a compromised backend archives it anyway", async () => {
+      const seller = newSeller();
+      seller.seed(STREAM_ID, 3);
+      const replay = seller.attest({
+        streamId: STREAM_ID,
+        request: {},
+        response: {},
+        nonce: firstBatchNonce,
+      });
+
+      // Written past the verifier, then batched and committed.
+      await backend.archive.archive({ ...replay, signer: SELLER.publicKey() });
+      for (let i = 5; i < 8; i++) {
+        const attestation = seller.attest({ streamId: STREAM_ID, request: { i }, response: { i } });
+        await meter(backend, attestation);
+      }
+      await commit(backend, 2);
+
+      // Within the second batch every leaf is individually well-signed, so the
+      // batch audits clean in isolation — the duplication is only visible
+      // against the first batch. That is precisely why the contract's
+      // replay challenge takes two committed leaves and two proofs.
+      const audit = await backend.archive.audit(STREAM_ID, 2);
+      expect(audit.rootMatches).toBe(true);
+
+      const original = await backend.archive.getProof(STREAM_ID, 1, 0);
+      const duplicate = await backend.archive.getProof(STREAM_ID, 2, 4);
+
+      expect(original.attestation.nonce).toBe(duplicate.attestation.nonce);
+      expect(original.attestation.call_index).toBeLessThan(duplicate.attestation.call_index);
+      // Both are provably committed, which is the whole evidentiary package
+      // challenge_nonce_replay needs.
+      expect(original.rootMatches).toBe(true);
+      expect(duplicate.rootMatches).toBe(true);
+      // The later batch loses its suffix from the replayed call onward.
+      expect(duplicate.voidableCalls).toBe(4);
+    });
+  });
+
+  describe("batch assembly", () => {
+    it("stops at a gap rather than committing across it", async () => {
+      const backend = newBackend();
+      const seller = newSeller();
+
+      for (let i = 0; i < 6; i++) {
+        const attestation = seller.attest({ streamId: STREAM_ID, request: { i }, response: { i } });
+        // Call 3 is rejected and never archived, leaving a hole.
+        if (i !== 3) await meter(backend, attestation);
+      }
+
+      const built = await backend.archive.buildBatch(STREAM_ID, { signer: SELLER });
+      expect(built.batch.callCount).toBe(3);
+      expect(built.batch.lastCallIndex).toBe(2);
+
+      // The tail past the gap waits for its own batch.
+      const next = await backend.archive.buildBatch(STREAM_ID, { signer: SELLER });
+      expect(next.batch.firstCallIndex).toBe(4);
+      expect(next.batch.callCount).toBe(2);
+    });
+
+    it("refuses a batch commitment signed by the wrong key", async () => {
+      const backend = newBackend();
+      const seller = newSeller();
+      for (let i = 0; i < 3; i++) {
+        await meter(backend, seller.attest({ streamId: STREAM_ID, request: { i }, response: { i } }));
+      }
+
+      const prepared = await backend.archive.prepareBatch(STREAM_ID);
+      const forged = MerkleBatchBuilder.signBatch(prepared.tree, IMPOSTOR);
+
+      await expect(
+        backend.archive.commitBatch(STREAM_ID, prepared.tree, {
+          seller: SELLER.publicKey(),
+          batchSignature: forged.batchSignature,
+        })
+      ).rejects.toThrow(/does not verify/);
+    });
+
+    it("returns nothing when there is nothing to batch", async () => {
+      const backend = newBackend();
+      expect(await backend.archive.prepareBatch(STREAM_ID)).toBeNull();
+      expect(await backend.archive.buildBatch(STREAM_ID, { signer: SELLER })).toBeNull();
+    });
+  });
+});

--- a/backend/src/__tests__/helpers/memoryAttestationRepo.js
+++ b/backend/src/__tests__/helpers/memoryAttestationRepo.js
@@ -1,0 +1,177 @@
+/**
+ * In-memory stand-in for attestationRepository.
+ *
+ * The end-to-end attestation suite is about cryptography, not SQL: it needs to
+ * archive leaves, group them into batches, and read them back, and none of that
+ * is more truthful for having gone through Postgres. Backing it with a Map
+ * keeps the suite runnable without a container, so a broken hash or a broken
+ * proof fails fast rather than only in CI.
+ *
+ * The SQL itself is covered separately, against a real database, in
+ * __tests__/repositories/attestationRepository.test.js.
+ *
+ * Implements exactly the surface AttestationArchive uses, including the
+ * behaviours it depends on: `recordLeaf` is idempotent on
+ * (stream_id, call_index) and returns null on conflict, and `burnNonce`
+ * returns false when the nonce was already spent.
+ */
+
+function createMemoryAttestationRepo() {
+  const leaves = []; // ordered by insertion
+  const batches = [];
+  const nonces = new Map(); // `${streamId}:${nonce}` -> callIndex
+  let nextLeafId = 1;
+  let nextBatchId = 1;
+
+  const byStream = (streamId) => leaves.filter((l) => l.stream_id === Number(streamId));
+
+  return {
+    async recordLeaf(leaf) {
+      const clash = leaves.find(
+        (l) => l.stream_id === Number(leaf.stream_id) && l.call_index === Number(leaf.call_index)
+      );
+      if (clash) return null;
+
+      const stored = {
+        ...leaf,
+        stream_id: Number(leaf.stream_id),
+        call_index: Number(leaf.call_index),
+        id: nextLeafId++,
+        batchRef: null,
+        verifyReason: leaf.verifyReason || "OK",
+      };
+      leaves.push(stored);
+      return stored;
+    },
+
+    async findUnbatchedLeaves(streamId, limit = 100) {
+      return byStream(streamId)
+        .filter((l) => l.batchRef === null)
+        .sort((a, b) => a.call_index - b.call_index)
+        .slice(0, limit);
+    },
+
+    async findLeavesByBatchRef(batchRef) {
+      return leaves
+        .filter((l) => l.batchRef === batchRef)
+        .sort((a, b) => a.call_index - b.call_index);
+    },
+
+    async findLeafByCallIndex(streamId, callIndex) {
+      return (
+        byStream(streamId).find((l) => l.call_index === Number(callIndex)) ?? null
+      );
+    },
+
+    async attachLeavesToBatch(batchRef, streamId, first, last) {
+      const claimed = byStream(streamId).filter(
+        (l) => l.batchRef === null && l.call_index >= first && l.call_index <= last
+      );
+      claimed.forEach((l) => {
+        l.batchRef = batchRef;
+      });
+      return claimed.length;
+    },
+
+    async burnNonce(streamId, nonce, callIndex) {
+      const key = `${streamId}:${nonce}`;
+      if (nonces.has(key)) return false;
+      nonces.set(key, callIndex);
+      return true;
+    },
+
+    async isNonceUsed(streamId, nonce) {
+      return nonces.has(`${streamId}:${nonce}`);
+    },
+
+    async highestCallIndex(streamId) {
+      const seen = [...nonces.entries()]
+        .filter(([key]) => key.startsWith(`${streamId}:`))
+        .map(([, callIndex]) => callIndex);
+      return seen.length ? Math.max(...seen) : null;
+    },
+
+    async createBatch(batch) {
+      const stored = {
+        ...batch,
+        streamId: Number(batch.streamId),
+        id: nextBatchId++,
+        batchId: null,
+        status: "pending",
+        voidedCalls: 0,
+        refundedAmount: 0,
+        txHash: null,
+        createdAt: Date.now(),
+      };
+      batches.push(stored);
+      return stored;
+    },
+
+    async markRecorded(id, { batchId, txHash }) {
+      const batch = batches.find((b) => b.id === id);
+      if (!batch) return null;
+      Object.assign(batch, { batchId: Number(batchId), txHash: txHash ?? null, status: "recorded" });
+      return batch;
+    },
+
+    async markVoided(id, { voidedCalls, refundedAmount, txHash }) {
+      const batch = batches.find((b) => b.id === id);
+      if (!batch) return null;
+      Object.assign(batch, {
+        voidedCalls,
+        refundedAmount,
+        txHash: txHash ?? batch.txHash,
+        status: voidedCalls >= batch.callCount ? "voided" : "challenged",
+      });
+      return batch;
+    },
+
+    async findBatchById(id) {
+      return batches.find((b) => b.id === id) ?? null;
+    },
+
+    async findBatchByOnChainId(streamId, batchId) {
+      return (
+        batches.find(
+          (b) => b.streamId === Number(streamId) && b.batchId === Number(batchId)
+        ) ?? null
+      );
+    },
+
+    async findBatchesByStream(streamId) {
+      const data = batches
+        .filter((b) => b.streamId === Number(streamId))
+        .sort((a, b) => b.id - a.id);
+      return { data, meta: { total: data.length, page: 1, limit: 20, pages: 1 } };
+    },
+
+    async findPendingBatches(limit = 50) {
+      return batches.filter((b) => b.status === "pending").slice(0, limit);
+    },
+
+    createStores() {
+      return {
+        nonceStore: {
+          has: (streamId, nonce) => this.isNonceUsed(streamId, nonce),
+          add: (streamId, nonce, _client, callIndex) =>
+            this.burnNonce(streamId, nonce, callIndex),
+        },
+        indexStore: {
+          highest: (streamId) => this.highestCallIndex(streamId),
+          set: async () => {},
+        },
+      };
+    },
+
+    /** Test-only: reach in and corrupt an archived leaf. */
+    _tamper(streamId, callIndex, patch) {
+      const leaf = byStream(streamId).find((l) => l.call_index === Number(callIndex));
+      Object.assign(leaf, patch);
+      return leaf;
+    },
+
+    _raw: { leaves, batches, nonces },
+  };
+}
+
+module.exports = { createMemoryAttestationRepo };

--- a/backend/src/__tests__/helpers/testDb.js
+++ b/backend/src/__tests__/helpers/testDb.js
@@ -14,7 +14,8 @@ async function truncateAll() {
   await query(
     `TRUNCATE TABLE reports, licenses, events_log, event_cursor, streams, agents, assets,
        admin_actions, agent_bans, contract_state, dispute_votes, disputes, agent_stakes,
-       usage_events, fraud_signals, agent_funding_sources
+       usage_events, fraud_signals, agent_funding_sources,
+       attestation_leaves, attestation_batches, used_nonces
      RESTART IDENTITY CASCADE`
   );
   await query("DELETE FROM replica_heartbeat");

--- a/backend/src/__tests__/protocol.test.js
+++ b/backend/src/__tests__/protocol.test.js
@@ -13,6 +13,7 @@ const {
 const QuoteManager = require("../protocol/QuoteManager");
 const StreamNegotiator = require("../protocol/StreamNegotiator");
 const MeteringEngine = require("../protocol/MeteringEngine");
+const AttestationBuilder = require("../attestation/AttestationBuilder");
 const StreamMonitor = require("../protocol/StreamMonitor");
 const BatchSettler = require("../protocol/BatchSettler");
 const CortexAgentSDK = require("../sdk/CortexAgentSDK");
@@ -93,7 +94,13 @@ describe("Agent Payment Protocol - QuoteManager", () => {
 describe("Agent Payment Protocol - MeteringEngine Concurrency", () => {
   it("is atomic under concurrent requests (race condition test)", async () => {
     const buyer = OWNER_A;
-    const recipient = OWNER_B;
+    // Metering now requires a seller-signed attestation per call, so the
+    // recipient has to be a key this test can actually sign with rather than a
+    // fixture address. A Stellar G... address *is* the Ed25519 key the
+    // attestation is verified against, so recipient and signer are the same
+    // thing.
+    const sellerKeypair = Keypair.random();
+    const recipient = sellerKeypair.publicKey();
     const pricePerCall = 1000;
 
     // Create a stream row with exactly 5 remaining calls
@@ -115,10 +122,18 @@ describe("Agent Payment Protocol - MeteringEngine Concurrency", () => {
 
     const token = StreamNegotiator.issueStreamToken(stream, pricePerCall);
 
-    // Make 10 concurrent requests to MeteringEngine.meterCall
+    // Make 10 concurrent requests to MeteringEngine.meterCall, each carrying
+    // its own attestation. Distinct call indices and nonces mean the race is
+    // still decided by the stream's call budget, not by replay protection.
+    const attestationBuilder = new AttestationBuilder({ signer: sellerKeypair });
     const promises = [];
     for (let i = 0; i < 10; i++) {
-      promises.push(MeteringEngine.meterCall(token).catch((err) => err));
+      const attestation = attestationBuilder.attest({
+        streamId: 12345,
+        request: { i },
+        response: { i },
+      });
+      promises.push(MeteringEngine.meterCall(token, { attestation }).catch((err) => err));
     }
 
     const results = await Promise.all(promises);

--- a/backend/src/__tests__/repositories/attestationRepository.test.js
+++ b/backend/src/__tests__/repositories/attestationRepository.test.js
@@ -1,0 +1,222 @@
+/**
+ * attestationRepository against a real PostgreSQL instance.
+ *
+ * The crypto is covered without a database in __tests__/attestation; what needs
+ * a real server is everything the schema promises rather than the JavaScript:
+ * the uniqueness constraints that make replay protection race-safe, the CHECK
+ * constraints on the hex columns, and the partial indexes the batch queries
+ * lean on.
+ */
+
+const attestationRepository = require("../../repositories/attestationRepository");
+const { truncateAll, closePool } = require("../helpers/testDb");
+
+const STREAM_ID = 900;
+const SELLER = "GD226Q4QUIIDFBQ7TWPTP4UT4TKPX2MQRVEJSFMMCSM6ORDCPNZPPKCT";
+
+const hex = (byte, bytes = 32) => byte.toString(16).padStart(2, "0").repeat(bytes);
+
+function buildLeaf(callIndex, overrides = {}) {
+  return {
+    stream_id: STREAM_ID,
+    call_index: callIndex,
+    request_hash: hex(callIndex),
+    response_hash: hex(callIndex + 100),
+    timestamp: 1_700_000_000 + callIndex,
+    nonce: hex(callIndex + 1),
+    signature: hex(callIndex, 64),
+    signer: SELLER,
+    leaf_hash: hex(callIndex + 200),
+    ...overrides,
+  };
+}
+
+function buildBatch(overrides = {}) {
+  return {
+    streamId: STREAM_ID,
+    seller: SELLER,
+    merkleRoot: hex(0xab),
+    callCount: 5,
+    firstCallIndex: 0,
+    lastCallIndex: 4,
+    batchSignature: hex(0xcd, 64),
+    ...overrides,
+  };
+}
+
+describe("attestationRepository", () => {
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  afterAll(async () => {
+    await closePool();
+  });
+
+  describe("leaves", () => {
+    it("archives a leaf and reads it back in the crypto layer's shape", async () => {
+      await attestationRepository.recordLeaf(buildLeaf(0));
+
+      const found = await attestationRepository.findLeafByCallIndex(STREAM_ID, 0);
+      // Signed fields keep their wire names so they can go straight back into
+      // the hasher without a rename step.
+      expect(found).toMatchObject({
+        stream_id: STREAM_ID,
+        call_index: 0,
+        signer: SELLER,
+        timestamp: 1_700_000_000,
+      });
+    });
+
+    it("is idempotent on (stream_id, call_index)", async () => {
+      expect(await attestationRepository.recordLeaf(buildLeaf(0))).not.toBeNull();
+      // A retried metering request must not create a second leaf, and must not
+      // blow up either — the caller distinguishes the cases by the null.
+      expect(await attestationRepository.recordLeaf(buildLeaf(0))).toBeNull();
+
+      const unbatched = await attestationRepository.findUnbatchedLeaves(STREAM_ID);
+      expect(unbatched).toHaveLength(1);
+    });
+
+    it("rejects a malformed hash at the schema level", async () => {
+      await expect(
+        attestationRepository.recordLeaf(buildLeaf(0, { nonce: "not-hex" }))
+      ).rejects.toThrow();
+    });
+
+    it("returns the un-batched tail in call order", async () => {
+      for (const i of [2, 0, 1]) await attestationRepository.recordLeaf(buildLeaf(i));
+
+      const tail = await attestationRepository.findUnbatchedLeaves(STREAM_ID);
+      expect(tail.map((l) => l.call_index)).toEqual([0, 1, 2]);
+    });
+  });
+
+  describe("nonces", () => {
+    it("burns a nonce once and refuses it thereafter", async () => {
+      expect(await attestationRepository.burnNonce(STREAM_ID, hex(1), 0)).toBe(true);
+      // The unique constraint is what makes this safe under concurrency: two
+      // simultaneous metering transactions cannot both win.
+      expect(await attestationRepository.burnNonce(STREAM_ID, hex(1), 1)).toBe(false);
+      expect(await attestationRepository.isNonceUsed(STREAM_ID, hex(1))).toBe(true);
+    });
+
+    it("keeps nonce sets separate per stream", async () => {
+      await attestationRepository.burnNonce(STREAM_ID, hex(1), 0);
+      expect(await attestationRepository.burnNonce(STREAM_ID + 1, hex(1), 0)).toBe(true);
+    });
+
+    it("reports the highest spent index, so a restart resumes cleanly", async () => {
+      expect(await attestationRepository.highestCallIndex(STREAM_ID)).toBeNull();
+
+      await attestationRepository.burnNonce(STREAM_ID, hex(1), 4);
+      await attestationRepository.burnNonce(STREAM_ID, hex(2), 9);
+      expect(await attestationRepository.highestCallIndex(STREAM_ID)).toBe(9);
+    });
+  });
+
+  describe("batches", () => {
+    it("creates a batch pending, then binds it to its on-chain id", async () => {
+      const created = await attestationRepository.createBatch(buildBatch());
+      expect(created).toMatchObject({ status: "pending", batchId: null });
+
+      const recorded = await attestationRepository.markRecorded(created.id, {
+        batchId: 7,
+        txHash: "abc123",
+      });
+      expect(recorded).toMatchObject({ status: "recorded", batchId: 7, txHash: "abc123" });
+      expect(recorded.recordedAt).toEqual(expect.any(Number));
+    });
+
+    it("rejects a batch whose index range contradicts its call count", async () => {
+      // The contract derives a refund from (call_index - first_call_index)
+      // against call_count; a row where those disagree would misprice a void.
+      await expect(
+        attestationRepository.createBatch(buildBatch({ lastCallIndex: 99 }))
+      ).rejects.toThrow();
+    });
+
+    it("claims exactly the leaves in the committed range", async () => {
+      for (let i = 0; i < 8; i++) await attestationRepository.recordLeaf(buildLeaf(i));
+      const batch = await attestationRepository.createBatch(
+        buildBatch({ callCount: 5, firstCallIndex: 0, lastCallIndex: 4 })
+      );
+
+      const claimed = await attestationRepository.attachLeavesToBatch(batch.id, STREAM_ID, 0, 4);
+      expect(claimed).toBe(5);
+
+      expect(await attestationRepository.findLeavesByBatchRef(batch.id)).toHaveLength(5);
+      // Leaves past the range stay available for the next batch.
+      expect(await attestationRepository.findUnbatchedLeaves(STREAM_ID)).toHaveLength(3);
+    });
+
+    it("finds a batch by the id the contract assigned it", async () => {
+      const created = await attestationRepository.createBatch(buildBatch());
+      await attestationRepository.markRecorded(created.id, { batchId: 3, txHash: null });
+
+      const found = await attestationRepository.findBatchByOnChainId(STREAM_ID, 3);
+      expect(found.id).toBe(created.id);
+    });
+
+    it("marks a partially voided batch challenged and a fully voided one voided", async () => {
+      const partial = await attestationRepository.createBatch(buildBatch());
+      const challenged = await attestationRepository.markVoided(partial.id, {
+        voidedCalls: 2,
+        refundedAmount: 2000,
+        txHash: "tx-1",
+      });
+      expect(challenged).toMatchObject({ status: "challenged", voidedCalls: 2 });
+
+      const full = await attestationRepository.markVoided(partial.id, {
+        voidedCalls: 5,
+        refundedAmount: 5000,
+        txHash: "tx-2",
+      });
+      expect(full.status).toBe("voided");
+    });
+
+    it("refuses to void more calls than the batch contains", async () => {
+      const batch = await attestationRepository.createBatch(buildBatch());
+      await expect(
+        attestationRepository.markVoided(batch.id, { voidedCalls: 6, refundedAmount: 0 })
+      ).rejects.toThrow();
+    });
+
+    it("pages a stream's batches newest first", async () => {
+      for (let i = 0; i < 3; i++) {
+        await attestationRepository.createBatch(
+          buildBatch({ firstCallIndex: i * 5, lastCallIndex: i * 5 + 4 })
+        );
+      }
+
+      const page = await attestationRepository.findBatchesByStream(STREAM_ID, { page: 1, limit: 2 });
+      expect(page.data).toHaveLength(2);
+      expect(page.meta.total).toBe(3);
+      expect(page.data[0].firstCallIndex).toBe(10);
+    });
+
+    it("lists only pending batches for the submitter", async () => {
+      const first = await attestationRepository.createBatch(buildBatch());
+      await attestationRepository.createBatch(
+        buildBatch({ firstCallIndex: 5, lastCallIndex: 9 })
+      );
+      await attestationRepository.markRecorded(first.id, { batchId: 1, txHash: null });
+
+      const pending = await attestationRepository.findPendingBatches();
+      expect(pending).toHaveLength(1);
+      expect(pending[0].firstCallIndex).toBe(5);
+    });
+  });
+
+  describe("createStores", () => {
+    it("gives the verifier durable replay protection", async () => {
+      const { nonceStore, indexStore } = attestationRepository.createStores();
+
+      expect(await nonceStore.has(STREAM_ID, hex(1))).toBe(false);
+      await nonceStore.add(STREAM_ID, hex(1), undefined, 3);
+      expect(await nonceStore.has(STREAM_ID, hex(1))).toBe(true);
+      // The high-water mark rides on the nonce row, so no extra write.
+      expect(await indexStore.highest(STREAM_ID)).toBe(3);
+    });
+  });
+});

--- a/backend/src/attestation/AttestationArchive.js
+++ b/backend/src/attestation/AttestationArchive.js
@@ -1,0 +1,363 @@
+/**
+ * AttestationArchive — the off-chain half of the commitment.
+ *
+ * On-chain a batch is 32 bytes. That is enough to *detect* a lie but not enough
+ * to *prove* one: to challenge a batch a buyer needs the actual attestations
+ * that went into it, plus the sibling hashes linking the disputed one to the
+ * committed root. This module stores those sets and serves them back.
+ *
+ * The archive is deliberately untrusted. Every leaf it returns carries the
+ * seller's signature over its own contents, and `audit()` re-derives the root
+ * from scratch rather than believing the stored `merkle_root`. A backend that
+ * tampered with an archived row would produce a set whose recomputed root no
+ * longer matches what is on-chain — which is exactly the failure the buyer is
+ * checking for, and it is indistinguishable from a lying seller. Either way the
+ * buyer learns not to trust the batch, which is the property we wanted.
+ */
+
+const attestationRepository = require("../repositories/attestationRepository");
+const AttestationVerifier = require("./AttestationVerifier");
+const MerkleBatchBuilder = require("./MerkleBatchBuilder");
+const { batchCommitmentMessage, leafHash } = require("./canonical");
+const { logger } = require("../utils/logger");
+
+/** Default ceiling on batch size — keeps a proof at 7 hashes or fewer. */
+const DEFAULT_MAX_BATCH = 128;
+
+/**
+ * Strip an archived leaf down to exactly the signed fields plus signature.
+ * Passing the repository's extra bookkeeping keys into the hasher would be
+ * harmless (the encoder reads named fields) but returning them to a buyer as
+ * "the attestation" invites them to think those fields are covered too.
+ */
+function toWireAttestation(leaf) {
+  return {
+    stream_id: leaf.stream_id,
+    call_index: leaf.call_index,
+    request_hash: leaf.request_hash,
+    response_hash: leaf.response_hash,
+    timestamp: leaf.timestamp,
+    nonce: leaf.nonce,
+    signature: leaf.signature,
+    signer: leaf.signer,
+  };
+}
+
+class AttestationArchive {
+  /**
+   * @param {object} [deps]
+   * @param {object} [deps.repository] - injectable for tests
+   * @param {AttestationVerifier} [deps.verifier]
+   */
+  constructor(deps = {}) {
+    this.repository = deps.repository || attestationRepository;
+    this.verifier = deps.verifier || new AttestationVerifier();
+  }
+
+  /**
+   * Archive one attestation. Idempotent on (stream_id, call_index).
+   *
+   * @param {object} attestation - as produced by AttestationBuilder
+   * @param {object} [options]
+   * @param {string} [options.verifyReason] - the verifier's verdict at metering
+   * @param {*} [options.client] - pg client to join the metering transaction
+   * @returns {object|null} the stored leaf, or null if it already existed
+   */
+  async archive(attestation, { verifyReason = "OK", client } = {}) {
+    return this.repository.recordLeaf(
+      {
+        ...attestation,
+        leaf_hash: attestation.leaf_hash || leafHash(attestation).toString("hex"),
+        verifyReason,
+      },
+      client
+    );
+  }
+
+  /**
+   * Compute the Merkle tree over the un-batched tail of a stream, unsigned.
+   *
+   * Only the *contiguous* prefix of the tail is taken. If leaf 7 is missing
+   * because its call was rejected, a batch of 5..6 goes out now and 8.. waits;
+   * committing across the gap would break the arithmetic the contract uses to
+   * price a void (see MerkleBatchBuilder's header).
+   *
+   * Stops short of signing because the backend does not have — and must never
+   * have — the seller's key. It hands back the exact bytes to sign; the seller
+   * signs them wherever that key lives and posts the signature to
+   * `commitBatch`.
+   *
+   * @param {number} streamId
+   * @param {object} [options]
+   * @param {number} [options.maxSize]
+   * @param {number} [options.minSize] - return null below this, so a caller can
+   *   poll without emitting one-call batches
+   * @returns {object|null} { tree, message } or null if there is nothing to do
+   */
+  async prepareBatch(streamId, { maxSize = DEFAULT_MAX_BATCH, minSize = 1 } = {}) {
+    const pending = await this.repository.findUnbatchedLeaves(streamId, maxSize);
+    if (pending.length < minSize) return null;
+
+    // Cut at the first gap.
+    const contiguous = [pending[0]];
+    for (let i = 1; i < pending.length; i++) {
+      if (pending[i].call_index !== contiguous[contiguous.length - 1].call_index + 1) break;
+      contiguous.push(pending[i]);
+    }
+    if (contiguous.length < minSize) return null;
+
+    const tree = MerkleBatchBuilder.build(contiguous.map(toWireAttestation));
+    return {
+      tree,
+      // The seller signs these bytes; record_usage_batch reconstructs them.
+      message: batchCommitmentMessage({
+        stream_id: streamId,
+        merkle_root: tree.root,
+        call_count: tree.callCount,
+      }).toString("hex"),
+    };
+  }
+
+  /**
+   * Persist a batch the seller has signed.
+   *
+   * The signature is re-verified here rather than taken on faith: a batch row
+   * with a signature that does not check out would be rejected by
+   * `record_usage_batch` anyway, and storing it would leave the archive
+   * asserting a commitment nobody made.
+   *
+   * @param {number} streamId
+   * @param {object} tree - from prepareBatch
+   * @param {object} commitment
+   * @param {string} commitment.seller - the seller's G... address
+   * @param {string} commitment.batchSignature - hex, 64 bytes
+   */
+  async commitBatch(streamId, tree, { seller, batchSignature }) {
+    const valid = MerkleBatchBuilder.verifyBatchSignature(
+      {
+        streamId: Number(streamId),
+        merkleRoot: tree.root,
+        callCount: tree.callCount,
+        batchSignature,
+      },
+      seller
+    );
+
+    if (!valid) {
+      const err = new Error("batch commitment signature does not verify under the seller key");
+      err.status = 400;
+      err.reason = "BAD_BATCH_SIGNATURE";
+      throw err;
+    }
+
+    const batch = await this.repository.createBatch({
+      streamId,
+      seller,
+      merkleRoot: tree.root,
+      callCount: tree.callCount,
+      firstCallIndex: tree.firstCallIndex,
+      lastCallIndex: tree.lastCallIndex,
+      batchSignature,
+    });
+
+    await this.repository.attachLeavesToBatch(
+      batch.id,
+      streamId,
+      tree.firstCallIndex,
+      tree.lastCallIndex
+    );
+
+    logger.info("attestation batch committed", {
+      streamId,
+      batchRef: batch.id,
+      callCount: tree.callCount,
+      merkleRoot: tree.root,
+    });
+
+    return batch;
+  }
+
+  /**
+   * prepareBatch + sign + commitBatch, for callers that legitimately hold the
+   * seller's key in-process: the simulation harness, the seller's own agent,
+   * and the end-to-end tests.
+   *
+   * @param {number} streamId
+   * @param {object} options
+   * @param {object} options.signer - the seller's Stellar Keypair
+   * @returns {object|null} { batch, commitment, tree }
+   */
+  async buildBatch(streamId, { signer, maxSize = DEFAULT_MAX_BATCH, minSize = 1 } = {}) {
+    if (!signer) throw new Error("signer is required to commit a batch");
+
+    const prepared = await this.prepareBatch(streamId, { maxSize, minSize });
+    if (!prepared) return null;
+
+    const commitment = MerkleBatchBuilder.signBatch(prepared.tree, signer);
+    const batch = await this.commitBatch(streamId, prepared.tree, {
+      seller: commitment.signer,
+      batchSignature: commitment.batchSignature,
+    });
+
+    return { batch, commitment, tree: prepared.tree };
+  }
+
+  /** Rehydrate a batch and its archived leaves into a verifiable tree. */
+  async loadBatch(streamId, batchId) {
+    const batch =
+      (await this.repository.findBatchByOnChainId(streamId, batchId)) ??
+      (await this.repository.findBatchById(batchId));
+
+    if (!batch || Number(batch.streamId) !== Number(streamId)) return null;
+
+    const leaves = await this.repository.findLeavesByBatchRef(batch.id);
+    return { batch, leaves };
+  }
+
+  /**
+   * The buyer's independent verification of a whole batch.
+   *
+   * Four things have to hold, and the result says which one failed:
+   *   1. the archive actually has every call the batch claims;
+   *   2. every attestation carries a good signature by the seller's key, with
+   *      no repeated nonce and no non-increasing index;
+   *   3. the root recomputed from those leaves equals the committed root;
+   *   4. the batch commitment signature covers that root and call count.
+   *
+   * Nothing here trusts the backend beyond it handing over bytes.
+   *
+   * @param {number} streamId
+   * @param {number} batchId - the on-chain batch id
+   * @param {object} [options]
+   * @param {string} [options.sellerPublicKey] - defaults to the batch's seller
+   */
+  async audit(streamId, batchId, { sellerPublicKey } = {}) {
+    const loaded = await this.loadBatch(streamId, batchId);
+    if (!loaded) return { found: false, valid: false, reason: "BATCH_NOT_FOUND" };
+
+    const { batch, leaves } = loaded;
+    const signer = sellerPublicKey || batch.seller;
+
+    if (leaves.length !== batch.callCount) {
+      return {
+        found: true,
+        valid: false,
+        reason: "ARCHIVE_INCOMPLETE",
+        message: `batch commits to ${batch.callCount} calls but the archive holds ${leaves.length}`,
+        batch,
+      };
+    }
+
+    const attestations = leaves.map(toWireAttestation);
+    const setResult = this.verifier.checkSet(attestations, {
+      signer,
+      streamId: Number(streamId),
+      // The first leaf legitimately continues an earlier batch, so seed the
+      // monotonic check one below it rather than at zero.
+      startingIndex: batch.firstCallIndex - 1,
+    });
+
+    // A recomputed root is only meaningful once the leaves themselves stand up,
+    // but compute it either way: a buyer wants to see both facts at once.
+    let recomputedRoot = null;
+    let rootMatches = false;
+    try {
+      recomputedRoot = MerkleBatchBuilder.build(attestations).root;
+      rootMatches = recomputedRoot === batch.merkleRoot;
+    } catch (err) {
+      logger.warn("attestation batch failed to rebuild", {
+        streamId,
+        batchId,
+        error: err.message,
+      });
+    }
+
+    const commitmentValid = MerkleBatchBuilder.verifyBatchSignature(
+      {
+        streamId: Number(streamId),
+        merkleRoot: batch.merkleRoot,
+        callCount: batch.callCount,
+        batchSignature: batch.batchSignature,
+      },
+      signer
+    );
+
+    const reason = !rootMatches
+      ? "ROOT_MISMATCH"
+      : !commitmentValid
+        ? "BAD_BATCH_SIGNATURE"
+        : !setResult.valid
+          ? setResult.results[setResult.firstInvalidIndex].reason
+          : null;
+
+    return {
+      found: true,
+      valid: rootMatches && commitmentValid && setResult.valid,
+      reason,
+      batch,
+      committedRoot: batch.merkleRoot,
+      recomputedRoot,
+      rootMatches,
+      commitmentValid,
+      leafResults: setResult.results,
+      firstInvalidIndex: setResult.firstInvalidIndex,
+      // The call a challenge should name, translated out of batch-local space.
+      disputableCallIndex:
+        setResult.firstInvalidIndex === null
+          ? null
+          : batch.firstCallIndex + setResult.firstInvalidIndex,
+    };
+  }
+
+  /**
+   * Everything needed to submit `challenge_usage_batch` for one call.
+   *
+   * @returns {object|null} { attestation, proof, root, batch, position, verdict }
+   */
+  async getProof(streamId, batchId, callIndex) {
+    const loaded = await this.loadBatch(streamId, batchId);
+    if (!loaded) return null;
+
+    const { batch, leaves } = loaded;
+    const position = Number(callIndex) - batch.firstCallIndex;
+    if (position < 0 || position >= batch.callCount) return null;
+
+    const attestations = leaves.map(toWireAttestation);
+    const tree = MerkleBatchBuilder.build(attestations);
+    const proof = MerkleBatchBuilder.proofForPosition(tree, position);
+    const attestation = attestations[position];
+
+    return {
+      attestation,
+      proof,
+      root: tree.root,
+      committedRoot: batch.merkleRoot,
+      rootMatches: tree.root === batch.merkleRoot,
+      batch,
+      position,
+      // How many calls a successful challenge reverses — the suffix from here
+      // to the end of the batch. Mirrors the contract's arithmetic exactly so
+      // the UI can show the refund before the buyer pays for the transaction.
+      voidableCalls: batch.callCount - position,
+      verdict: this.verifier.check(attestation, { signer: batch.seller, streamId: Number(streamId) }),
+    };
+  }
+
+  /** Mirror a recorded batch back into the archive. */
+  markRecorded(batchRef, outcome, client) {
+    return this.repository.markRecorded(batchRef, outcome, client);
+  }
+
+  /** Mirror a successful challenge back into the archive. */
+  markVoided(batchRef, outcome, client) {
+    return this.repository.markVoided(batchRef, outcome, client);
+  }
+
+  listBatches(streamId, pagination) {
+    return this.repository.findBatchesByStream(streamId, pagination);
+  }
+}
+
+module.exports = AttestationArchive;
+module.exports.toWireAttestation = toWireAttestation;
+module.exports.DEFAULT_MAX_BATCH = DEFAULT_MAX_BATCH;

--- a/backend/src/attestation/AttestationBuilder.js
+++ b/backend/src/attestation/AttestationBuilder.js
@@ -1,0 +1,203 @@
+/**
+ * AttestationBuilder — the seller side of zero-trust metering.
+ *
+ * For every metered call the seller's own service signs a statement about what
+ * it served: which stream, which call in that stream's sequence, hashes of the
+ * request and the response, when, and a nonce. The backend never sees the
+ * seller's key and cannot manufacture one of these; the buyer can check every
+ * one of them against the seller's published public key.
+ *
+ * The counter that produces `call_index` lives here rather than in the backend
+ * for the same reason: a backend that could choose call indices could quietly
+ * insert calls that never happened. `seed()` restores the counter from
+ * durable storage on restart so indices stay monotonic across process
+ * lifetimes — see AttestationVerifier, which rejects any index that does not
+ * strictly increase.
+ */
+
+const crypto = require("crypto");
+const { Keypair } = require("@stellar/stellar-sdk");
+const {
+  NONCE_BYTES,
+  SIGNATURE_BYTES,
+  hashPayload,
+  signingMessage,
+  leafHash,
+  toFixedBuffer,
+} = require("./canonical");
+
+/**
+ * Normalize whatever the caller handed us into `{ sign, publicKey }`.
+ *
+ * Accepts a Stellar Keypair (what a seller agent already has), an object with
+ * the same shape, or a raw 32-byte Ed25519 seed.
+ */
+function normalizeSigner(signer) {
+  if (!signer) throw new Error("signer is required");
+
+  if (typeof signer.sign === "function" && typeof signer.publicKey === "function") {
+    return signer;
+  }
+
+  if (typeof signer === "string" && signer.startsWith("S")) {
+    return Keypair.fromSecret(signer);
+  }
+
+  if (Buffer.isBuffer(signer) || signer instanceof Uint8Array) {
+    return Keypair.fromRawEd25519Seed(Buffer.from(signer));
+  }
+
+  throw new Error("signer must be a Stellar Keypair, an S... secret, or a 32-byte seed");
+}
+
+class AttestationBuilder {
+  /**
+   * @param {object} config
+   * @param {object|string} config.signer - Stellar Keypair, S... secret, or raw seed
+   * @param {number} [config.now] - injectable clock (epoch seconds) for tests
+   */
+  constructor(config = {}) {
+    this.keypair = normalizeSigner(config.signer);
+    this.publicKey = this.keypair.publicKey();
+    this._now = config.now || (() => Math.floor(Date.now() / 1000));
+
+    // streamId (string) -> next call_index to hand out.
+    this._nextIndex = new Map();
+  }
+
+  /**
+   * Restore the counter for a stream after a restart.
+   *
+   * @param {number|string} streamId
+   * @param {number} lastIssuedIndex - highest index already attested, or -1 for
+   *   a stream that has never been metered
+   */
+  seed(streamId, lastIssuedIndex) {
+    const next = Number(lastIssuedIndex) + 1;
+    if (!Number.isInteger(next) || next < 0) {
+      throw new Error("lastIssuedIndex must be an integer >= -1");
+    }
+    this._nextIndex.set(String(streamId), next);
+    return next;
+  }
+
+  /** The index that would be assigned to the next attestation for a stream. */
+  peek(streamId) {
+    return this._nextIndex.get(String(streamId)) ?? 0;
+  }
+
+  /**
+   * Sign one metered call.
+   *
+   * @param {object} params
+   * @param {number|string} params.streamId
+   * @param {*} [params.request] - the request payload, hashed canonically
+   * @param {*} [params.response] - the response payload, hashed canonically
+   * @param {Buffer|string} [params.requestHash] - supply instead of `request`
+   *   when the payload must not be held in memory here
+   * @param {Buffer|string} [params.responseHash]
+   * @param {number} [params.callIndex] - override the counter (replay tests)
+   * @param {Buffer|string} [params.nonce] - override the random nonce (tests)
+   * @param {number} [params.timestamp] - override the clock (tests)
+   * @returns {object} attestation with hex-encoded fields plus `signature`,
+   *   `signer` (the seller's G... address) and `leaf_hash`
+   */
+  attest({
+    streamId,
+    request,
+    response,
+    requestHash,
+    responseHash,
+    callIndex,
+    nonce,
+    timestamp,
+  } = {}) {
+    if (streamId === undefined || streamId === null) {
+      throw new Error("streamId is required");
+    }
+
+    const key = String(streamId);
+    const index = callIndex === undefined ? this.peek(key) : Number(callIndex);
+    if (!Number.isInteger(index) || index < 0) {
+      throw new Error("callIndex must be a non-negative integer");
+    }
+
+    const attestation = {
+      stream_id: Number(streamId),
+      call_index: index,
+      request_hash: (requestHash
+        ? toFixedBuffer(requestHash, 32, "requestHash")
+        : hashPayload(request)
+      ).toString("hex"),
+      response_hash: (responseHash
+        ? toFixedBuffer(responseHash, 32, "responseHash")
+        : hashPayload(response)
+      ).toString("hex"),
+      timestamp: timestamp === undefined ? this._now() : Number(timestamp),
+      nonce: (nonce
+        ? toFixedBuffer(nonce, NONCE_BYTES, "nonce")
+        : crypto.randomBytes(NONCE_BYTES)
+      ).toString("hex"),
+    };
+
+    const signature = this.keypair.sign(signingMessage(attestation));
+    if (signature.length !== SIGNATURE_BYTES) {
+      throw new Error(`signer produced a ${signature.length}-byte signature, expected 64`);
+    }
+
+    // Only advance the counter once signing succeeded, and only when we were
+    // the one choosing the index. An explicit callIndex is a test/replay path
+    // and must not perturb the live sequence.
+    if (callIndex === undefined) {
+      this._nextIndex.set(key, index + 1);
+    }
+
+    return {
+      ...attestation,
+      signature: Buffer.from(signature).toString("hex"),
+      signer: this.publicKey,
+      leaf_hash: leafHash(attestation).toString("hex"),
+    };
+  }
+
+  /**
+   * Drop-in wrapper for an existing response handler.
+   *
+   * The acceptance criterion is that a seller integrates attestation without
+   * restructuring their service, so this takes the handler they already have
+   * and returns one that attaches `attestation` to whatever it returned:
+   *
+   *   const handler = builder.wrap(async (req) => ({ answer: 42 }));
+   *   const { answer, attestation } = await handler(req, { streamId });
+   *
+   * A handler returning a non-object (a string, a Buffer) gets its value moved
+   * under `data` so there is somewhere to hang the attestation.
+   *
+   * @param {Function} handler - (request, ctx) => response
+   * @param {object} [options]
+   * @param {(req: any, ctx: any) => number|string} [options.streamId] - derive
+   *   the stream id from the request when the caller does not pass one
+   */
+  wrap(handler, options = {}) {
+    if (typeof handler !== "function") throw new Error("handler must be a function");
+    const self = this;
+
+    return async function attestedHandler(request, ctx = {}) {
+      const streamId =
+        ctx.streamId ?? (options.streamId ? options.streamId(request, ctx) : undefined);
+      if (streamId === undefined || streamId === null) {
+        throw new Error("streamId must come from ctx.streamId or options.streamId");
+      }
+
+      const response = await handler(request, ctx);
+      const attestation = self.attest({ streamId, request, response });
+
+      return response && typeof response === "object" && !Buffer.isBuffer(response)
+        ? { ...response, attestation }
+        : { data: response, attestation };
+    };
+  }
+}
+
+module.exports = AttestationBuilder;
+module.exports.normalizeSigner = normalizeSigner;

--- a/backend/src/attestation/AttestationVerifier.js
+++ b/backend/src/attestation/AttestationVerifier.js
@@ -1,0 +1,303 @@
+/**
+ * AttestationVerifier — decides whether a signed attestation may be credited.
+ *
+ * Three independent checks, in cost order (cheap and local first, so a
+ * malformed or replayed attestation never reaches the curve arithmetic):
+ *
+ *   1. Shape + signer binding — fields present, sizes right, stream matches,
+ *      and the signature is by the key we expect for this seller.
+ *   2. Ed25519 signature over `0x00 || LEAF_PREIMAGE` (see canonical.js).
+ *   3. Freshness — the nonce has not been seen before on this stream, and the
+ *      call_index strictly increases.
+ *
+ * Checks 1 and 2 are pure: `check()` runs them and mutates nothing, which is
+ * what a buyer calls when independently auditing an archived batch. Check 3
+ * needs durable state, so it lives behind pluggable stores and only runs in
+ * `accept()`, the metering hot path.
+ *
+ * ── Why nonces are keyed per stream ──────────────────────────────────────────
+ * A global nonce set would be a single hot row on every metered call across
+ * every seller. Per-stream is both cheaper and sufficient: an attestation
+ * commits to its own stream_id, so a nonce lifted from stream A cannot be
+ * presented on stream B without breaking the signature. The replay we actually
+ * have to stop is the same nonce twice *within* a stream — including across two
+ * different batches, which is why the store outlives any one batch.
+ */
+
+const crypto = require("crypto");
+const { Keypair, StrKey } = require("@stellar/stellar-sdk");
+const {
+  HASH_BYTES,
+  NONCE_BYTES,
+  SIGNATURE_BYTES,
+  signingMessage,
+  leafHash,
+  toFixedBuffer,
+} = require("./canonical");
+
+/** Machine-readable outcomes; the frontend renders these directly. */
+const Reason = Object.freeze({
+  OK: "OK",
+  MALFORMED: "MALFORMED",
+  STREAM_MISMATCH: "STREAM_MISMATCH",
+  SIGNER_MISMATCH: "SIGNER_MISMATCH",
+  BAD_SIGNATURE: "BAD_SIGNATURE",
+  NONCE_REUSED: "NONCE_REUSED",
+  INDEX_NOT_MONOTONIC: "INDEX_NOT_MONOTONIC",
+  CLOCK_SKEW: "CLOCK_SKEW",
+});
+
+/** A rejection that is provable on-chain, i.e. worth challenging a batch over. */
+const PROVABLE_ON_CHAIN = Object.freeze([Reason.BAD_SIGNATURE, Reason.NONCE_REUSED]);
+
+function fail(reason, message) {
+  return { valid: false, reason, message, provableOnChain: PROVABLE_ON_CHAIN.includes(reason) };
+}
+
+const OK = Object.freeze({ valid: true, reason: Reason.OK, message: null, provableOnChain: false });
+
+/**
+ * In-memory nonce + index stores. Fine for a single process and for tests;
+ * production passes the Postgres-backed pair from attestationRepository so the
+ * replay window survives a restart and spans replicas.
+ */
+function createMemoryStores() {
+  const nonces = new Map(); // streamId -> Set<nonceHex>
+  const indices = new Map(); // streamId -> highest accepted call_index
+
+  return {
+    nonceStore: {
+      async has(streamId, nonceHex) {
+        return nonces.get(String(streamId))?.has(nonceHex) ?? false;
+      },
+      async add(streamId, nonceHex, _client, _callIndex) {
+        const key = String(streamId);
+        if (!nonces.has(key)) nonces.set(key, new Set());
+        nonces.get(key).add(nonceHex);
+      },
+    },
+    indexStore: {
+      async highest(streamId) {
+        const v = indices.get(String(streamId));
+        return v === undefined ? null : v;
+      },
+      async set(streamId, callIndex) {
+        indices.set(String(streamId), callIndex);
+      },
+    },
+    _raw: { nonces, indices },
+  };
+}
+
+/**
+ * Ed25519 verify, with every failure mode collapsed to `false`.
+ *
+ * Keypair.verify throws on a malformed signature rather than returning false,
+ * and a garbage public key throws inside StrKey. Neither is a crash: both mean
+ * "this attestation does not verify".
+ */
+function verifySignatureRaw(message, signatureHex, publicKey) {
+  try {
+    const signature = toFixedBuffer(signatureHex, SIGNATURE_BYTES, "signature");
+    const kp =
+      typeof publicKey === "string"
+        ? Keypair.fromPublicKey(publicKey)
+        : Keypair.fromPublicKey(StrKey.encodeEd25519PublicKey(Buffer.from(publicKey)));
+    return kp.verify(message, signature);
+  } catch {
+    return false;
+  }
+}
+
+/** Every field an attestation must carry, with its expected byte width. */
+const HEX_FIELDS = Object.freeze({
+  request_hash: HASH_BYTES,
+  response_hash: HASH_BYTES,
+  nonce: NONCE_BYTES,
+  signature: SIGNATURE_BYTES,
+});
+
+class AttestationVerifier {
+  /**
+   * @param {object} [config]
+   * @param {object} [config.nonceStore] - { has(streamId, nonce, client),
+   *   add(streamId, nonce, client, callIndex) }
+   * @param {object} [config.indexStore] - { highest(streamId), set(streamId, index) }
+   * @param {number} [config.maxClockSkewSeconds] - reject attestations dated
+   *   further than this into the future; 0 disables the check
+   * @param {Function} [config.now] - injectable clock, epoch seconds
+   */
+  constructor(config = {}) {
+    const memory = createMemoryStores();
+    this.nonceStore = config.nonceStore || memory.nonceStore;
+    this.indexStore = config.indexStore || memory.indexStore;
+    this.maxClockSkewSeconds = config.maxClockSkewSeconds ?? 300;
+    this._now = config.now || (() => Math.floor(Date.now() / 1000));
+  }
+
+  /**
+   * Stateless validation: shape, stream binding, signer binding, signature.
+   *
+   * This is the whole of what a buyer needs to verify an archived attestation
+   * offline — it touches no store and no network.
+   *
+   * @param {object} attestation
+   * @param {object} [expect]
+   * @param {string} [expect.signer] - the seller's G... address
+   * @param {number|string} [expect.streamId]
+   */
+  check(attestation, expect = {}) {
+    if (!attestation || typeof attestation !== "object") {
+      return fail(Reason.MALFORMED, "attestation must be an object");
+    }
+
+    for (const field of ["stream_id", "call_index", "timestamp"]) {
+      const value = Number(attestation[field]);
+      if (!Number.isInteger(value) || value < 0) {
+        return fail(Reason.MALFORMED, `${field} must be a non-negative integer`);
+      }
+    }
+
+    for (const [field, size] of Object.entries(HEX_FIELDS)) {
+      try {
+        toFixedBuffer(attestation[field], size, field);
+      } catch (err) {
+        return fail(Reason.MALFORMED, err.message);
+      }
+    }
+
+    if (expect.streamId !== undefined && Number(attestation.stream_id) !== Number(expect.streamId)) {
+      return fail(
+        Reason.STREAM_MISMATCH,
+        `attestation is for stream ${attestation.stream_id}, expected ${expect.streamId}`
+      );
+    }
+
+    const signer = expect.signer || attestation.signer;
+    if (!signer) {
+      return fail(Reason.MALFORMED, "no signer: pass expect.signer or set attestation.signer");
+    }
+    if (expect.signer && attestation.signer && attestation.signer !== expect.signer) {
+      return fail(
+        Reason.SIGNER_MISMATCH,
+        `attestation claims signer ${attestation.signer}, expected ${expect.signer}`
+      );
+    }
+
+    if (!verifySignatureRaw(signingMessage(attestation), attestation.signature, signer)) {
+      return fail(Reason.BAD_SIGNATURE, `signature does not verify under ${signer}`);
+    }
+
+    if (this.maxClockSkewSeconds > 0) {
+      const drift = Number(attestation.timestamp) - this._now();
+      if (drift > this.maxClockSkewSeconds) {
+        return fail(
+          Reason.CLOCK_SKEW,
+          `attestation is dated ${drift}s in the future (limit ${this.maxClockSkewSeconds}s)`
+        );
+      }
+    }
+
+    return OK;
+  }
+
+  /**
+   * Full validation, including the stateful freshness checks, recording the
+   * nonce and advancing the index when — and only when — everything passes.
+   *
+   * Call this once per metered call. Calling it twice with the same
+   * attestation returns NONCE_REUSED the second time, by construction.
+   *
+   * @param {object} attestation
+   * @param {object} [expect] - as `check()`, plus:
+   * @param {*} [expect.client] - pg client, threaded to the stores so the
+   *   nonce insert lands in the same transaction as the usage decrement
+   */
+  async accept(attestation, expect = {}) {
+    const stateless = this.check(attestation, expect);
+    if (!stateless.valid) return stateless;
+
+    const streamId = Number(attestation.stream_id);
+    const nonce = toFixedBuffer(attestation.nonce, NONCE_BYTES, "nonce").toString("hex");
+
+    if (await this.nonceStore.has(streamId, nonce, expect.client)) {
+      return fail(Reason.NONCE_REUSED, `nonce ${nonce.slice(0, 16)}… already used on this stream`);
+    }
+
+    const highest = await this.indexStore.highest(streamId, expect.client);
+    const callIndex = Number(attestation.call_index);
+    if (highest !== null && highest !== undefined && callIndex <= Number(highest)) {
+      return fail(
+        Reason.INDEX_NOT_MONOTONIC,
+        `call_index ${callIndex} does not exceed the highest accepted index ${highest}`
+      );
+    }
+
+    await this.nonceStore.add(streamId, nonce, expect.client, callIndex);
+    await this.indexStore.set(streamId, callIndex, expect.client);
+
+    return { ...OK, leafHash: leafHash(attestation).toString("hex") };
+  }
+
+  /**
+   * Verify a whole archived set at once, the buyer's audit path.
+   *
+   * Stateless per-attestation checks run against a local nonce set so a replay
+   * *inside* the set is caught without touching any store — this is exactly the
+   * evidence a buyer needs before calling `challengeBatch`.
+   *
+   * @returns {{valid: boolean, results: Array, firstInvalidIndex: number|null}}
+   */
+  checkSet(attestations, expect = {}) {
+    const seenNonces = new Set();
+    let highest = expect.startingIndex ?? null;
+    let firstInvalidIndex = null;
+
+    const results = attestations.map((attestation, position) => {
+      let outcome = this.check(attestation, expect);
+
+      if (outcome.valid) {
+        const nonce = String(attestation.nonce).toLowerCase();
+        if (seenNonces.has(nonce)) {
+          outcome = fail(Reason.NONCE_REUSED, `nonce repeated at position ${position}`);
+        } else {
+          seenNonces.add(nonce);
+          const callIndex = Number(attestation.call_index);
+          if (highest !== null && callIndex <= highest) {
+            outcome = fail(
+              Reason.INDEX_NOT_MONOTONIC,
+              `call_index ${callIndex} does not exceed ${highest}`
+            );
+          } else {
+            highest = callIndex;
+          }
+        }
+      }
+
+      if (!outcome.valid && firstInvalidIndex === null) firstInvalidIndex = position;
+      return { position, callIndex: Number(attestation?.call_index), ...outcome };
+    });
+
+    return { valid: firstInvalidIndex === null, results, firstInvalidIndex };
+  }
+}
+
+/**
+ * Constant-time hex comparison, for callers checking a root or a leaf hash
+ * against an expected value.
+ */
+function hashesEqual(a, b) {
+  try {
+    const left = toFixedBuffer(a, HASH_BYTES, "hash a");
+    const right = toFixedBuffer(b, HASH_BYTES, "hash b");
+    return crypto.timingSafeEqual(left, right);
+  } catch {
+    return false;
+  }
+}
+
+module.exports = AttestationVerifier;
+module.exports.Reason = Reason;
+module.exports.createMemoryStores = createMemoryStores;
+module.exports.verifySignatureRaw = verifySignatureRaw;
+module.exports.hashesEqual = hashesEqual;

--- a/backend/src/attestation/MerkleBatchBuilder.js
+++ b/backend/src/attestation/MerkleBatchBuilder.js
@@ -1,0 +1,214 @@
+/**
+ * MerkleBatchBuilder — collapses N attestations into one 32-byte commitment.
+ *
+ * The point of the tree is cost. Putting 50 attestations on-chain costs 50
+ * writes; putting their root on-chain costs one, and the buyer keeps the same
+ * guarantee, because any single attestation the seller later denies (or
+ * invents) can be proven in or out of that root with log2(N) sibling hashes.
+ *
+ * ── Batch invariants ─────────────────────────────────────────────────────────
+ * A batch must cover a *contiguous* run of call indices:
+ *
+ *     call_index[i] === first_call_index + i
+ *
+ * This is not incidental tidiness. It is what makes the on-chain void
+ * arithmetic decidable: given only `first_call_index` and `call_count` (both
+ * committed on-chain) the contract can turn a disputed leaf's `call_index`
+ * into its position in the batch, and therefore into a refund amount, without
+ * ever seeing the other leaves. A gap in the run would make that arithmetic a
+ * lie, so `build()` refuses to produce a root for one.
+ *
+ * ── Odd levels ───────────────────────────────────────────────────────────────
+ * When a level has an odd node count the last node is paired with itself. That
+ * is the common convention and it is safe here because domain-separated leaf
+ * and internal hashes cannot collide (see canonical.js).
+ */
+
+const {
+  HASH_BYTES,
+  leafHash,
+  hashInternal,
+  toFixedBuffer,
+  batchCommitmentMessage,
+} = require("./canonical");
+
+/** Build every level of the tree, leaves first, root last. */
+function buildLevels(leafHashes) {
+  const levels = [leafHashes];
+  let current = leafHashes;
+
+  while (current.length > 1) {
+    const next = [];
+    for (let i = 0; i < current.length; i += 2) {
+      const left = current[i];
+      // Odd tail pairs with itself.
+      const right = i + 1 < current.length ? current[i + 1] : current[i];
+      next.push(hashInternal(left, right));
+    }
+    levels.push(next);
+    current = next;
+  }
+
+  return levels;
+}
+
+class MerkleBatchBuilder {
+  /**
+   * Build a batch commitment over an ordered set of attestations.
+   *
+   * @param {Array<object>} attestations - in call_index order, contiguous
+   * @returns {{
+   *   root: string, callCount: number, firstCallIndex: number,
+   *   lastCallIndex: number, leaves: string[], levels: string[][],
+   *   attestations: Array<object>
+   * }}
+   */
+  static build(attestations) {
+    if (!Array.isArray(attestations) || attestations.length === 0) {
+      throw new Error("a batch needs at least one attestation");
+    }
+
+    const streamId = Number(attestations[0].stream_id);
+    const firstCallIndex = Number(attestations[0].call_index);
+
+    attestations.forEach((att, i) => {
+      if (Number(att.stream_id) !== streamId) {
+        throw new Error(
+          `batch mixes streams: position ${i} is stream ${att.stream_id}, expected ${streamId}`
+        );
+      }
+      const expected = firstCallIndex + i;
+      if (Number(att.call_index) !== expected) {
+        throw new Error(
+          `batch must cover a contiguous index range: position ${i} has call_index ` +
+            `${att.call_index}, expected ${expected}`
+        );
+      }
+    });
+
+    const leafBuffers = attestations.map((att) => leafHash(att));
+    const levels = buildLevels(leafBuffers);
+
+    return {
+      streamId,
+      root: levels[levels.length - 1][0].toString("hex"),
+      callCount: attestations.length,
+      firstCallIndex,
+      lastCallIndex: firstCallIndex + attestations.length - 1,
+      leaves: leafBuffers.map((b) => b.toString("hex")),
+      levels: levels.map((level) => level.map((b) => b.toString("hex"))),
+      attestations,
+    };
+  }
+
+  /**
+   * Sibling hashes proving `position`'s leaf is in the root, bottom level up.
+   *
+   * @param {object} batch - the value returned by build()
+   * @param {number} position - 0-based index within the batch
+   * @returns {string[]} hex sibling hashes
+   */
+  static proofForPosition(batch, position) {
+    if (!Number.isInteger(position) || position < 0 || position >= batch.callCount) {
+      throw new Error(`position ${position} is outside a batch of ${batch.callCount}`);
+    }
+
+    const proof = [];
+    let index = position;
+
+    // Stop before the root level: the root has no sibling.
+    for (let level = 0; level < batch.levels.length - 1; level++) {
+      const nodes = batch.levels[level];
+      const isRightChild = index % 2 === 1;
+      const siblingIndex = isRightChild ? index - 1 : index + 1;
+      // An odd tail was paired with itself, so its sibling is itself.
+      proof.push(siblingIndex < nodes.length ? nodes[siblingIndex] : nodes[index]);
+      index = Math.floor(index / 2);
+    }
+
+    return proof;
+  }
+
+  /** Proof for a leaf addressed by its call_index rather than its position. */
+  static proofForCallIndex(batch, callIndex) {
+    const position = Number(callIndex) - batch.firstCallIndex;
+    if (position < 0 || position >= batch.callCount) {
+      throw new Error(
+        `call_index ${callIndex} is outside batch range ` +
+          `[${batch.firstCallIndex}, ${batch.lastCallIndex}]`
+      );
+    }
+    return MerkleBatchBuilder.proofForPosition(batch, position);
+  }
+
+  /**
+   * Recompute a root from a leaf and its siblings — the same walk the contract
+   * does, kept here so a buyer can pre-check a challenge before paying for it.
+   *
+   * @param {Buffer|string} leaf - 32-byte leaf hash
+   * @param {string[]} proof - sibling hashes, bottom up
+   * @returns {string} hex root
+   */
+  static rootFromProof(leaf, proof) {
+    let node = toFixedBuffer(leaf, HASH_BYTES, "leaf");
+    for (const sibling of proof) {
+      node = hashInternal(node, toFixedBuffer(sibling, HASH_BYTES, "proof element"));
+    }
+    return node.toString("hex");
+  }
+
+  /** True when `attestation` is committed under `root` by `proof`. */
+  static verifyProof(attestation, proof, root) {
+    try {
+      const computed = MerkleBatchBuilder.rootFromProof(leafHash(attestation), proof);
+      return computed === String(root).toLowerCase();
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Sign the batch commitment with the seller's key.
+   *
+   * Covers `0x02 || stream_id || merkle_root || call_count`, the same bytes
+   * `record_usage_batch` reconstructs and checks against the seller's
+   * registered attestation key.
+   *
+   * @param {object} batch - from build()
+   * @param {object} signer - Stellar Keypair (or anything with .sign/.publicKey)
+   */
+  static signBatch(batch, signer) {
+    const message = batchCommitmentMessage({
+      stream_id: batch.streamId,
+      merkle_root: batch.root,
+      call_count: batch.callCount,
+    });
+
+    return {
+      merkleRoot: batch.root,
+      callCount: batch.callCount,
+      firstCallIndex: batch.firstCallIndex,
+      streamId: batch.streamId,
+      batchSignature: Buffer.from(signer.sign(message)).toString("hex"),
+      signer: signer.publicKey(),
+    };
+  }
+
+  /**
+   * Verify a batch commitment signature without trusting whoever relayed it.
+   */
+  static verifyBatchSignature({ streamId, merkleRoot, callCount, batchSignature }, publicKey) {
+    const { verifySignatureRaw } = require("./AttestationVerifier");
+    return verifySignatureRaw(
+      batchCommitmentMessage({
+        stream_id: streamId,
+        merkle_root: merkleRoot,
+        call_count: callCount,
+      }),
+      batchSignature,
+      publicKey
+    );
+  }
+}
+
+module.exports = MerkleBatchBuilder;

--- a/backend/src/attestation/canonical.js
+++ b/backend/src/attestation/canonical.js
@@ -1,0 +1,242 @@
+/**
+ * Canonical attestation encoding — the single source of truth for the bytes
+ * that get hashed and signed.
+ *
+ * Everything in this file has a byte-for-byte twin in
+ * `contract/contracts/micropayments/src/attestation.rs`. If you change an
+ * offset, a domain tag, or a field order here, you MUST change it there too or
+ * every on-chain Merkle proof silently stops verifying.
+ *
+ * ── Wire format ──────────────────────────────────────────────────────────────
+ *
+ * LEAF_PREIMAGE is a fixed 120-byte big-endian record. Fixed-width beats JSON
+ * here: there is no canonicalisation question, no field-separator ambiguity,
+ * and no `alloc`-hungry string building inside the contract.
+ *
+ *   offset  size  field
+ *   ------  ----  -----------------------------------------------------------
+ *        0     8  stream_id      u64 BE
+ *        8     8  call_index     u64 BE
+ *       16    32  request_hash   sha256 of the canonicalised request
+ *       48    32  response_hash  sha256 of the canonicalised response
+ *       80     8  timestamp      u64 BE, epoch seconds
+ *       88    32  nonce          32 random bytes, unique per (stream, call)
+ *
+ * Domain tags prefix every hash input so a value from one position can never be
+ * reinterpreted as a value from another — without them, a 120-byte leaf could
+ * be presented as an internal node pair (64 bytes) or vice versa and a
+ * second-preimage attack on the tree becomes possible.
+ *
+ *   0x00  leaf         sha256(0x00 || LEAF_PREIMAGE)
+ *   0x01  internal     sha256(0x01 || min(a,b) || max(a,b))
+ *   0x02  batch commit sha256 is not used; the tag prefixes the signed message
+ *
+ * Internal nodes hash their children in lexicographic order rather than
+ * tree order. That makes a Merkle proof a bare list of sibling hashes with no
+ * direction bits, which is what lets `challenge_usage_batch` take
+ * `Vec<BytesN<32>>` and nothing more. The usual objection to sorted pairs —
+ * that a proof no longer pins the leaf's position — does not bite here: the
+ * contract recomputes the leaf hash from a fully-specified AttestationLeaf, and
+ * the leaf's own `call_index` (not its position in the proof) is what the
+ * void arithmetic keys off. Domain separation does the rest: an internal node
+ * is a hash over 64 bytes tagged 0x01 and a leaf is a hash over 120 bytes
+ * tagged 0x00, so an internal node can never be resubmitted as a leaf.
+ *
+ * The per-call Ed25519 signature covers `0x00 || LEAF_PREIMAGE` — the exact
+ * same bytes as the leaf-hash preimage. That is deliberate: the contract
+ * recomputes one buffer and uses it for both the signature check and the Merkle
+ * path, so a leaf that verifies as signed is necessarily the leaf that was
+ * committed.
+ *
+ * The batch signature covers `0x02 || stream_id || merkle_root || call_count`.
+ * The issue specifies a commitment over (merkle_root, call_count); stream_id is
+ * folded in as well so a batch signature captured on one stream cannot be
+ * replayed to charge a different stream that happens to share a root.
+ */
+
+const crypto = require("crypto");
+
+const LEAF_PREIMAGE_BYTES = 120;
+const HASH_BYTES = 32;
+const NONCE_BYTES = 32;
+const SIGNATURE_BYTES = 64;
+
+const DOMAIN_LEAF = 0x00;
+const DOMAIN_INTERNAL = 0x01;
+const DOMAIN_BATCH = 0x02;
+
+/** Field offsets within LEAF_PREIMAGE, exported so tests can assert them. */
+const OFFSETS = Object.freeze({
+  streamId: 0,
+  callIndex: 8,
+  requestHash: 16,
+  responseHash: 48,
+  timestamp: 80,
+  nonce: 88,
+});
+
+/**
+ * Recursively sort object keys so structurally identical payloads serialize
+ * identically. Mirrors MeteringEngine.canonicalize — a seller's request hash
+ * and the backend's replay hash have to agree on what "the same payload" means.
+ */
+function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    const sorted = {};
+    for (const key of Object.keys(value).sort()) {
+      sorted[key] = canonicalize(value[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+/**
+ * SHA-256 of an arbitrary payload, as a 32-byte Buffer.
+ *
+ * Unlike MeteringEngine.hashPayload this never returns null: an attestation
+ * field is fixed-width, so "no payload" has to hash to something. An absent
+ * payload hashes as the empty string, which is distinct from `{}`.
+ */
+function hashPayload(payload) {
+  const json =
+    payload === null || payload === undefined ? "" : JSON.stringify(canonicalize(payload)) ?? "";
+  return crypto.createHash("sha256").update(json, "utf8").digest();
+}
+
+/** Coerce hex string | Buffer | Uint8Array to a Buffer of exactly `size`. */
+function toFixedBuffer(value, size, label) {
+  let buf;
+  if (Buffer.isBuffer(value)) buf = value;
+  else if (value instanceof Uint8Array) buf = Buffer.from(value);
+  else if (typeof value === "string") {
+    if (!/^[0-9a-fA-F]*$/.test(value) || value.length !== size * 2) {
+      throw new Error(`${label} must be ${size * 2} hex characters`);
+    }
+    buf = Buffer.from(value, "hex");
+  } else {
+    throw new Error(`${label} must be a Buffer or hex string`);
+  }
+
+  if (buf.length !== size) {
+    throw new Error(`${label} must be exactly ${size} bytes, got ${buf.length}`);
+  }
+  return buf;
+}
+
+/** Coerce to a u64-safe non-negative integer. */
+function toU64(value, label) {
+  const n = typeof value === "bigint" ? value : BigInt(Math.trunc(Number(value)));
+  if (n < 0n) throw new Error(`${label} must be non-negative`);
+  if (n > 0xffffffffffffffffn) throw new Error(`${label} exceeds u64`);
+  return n;
+}
+
+function writeU64BE(buf, value, offset, label) {
+  buf.writeBigUInt64BE(toU64(value, label), offset);
+}
+
+/**
+ * Serialize an attestation into its canonical 120-byte preimage.
+ *
+ * @param {object} att
+ * @param {number|bigint|string} att.stream_id
+ * @param {number|bigint|string} att.call_index - monotonic, per stream, 0-based
+ * @param {Buffer|string} att.request_hash - 32 bytes
+ * @param {Buffer|string} att.response_hash - 32 bytes
+ * @param {number|bigint|string} att.timestamp - epoch seconds
+ * @param {Buffer|string} att.nonce - 32 bytes
+ * @returns {Buffer} 120 bytes
+ */
+function encodeLeafPreimage(att) {
+  if (!att || typeof att !== "object") throw new Error("attestation must be an object");
+
+  const buf = Buffer.alloc(LEAF_PREIMAGE_BYTES);
+  writeU64BE(buf, att.stream_id, OFFSETS.streamId, "stream_id");
+  writeU64BE(buf, att.call_index, OFFSETS.callIndex, "call_index");
+  toFixedBuffer(att.request_hash, HASH_BYTES, "request_hash").copy(buf, OFFSETS.requestHash);
+  toFixedBuffer(att.response_hash, HASH_BYTES, "response_hash").copy(buf, OFFSETS.responseHash);
+  writeU64BE(buf, att.timestamp, OFFSETS.timestamp, "timestamp");
+  toFixedBuffer(att.nonce, NONCE_BYTES, "nonce").copy(buf, OFFSETS.nonce);
+  return buf;
+}
+
+/** Parse a 120-byte preimage back into an attestation with hex fields. */
+function decodeLeafPreimage(bytes) {
+  const buf = toFixedBuffer(bytes, LEAF_PREIMAGE_BYTES, "leaf preimage");
+  return {
+    stream_id: Number(buf.readBigUInt64BE(OFFSETS.streamId)),
+    call_index: Number(buf.readBigUInt64BE(OFFSETS.callIndex)),
+    request_hash: buf.subarray(OFFSETS.requestHash, OFFSETS.requestHash + HASH_BYTES).toString("hex"),
+    response_hash: buf
+      .subarray(OFFSETS.responseHash, OFFSETS.responseHash + HASH_BYTES)
+      .toString("hex"),
+    timestamp: Number(buf.readBigUInt64BE(OFFSETS.timestamp)),
+    nonce: buf.subarray(OFFSETS.nonce, OFFSETS.nonce + NONCE_BYTES).toString("hex"),
+  };
+}
+
+/**
+ * The exact bytes the seller's Ed25519 key signs: 0x00 || LEAF_PREIMAGE.
+ * Also the leaf-hash preimage — see the header note on why they are the same.
+ */
+function signingMessage(att) {
+  return Buffer.concat([Buffer.from([DOMAIN_LEAF]), encodeLeafPreimage(att)]);
+}
+
+/** leaf_hash = sha256(0x00 || LEAF_PREIMAGE) */
+function leafHash(att) {
+  return crypto.createHash("sha256").update(signingMessage(att)).digest();
+}
+
+/**
+ * internal node = sha256(0x01 || min(a,b) || max(a,b))
+ *
+ * Children are ordered by their byte value, not by their side of the tree —
+ * see the header note on why the proof format needs no direction bits.
+ */
+function hashInternal(a, b) {
+  const left = toFixedBuffer(a, HASH_BYTES, "node a");
+  const right = toFixedBuffer(b, HASH_BYTES, "node b");
+  const [lo, hi] = Buffer.compare(left, right) <= 0 ? [left, right] : [right, left];
+
+  return crypto
+    .createHash("sha256")
+    .update(Buffer.concat([Buffer.from([DOMAIN_INTERNAL]), lo, hi]))
+    .digest();
+}
+
+/**
+ * The bytes a seller signs to commit a whole batch on-chain:
+ * 0x02 || stream_id(8) || merkle_root(32) || call_count(8)
+ */
+function batchCommitmentMessage({ stream_id, merkle_root, call_count }) {
+  const buf = Buffer.alloc(1 + 8 + HASH_BYTES + 8);
+  buf.writeUInt8(DOMAIN_BATCH, 0);
+  writeU64BE(buf, stream_id, 1, "stream_id");
+  toFixedBuffer(merkle_root, HASH_BYTES, "merkle_root").copy(buf, 9);
+  writeU64BE(buf, call_count, 9 + HASH_BYTES, "call_count");
+  return buf;
+}
+
+module.exports = {
+  LEAF_PREIMAGE_BYTES,
+  HASH_BYTES,
+  NONCE_BYTES,
+  SIGNATURE_BYTES,
+  DOMAIN_LEAF,
+  DOMAIN_INTERNAL,
+  DOMAIN_BATCH,
+  OFFSETS,
+  canonicalize,
+  hashPayload,
+  toFixedBuffer,
+  toU64,
+  encodeLeafPreimage,
+  decodeLeafPreimage,
+  signingMessage,
+  leafHash,
+  hashInternal,
+  batchCommitmentMessage,
+};

--- a/backend/src/db/migrations/021_add_attestations.sql
+++ b/backend/src/db/migrations/021_add_attestations.sql
@@ -1,0 +1,140 @@
+-- ============================================================================
+-- 021 — Proof-of-execution attestations.
+--
+-- The issue asks for this as `019_add_attestations.sql`; 019 and 020 were both
+-- taken by the time it landed (settlement ledger, fraud signals), so it is
+-- numbered 021. The migration runner orders by numeric prefix, so the number
+-- is the only thing that had to change.
+--
+-- attestation_leaves   — one row per metered call, the full signed statement.
+--                        This is the archive: the on-chain commitment is only
+--                        a root, so a buyer disputing a batch needs these rows
+--                        to reconstruct the proof.
+-- attestation_batches  — the Merkle commitment over a contiguous run of leaves,
+--                        plus its on-chain lifecycle (pending → recorded →
+--                        challenged/voided).
+-- used_nonces          — the replay set. Kept separate from attestation_leaves
+--                        so the uniqueness check is a single narrow index probe
+--                        on the metering hot path, and so a nonce stays burnt
+--                        even if its leaf is later voided.
+--
+-- No foreign keys to `streams`, matching usage_events and events_log: these
+-- rows are written inside the transaction that bills a call, and a stream row
+-- that has not been indexed from chain yet must never fail a paid call.
+-- ============================================================================
+
+
+-- ── attestation_batches ──────────────────────────────────────────────────────
+-- One row per Merkle commitment. `batch_id` is assigned by the contract when
+-- record_usage_batch succeeds; until then the row sits in 'pending' with a NULL
+-- batch_id, which is why the primary key is a local surrogate.
+
+CREATE TABLE IF NOT EXISTS attestation_batches (
+    id                BIGSERIAL   PRIMARY KEY,
+    stream_id         BIGINT      NOT NULL,
+    -- Assigned on-chain; NULL until the batch is recorded.
+    batch_id          BIGINT,
+    seller            TEXT        NOT NULL,
+    -- 64 hex chars = the 32-byte root committed on-chain.
+    merkle_root       TEXT        NOT NULL CHECK (merkle_root ~ '^[0-9a-f]{64}$'),
+    call_count        BIGINT      NOT NULL CHECK (call_count > 0),
+    -- Batches cover a contiguous index run; these two bound it inclusively and
+    -- are what turns a disputed leaf's call_index into a refundable position.
+    first_call_index  BIGINT      NOT NULL CHECK (first_call_index >= 0),
+    last_call_index   BIGINT      NOT NULL CHECK (last_call_index >= first_call_index),
+    -- 128 hex chars = the seller's 64-byte Ed25519 batch commitment signature.
+    batch_signature   TEXT        NOT NULL CHECK (batch_signature ~ '^[0-9a-f]{128}$'),
+    status            TEXT        NOT NULL DEFAULT 'pending' CHECK (status IN (
+                          'pending', 'recorded', 'challenged', 'voided'
+                      )),
+    -- Set when a challenge succeeds: how many calls were reversed and what the
+    -- contract refunded, mirrored off-chain so the UI need not replay events.
+    voided_calls      BIGINT      NOT NULL DEFAULT 0 CHECK (voided_calls >= 0),
+    refunded_amount   BIGINT      NOT NULL DEFAULT 0 CHECK (refunded_amount >= 0),
+    tx_hash           TEXT,
+    recorded_at       TIMESTAMPTZ,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT attestation_batches_range_matches_count
+        CHECK (last_call_index - first_call_index + 1 = call_count),
+    CONSTRAINT attestation_batches_void_within_batch
+        CHECK (voided_calls <= call_count)
+);
+
+-- A given on-chain batch id is unique per stream. Partial: 'pending' rows all
+-- carry NULL and must not collide with each other.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_attestation_batches_stream_batch
+    ON attestation_batches (stream_id, batch_id) WHERE batch_id IS NOT NULL;
+
+-- The buyer's attestation page: newest batches for one stream.
+CREATE INDEX IF NOT EXISTS idx_attestation_batches_stream
+    ON attestation_batches (stream_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_attestation_batches_seller
+    ON attestation_batches (seller, created_at DESC);
+
+-- The submitter's work queue.
+CREATE INDEX IF NOT EXISTS idx_attestation_batches_pending
+    ON attestation_batches (created_at) WHERE status = 'pending';
+
+
+-- ── attestation_leaves ───────────────────────────────────────────────────────
+-- The archived attestation itself. Every column except batch_ref and the
+-- bookkeeping timestamps is covered by `signature`, so a row that has been
+-- tampered with in the database fails verification the same way a forged one
+-- does — the archive is untrusted storage by design.
+
+CREATE TABLE IF NOT EXISTS attestation_leaves (
+    id             BIGSERIAL   PRIMARY KEY,
+    -- NULL while a call is metered but not yet batched.
+    batch_ref      BIGINT      REFERENCES attestation_batches (id) ON DELETE SET NULL,
+    stream_id      BIGINT      NOT NULL,
+    call_index     BIGINT      NOT NULL CHECK (call_index >= 0),
+    request_hash   TEXT        NOT NULL CHECK (request_hash ~ '^[0-9a-f]{64}$'),
+    response_hash  TEXT        NOT NULL CHECK (response_hash ~ '^[0-9a-f]{64}$'),
+    attested_at    BIGINT      NOT NULL CHECK (attested_at >= 0),
+    nonce          TEXT        NOT NULL CHECK (nonce ~ '^[0-9a-f]{64}$'),
+    signature      TEXT        NOT NULL CHECK (signature ~ '^[0-9a-f]{128}$'),
+    signer         TEXT        NOT NULL,
+    -- Cached sha256(0x00 || leaf preimage). Derivable from the columns above;
+    -- stored so proof assembly is a plain SELECT rather than N rehashes.
+    leaf_hash      TEXT        NOT NULL CHECK (leaf_hash ~ '^[0-9a-f]{64}$'),
+    -- Verification outcome recorded at metering time, for triage. Never trusted
+    -- on the dispute path: a challenge re-verifies from the signed bytes.
+    verify_reason  TEXT        NOT NULL DEFAULT 'OK',
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    -- The monotonic-index rule, enforced by the schema rather than only in JS.
+    CONSTRAINT uq_attestation_leaves_stream_call UNIQUE (stream_id, call_index)
+);
+
+-- Proof assembly reads a whole batch in call order.
+CREATE INDEX IF NOT EXISTS idx_attestation_leaves_batch
+    ON attestation_leaves (batch_ref, call_index) WHERE batch_ref IS NOT NULL;
+
+-- Batching reads the un-batched tail of a stream in call order.
+CREATE INDEX IF NOT EXISTS idx_attestation_leaves_unbatched
+    ON attestation_leaves (stream_id, call_index) WHERE batch_ref IS NULL;
+
+
+-- ── used_nonces ──────────────────────────────────────────────────────────────
+-- The replay set, keyed per stream. A nonce lifted from another stream cannot
+-- be replayed anyway (stream_id is inside the signed bytes), so the composite
+-- key is both sufficient and narrower than a global one.
+--
+-- Rows are never deleted on a void: the point is that a nonce is spent once,
+-- and a voided batch must not free its nonces for reuse.
+
+CREATE TABLE IF NOT EXISTS used_nonces (
+    stream_id  BIGINT      NOT NULL,
+    nonce      TEXT        NOT NULL CHECK (nonce ~ '^[0-9a-f]{64}$'),
+    call_index BIGINT      NOT NULL CHECK (call_index >= 0),
+    used_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    PRIMARY KEY (stream_id, nonce)
+);
+
+-- Restoring AttestationBuilder's counter after a restart: MAX(call_index).
+CREATE INDEX IF NOT EXISTS idx_used_nonces_stream_index
+    ON used_nonces (stream_id, call_index DESC);

--- a/backend/src/protocol/MeteringEngine.js
+++ b/backend/src/protocol/MeteringEngine.js
@@ -1,8 +1,45 @@
+/**
+ * MeteringEngine — bills one call against a stream.
+ *
+ * Since attestation landed, a call is credited only when the seller's own
+ * signature says it happened. The backend's counters used to be the sole
+ * record of usage, which meant a compromised or buggy backend could
+ * under-report to sellers or over-charge buyers with nothing to check it
+ * against. Now the decrement and the seller's signed statement about the call
+ * are written in the same transaction: the billing log cannot claim a call the
+ * seller never attested, and it cannot drop one they did.
+ *
+ * The verifier's replay and monotonicity checks share that transaction too, so
+ * a nonce is only durably spent if the call it paid for was durably billed.
+ */
+
 const crypto = require("crypto");
 const jwt = require("jsonwebtoken");
 const streamRepository = require("../repositories/streamRepository");
 const usageEventRepository = require("../repositories/usageEventRepository");
+const attestationRepository = require("../repositories/attestationRepository");
+const AttestationVerifier = require("../attestation/AttestationVerifier");
+const AttestationArchive = require("../attestation/AttestationArchive");
+const { leafHash } = require("../attestation/canonical");
 const { withTransaction } = require("../db/connection");
+
+/**
+ * Whether an unattested call is refused outright.
+ *
+ * On by default — an opt-out that defaults to "off" would leave the trust hole
+ * open for anyone who never read the release note. Set
+ * ATTESTATION_ENFORCED=false only to run a seller integration that has not been
+ * migrated yet; those calls are billed on the backend's word alone and are
+ * logged as such.
+ */
+function attestationEnforced() {
+  return process.env.ATTESTATION_ENFORCED !== "false";
+}
+
+// Shares the Postgres-backed nonce and index stores, so replay protection spans
+// processes rather than living in one server's memory.
+const verifier = new AttestationVerifier(attestationRepository.createStores());
+const archive = new AttestationArchive({ verifier });
 
 function getJWTSecret() {
   return process.env.JWT_SECRET || process.env.SERVER_SECRET_KEY || "default-jwt-secret";
@@ -55,17 +92,50 @@ function verifyToken(token) {
 }
 
 /**
- * Decrement call counter atomically inside a transaction.
- * Returns { calls_remaining, settle_now: bool }
+ * The Ed25519 key a stream's attestations must be signed with.
+ *
+ * A Stellar `G...` address is an Ed25519 public key, so the stream's recipient
+ * doubles as the seller's attestation key and there is nothing to register:
+ * the key that gets paid is the key that signs.
+ *
+ * A seller may nominate a separate operational signing key, but only through
+ * the `sellerKey` claim in the stream token, which the backend signs at
+ * negotiation time. It deliberately cannot come from the metering request:
+ * a caller who could name the key an attestation is checked against could name
+ * their own and sign their own usage, which is the exact trust hole this whole
+ * subsystem exists to close.
+ */
+function expectedSigner(stream, tokenClaims) {
+  return tokenClaims?.sellerKey || stream.recipient;
+}
+
+/**
+ * Bill one call.
+ *
+ * The attestation is verified and archived inside the same transaction as the
+ * decrement, so the three facts — the seller said it happened, the buyer was
+ * charged, and the nonce is spent — commit or roll back together.
  *
  * @param {string} tokenString - stream_token JWT
  * @param {object} [options]
  * @param {string|null} [options.payloadHash] - canonical hash of the request
  *   payload, logged for replay detection (see hashPayload)
+ * @param {object|null} [options.attestation] - the seller's signed attestation
+ *   for this call, as produced by AttestationBuilder
+ * @throws {Error} status 403 when attestation is required and does not verify
  */
-async function meterCall(tokenString, { payloadHash = null } = {}) {
+async function meterCall(tokenString, { payloadHash = null, attestation = null } = {}) {
   const decoded = verifyToken(tokenString);
   const streamId = Number(decoded.streamId);
+
+  if (!attestation && attestationEnforced()) {
+    const err = new Error(
+      "Attestation required: this call must carry a seller-signed attestation"
+    );
+    err.status = 403;
+    err.reason = "ATTESTATION_MISSING";
+    throw err;
+  }
 
   return withTransaction(async (client) => {
     // 1. Lock the stream row FOR UPDATE
@@ -88,10 +158,38 @@ async function meterCall(tokenString, { payloadHash = null } = {}) {
       throw err;
     }
 
+    // 2. The seller's signature is what authorises the charge. Verifying
+    //    before the decrement means a forged or replayed attestation costs the
+    //    buyer nothing — the transaction never gets as far as billing.
+    let attestationResult = null;
+    if (attestation) {
+      const signer = expectedSigner(stream, decoded);
+      attestationResult = await verifier.accept(attestation, {
+        signer,
+        streamId,
+        client,
+      });
+
+      if (!attestationResult.valid) {
+        const err = new Error(`Attestation rejected: ${attestationResult.message}`);
+        err.status = 403;
+        err.reason = attestationResult.reason;
+        // Tells the caller whether this is worth an on-chain challenge or is
+        // merely a malformed request.
+        err.provableOnChain = attestationResult.provableOnChain;
+        throw err;
+      }
+
+      await archive.archive(
+        { ...attestation, signer, leaf_hash: leafHash(attestation).toString("hex") },
+        { client }
+      );
+    }
+
     const newCallsRemaining = stream.callsRemaining - 1;
     const newCallsUsed = stream.callsUsed + 1;
 
-    // 2. Update database
+    // 3. Update database
     const updated = await streamRepository.updateCalls(
       streamId,
       newCallsRemaining,
@@ -99,7 +197,7 @@ async function meterCall(tokenString, { payloadHash = null } = {}) {
       client
     );
 
-    // 3. Log the call for the fraud detectors. Same transaction as the
+    // 4. Log the call for the fraud detectors. Same transaction as the
     // decrement, so the usage log can never claim a call that wasn't billed
     // (or miss one that was).
     await usageEventRepository.record(
@@ -124,6 +222,11 @@ async function meterCall(tokenString, { payloadHash = null } = {}) {
       calls_remaining: newCallsRemaining,
       settle_now,
       stream: updated,
+      // Echoed back so the seller's SDK can confirm which call in the sequence
+      // this was, and so a buyer can match the response to an archived leaf.
+      attestation: attestationResult
+        ? { callIndex: Number(attestation.call_index), leafHash: attestationResult.leafHash }
+        : null,
     };
   });
 }
@@ -132,4 +235,10 @@ module.exports = {
   verifyToken,
   meterCall,
   hashPayload,
+  expectedSigner,
+  attestationEnforced,
+  // Exposed so the batch submitter and the routes share one verifier, and so
+  // tests can inject their own stores.
+  verifier,
+  archive,
 };

--- a/backend/src/protocol/StreamNegotiator.js
+++ b/backend/src/protocol/StreamNegotiator.js
@@ -72,7 +72,7 @@ function getAgreement(buyer, assetId, rate) {
  * optional: tokens issued before this existed still meter fine, their usage
  * events simply carry a null asset.
  */
-function issueStreamToken(stream, pricePerCall, assetId = null) {
+function issueStreamToken(stream, pricePerCall, assetId = null, sellerKey = null) {
   const payload = {
     streamId: String(stream.id),
     sender: stream.sender,
@@ -81,6 +81,11 @@ function issueStreamToken(stream, pricePerCall, assetId = null) {
     pricePerCall: Number(pricePerCall),
     assetId: assetId === null || assetId === undefined ? null : Number(assetId),
     expiresAt: Number(stream.endTime),
+    // The key the seller's attestations are verified against. Null means the
+    // recipient address itself, which is the usual case; a separate operational
+    // key is pinned here, inside the signed token, so a metering request can
+    // never nominate the key it is checked against.
+    sellerKey: sellerKey || null,
   };
 
   return jwt.sign(payload, getJWTSecret());

--- a/backend/src/repositories/attestationRepository.js
+++ b/backend/src/repositories/attestationRepository.js
@@ -1,0 +1,374 @@
+/**
+ * Attestation repository — all SQL touching attestation_batches,
+ * attestation_leaves and used_nonces.
+ *
+ * Split by hot path vs. audit path:
+ *
+ *   - `recordLeaf` / `burnNonce` / `highestCallIndex` run inside the metering
+ *     transaction. They do one statement each and read nothing back that the
+ *     caller does not need.
+ *   - Everything else serves batching, the buyer's attestation page, and the
+ *     dispute flow, where a couple of extra round trips are irrelevant.
+ *
+ * Every function takes an optional trailing `client` so it can join a
+ * caller-managed transaction, per the repoUtils contract.
+ */
+
+const { run, toMs, normalizePagination, buildMeta } = require("./repoUtils");
+
+const LEAF_COLUMNS = `
+  id, batch_ref, stream_id, call_index, request_hash, response_hash,
+  attested_at, nonce, signature, signer, leaf_hash, verify_reason, created_at
+`;
+
+const BATCH_COLUMNS = `
+  id, stream_id, batch_id, seller, merkle_root, call_count, first_call_index,
+  last_call_index, batch_signature, status, voided_calls, refunded_amount,
+  tx_hash, recorded_at, created_at, updated_at
+`;
+
+/**
+ * Row → the attestation shape the crypto layer expects.
+ *
+ * The signed fields keep their snake_case wire names (canonical.js reads them
+ * by those exact keys); the bookkeeping fields around them use the camelCase
+ * the rest of the repository layer returns. Mixing the two conventions in one
+ * object is deliberate — renaming a signed field on the way out would mean
+ * renaming it back before every verification.
+ */
+function mapLeaf(row) {
+  if (!row) return null;
+  return {
+    stream_id: Number(row.stream_id),
+    call_index: Number(row.call_index),
+    request_hash: row.request_hash,
+    response_hash: row.response_hash,
+    timestamp: Number(row.attested_at),
+    nonce: row.nonce,
+    signature: row.signature,
+    signer: row.signer,
+    leaf_hash: row.leaf_hash,
+
+    id: row.id,
+    batchRef: row.batch_ref,
+    verifyReason: row.verify_reason,
+    createdAt: toMs(row.created_at),
+  };
+}
+
+function mapBatch(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    streamId: Number(row.stream_id),
+    batchId: row.batch_id === null ? null : Number(row.batch_id),
+    seller: row.seller,
+    merkleRoot: row.merkle_root,
+    callCount: Number(row.call_count),
+    firstCallIndex: Number(row.first_call_index),
+    lastCallIndex: Number(row.last_call_index),
+    batchSignature: row.batch_signature,
+    status: row.status,
+    voidedCalls: Number(row.voided_calls),
+    refundedAmount: Number(row.refunded_amount),
+    txHash: row.tx_hash,
+    recordedAt: toMs(row.recorded_at),
+    createdAt: toMs(row.created_at),
+    updatedAt: toMs(row.updated_at),
+  };
+}
+
+// ── Leaves ───────────────────────────────────────────────────────────────────
+
+/**
+ * Archive one attestation.
+ *
+ * ON CONFLICT DO NOTHING on (stream_id, call_index) makes this idempotent: a
+ * retried metering request re-inserts the same leaf rather than erroring. The
+ * RETURNING clause is empty on conflict, so the caller gets null and can tell
+ * the two cases apart.
+ */
+async function recordLeaf(leaf, client) {
+  const { rows } = await run(
+    `INSERT INTO attestation_leaves
+       (batch_ref, stream_id, call_index, request_hash, response_hash,
+        attested_at, nonce, signature, signer, leaf_hash, verify_reason)
+     VALUES (NULL, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+     ON CONFLICT (stream_id, call_index) DO NOTHING
+     RETURNING ${LEAF_COLUMNS}`,
+    [
+      leaf.stream_id,
+      leaf.call_index,
+      leaf.request_hash,
+      leaf.response_hash,
+      leaf.timestamp,
+      leaf.nonce,
+      leaf.signature,
+      leaf.signer,
+      leaf.leaf_hash,
+      leaf.verifyReason || "OK",
+    ],
+    client
+  );
+  return mapLeaf(rows[0]);
+}
+
+/** The un-batched tail of a stream, oldest call first. */
+async function findUnbatchedLeaves(streamId, limit = 100, client) {
+  const { rows } = await run(
+    `SELECT ${LEAF_COLUMNS}
+       FROM attestation_leaves
+      WHERE stream_id = $1 AND batch_ref IS NULL
+      ORDER BY call_index ASC
+      LIMIT $2`,
+    [streamId, limit],
+    client
+  );
+  return rows.map(mapLeaf);
+}
+
+/** Every leaf in a batch, in call order — the archive a buyer audits. */
+async function findLeavesByBatchRef(batchRef, client) {
+  const { rows } = await run(
+    `SELECT ${LEAF_COLUMNS}
+       FROM attestation_leaves
+      WHERE batch_ref = $1
+      ORDER BY call_index ASC`,
+    [batchRef],
+    client
+  );
+  return rows.map(mapLeaf);
+}
+
+async function findLeafByCallIndex(streamId, callIndex, client) {
+  const { rows } = await run(
+    `SELECT ${LEAF_COLUMNS}
+       FROM attestation_leaves
+      WHERE stream_id = $1 AND call_index = $2`,
+    [streamId, callIndex],
+    client
+  );
+  return mapLeaf(rows[0]);
+}
+
+/** Claim a contiguous run of leaves for a batch. */
+async function attachLeavesToBatch(batchRef, streamId, firstCallIndex, lastCallIndex, client) {
+  const { rowCount } = await run(
+    `UPDATE attestation_leaves
+        SET batch_ref = $1
+      WHERE stream_id = $2
+        AND batch_ref IS NULL
+        AND call_index BETWEEN $3 AND $4`,
+    [batchRef, streamId, firstCallIndex, lastCallIndex],
+    client
+  );
+  return rowCount;
+}
+
+// ── Nonces ───────────────────────────────────────────────────────────────────
+
+/**
+ * Burn a nonce. Returns false when it was already spent on this stream, which
+ * is the replay signal — the unique constraint does the work, so two concurrent
+ * metering transactions cannot both win.
+ */
+async function burnNonce(streamId, nonce, callIndex, client) {
+  const { rowCount } = await run(
+    `INSERT INTO used_nonces (stream_id, nonce, call_index)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (stream_id, nonce) DO NOTHING`,
+    [streamId, nonce, callIndex],
+    client
+  );
+  return rowCount > 0;
+}
+
+async function isNonceUsed(streamId, nonce, client) {
+  const { rows } = await run(
+    `SELECT 1 FROM used_nonces WHERE stream_id = $1 AND nonce = $2`,
+    [streamId, nonce],
+    client
+  );
+  return rows.length > 0;
+}
+
+/**
+ * Highest call_index ever accepted on a stream, or null for a fresh stream.
+ *
+ * Read from used_nonces rather than attestation_leaves so the monotonic rule
+ * survives a leaf being voided or archived away: a spent index stays spent.
+ */
+async function highestCallIndex(streamId, client) {
+  const { rows } = await run(
+    `SELECT MAX(call_index) AS highest FROM used_nonces WHERE stream_id = $1`,
+    [streamId],
+    client
+  );
+  const highest = rows[0]?.highest;
+  return highest === null || highest === undefined ? null : Number(highest);
+}
+
+// ── Batches ──────────────────────────────────────────────────────────────────
+
+async function createBatch(batch, client) {
+  const { rows } = await run(
+    `INSERT INTO attestation_batches
+       (stream_id, seller, merkle_root, call_count, first_call_index,
+        last_call_index, batch_signature, status)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, 'pending')
+     RETURNING ${BATCH_COLUMNS}`,
+    [
+      batch.streamId,
+      batch.seller,
+      batch.merkleRoot,
+      batch.callCount,
+      batch.firstCallIndex,
+      batch.lastCallIndex,
+      batch.batchSignature,
+    ],
+    client
+  );
+  return mapBatch(rows[0]);
+}
+
+/** Record the on-chain outcome of a submitted batch. */
+async function markRecorded(id, { batchId, txHash }, client) {
+  const { rows } = await run(
+    `UPDATE attestation_batches
+        SET batch_id = $2, tx_hash = $3, status = 'recorded',
+            recorded_at = now(), updated_at = now()
+      WHERE id = $1
+      RETURNING ${BATCH_COLUMNS}`,
+    [id, batchId, txHash || null],
+    client
+  );
+  return mapBatch(rows[0]);
+}
+
+/**
+ * Mirror a successful challenge.
+ *
+ * A batch lands in 'voided' when every call was reversed and 'challenged' when
+ * only a suffix was — the distinction the frontend renders, and the reason
+ * voided_calls is stored rather than inferred from the status.
+ */
+async function markVoided(id, { voidedCalls, refundedAmount, txHash }, client) {
+  const { rows } = await run(
+    `UPDATE attestation_batches
+        SET voided_calls = $2,
+            refunded_amount = $3,
+            tx_hash = COALESCE($4, tx_hash),
+            status = CASE WHEN $2 >= call_count THEN 'voided' ELSE 'challenged' END,
+            updated_at = now()
+      WHERE id = $1
+      RETURNING ${BATCH_COLUMNS}`,
+    [id, voidedCalls, refundedAmount, txHash || null],
+    client
+  );
+  return mapBatch(rows[0]);
+}
+
+async function findBatchById(id, client) {
+  const { rows } = await run(
+    `SELECT ${BATCH_COLUMNS} FROM attestation_batches WHERE id = $1`,
+    [id],
+    client
+  );
+  return mapBatch(rows[0]);
+}
+
+/** Look a batch up by the id the contract assigned it. */
+async function findBatchByOnChainId(streamId, batchId, client) {
+  const { rows } = await run(
+    `SELECT ${BATCH_COLUMNS}
+       FROM attestation_batches
+      WHERE stream_id = $1 AND batch_id = $2`,
+    [streamId, batchId],
+    client
+  );
+  return mapBatch(rows[0]);
+}
+
+/** Paginated batch list for one stream, newest first. */
+async function findBatchesByStream(streamId, pagination = {}, client) {
+  const { page, limit, offset } = normalizePagination(pagination);
+
+  const [list, count] = await Promise.all([
+    run(
+      `SELECT ${BATCH_COLUMNS}
+         FROM attestation_batches
+        WHERE stream_id = $1
+        ORDER BY created_at DESC, id DESC
+        LIMIT $2 OFFSET $3`,
+      [streamId, limit, offset],
+      client,
+      "read"
+    ),
+    run(
+      `SELECT COUNT(*)::int AS total FROM attestation_batches WHERE stream_id = $1`,
+      [streamId],
+      client,
+      "read"
+    ),
+  ]);
+
+  const total = count.rows[0]?.total ?? 0;
+  return { data: list.rows.map(mapBatch), meta: buildMeta(total, page, limit) };
+}
+
+async function findPendingBatches(limit = 50, client) {
+  const { rows } = await run(
+    `SELECT ${BATCH_COLUMNS}
+       FROM attestation_batches
+      WHERE status = 'pending'
+      ORDER BY created_at ASC
+      LIMIT $1`,
+    [limit],
+    client
+  );
+  return rows.map(mapBatch);
+}
+
+/**
+ * Postgres-backed stores for AttestationVerifier.
+ *
+ * The verifier calls `has` then `add`; both take the pg client the metering
+ * transaction is already holding, so a nonce is only durably burnt if the call
+ * it paid for was also durably billed.
+ */
+function createStores() {
+  return {
+    nonceStore: {
+      has: (streamId, nonce, client) => isNonceUsed(streamId, nonce, client),
+      add: (streamId, nonce, client, callIndex) =>
+        burnNonce(streamId, nonce, callIndex, client),
+    },
+    indexStore: {
+      highest: (streamId, client) => highestCallIndex(streamId, client),
+      // used_nonces carries call_index on the row the nonce store just wrote,
+      // so the high-water mark needs no separate write of its own.
+      set: async () => {},
+    },
+  };
+}
+
+module.exports = {
+  recordLeaf,
+  findUnbatchedLeaves,
+  findLeavesByBatchRef,
+  findLeafByCallIndex,
+  attachLeavesToBatch,
+  burnNonce,
+  isNonceUsed,
+  highestCallIndex,
+  createBatch,
+  markRecorded,
+  markVoided,
+  findBatchById,
+  findBatchByOnChainId,
+  findBatchesByStream,
+  findPendingBatches,
+  createStores,
+  mapLeaf,
+  mapBatch,
+};

--- a/backend/src/routes/protocol.js
+++ b/backend/src/routes/protocol.js
@@ -12,6 +12,8 @@ const AuctionEngine = require("../protocol/AuctionEngine");
 const { CONTRACT_IDS } = require("../config/stellar");
 const { viewContract, invokeContract } = require("../services/stellarService");
 const streamRepository = require("../repositories/streamRepository");
+const AttestationArchive = require("../attestation/AttestationArchive");
+const attestationRepository = require("../repositories/attestationRepository");
 const assetRepository = require("../repositories/assetRepository");
 const { Keypair } = require("@stellar/stellar-sdk");
 const { logger } = require("../utils/logger");
@@ -240,20 +242,36 @@ router.post(
     delete payload.stream_token;
     delete payload.streamToken;
     delete payload.payloadHash;
+    // The attestation is transport, not payload: hashing it into payloadHash
+    // would make every call look unique to the replay detector, and it is
+    // covered by its own signature anyway.
+    delete payload.attestation;
+    delete payload.sellerPublicKey;
     const payloadHash =
       typeof body.payloadHash === "string" && body.payloadHash.length
         ? body.payloadHash
         : MeteringEngine.hashPayload(payload);
 
     try {
-      const { calls_remaining, settle_now, stream } = await MeteringEngine.meterCall(token, {
-        payloadHash,
-      });
+      const { calls_remaining, settle_now, stream, attestation } =
+        await MeteringEngine.meterCall(token, {
+          payloadHash,
+          attestation: body.attestation || null,
+        });
       StreamMonitor.checkStreamAndAlert(stream);
-      res.json({ calls_remaining, settle_now });
+      res.json({ calls_remaining, settle_now, attestation });
     } catch (err) {
       if (err.status === 402) {
         return res.status(402).json({ error: err.message });
+      }
+      // A rejected attestation is not a malformed request: the call was
+      // refused on cryptographic grounds, and `reason` tells the caller which.
+      if (err.status === 403) {
+        return res.status(403).json({
+          error: err.message,
+          reason: err.reason,
+          provableOnChain: Boolean(err.provableOnChain),
+        });
       }
       res.status(400).json({ error: err.message });
     }
@@ -456,6 +474,248 @@ router.post(
     const auctionId = Number(req.params.id);
     const transitions = await AuctionEngine.engine.tickFor(auctionId);
     res.json({ auctionId, ...transitions });
+  })
+);
+
+// ── Attestation ──────────────────────────────────────────────────────────────
+//
+// These endpoints exist so a buyer never has to take the backend's word for
+// anything: the archive hands over the signed bytes, and every verdict below is
+// one the caller can recompute locally with CortexAgentSDK.verifyBatch.
+
+const archive = MeteringEngine.archive;
+
+/**
+ * GET /api/v1/protocol/stream/:id/attestations
+ * Committed usage batches for a stream, newest first, each with its audit
+ * verdict so the buyer's dashboard can flag a bad batch without N round trips.
+ */
+router.get(
+  "/stream/:id/attestations",
+  [param("id").isInt({ min: 1 })],
+  validate,
+  asyncHandler(async (req, res) => {
+    const streamId = Number(req.params.id);
+    const { page, limit, verify } = req.query;
+
+    const listed = await archive.listBatches(streamId, { page, limit });
+
+    // Verification re-hashes every archived leaf, so it is opt-out for a caller
+    // paging through a long history who only needs the headline rows.
+    const withVerdicts =
+      verify === "false"
+        ? listed.data.map((batch) => ({ ...batch, audit: null }))
+        : await Promise.all(
+            listed.data.map(async (batch) => {
+              if (batch.batchId === null) return { ...batch, audit: null };
+              const audit = await archive.audit(streamId, batch.batchId);
+              return {
+                ...batch,
+                audit: {
+                  valid: audit.valid,
+                  reason: audit.reason,
+                  rootMatches: audit.rootMatches,
+                  commitmentValid: audit.commitmentValid,
+                  disputableCallIndex: audit.disputableCallIndex,
+                },
+              };
+            })
+          );
+
+    res.json({ streamId, data: withVerdicts, meta: listed.meta });
+  })
+);
+
+/**
+ * GET /api/v1/protocol/stream/:id/attestations/next-index
+ * The highest call index ever accepted, so a restarted seller can resume its
+ * counter instead of colliding with indices it already spent.
+ */
+router.get(
+  "/stream/:id/attestations/next-index",
+  [param("id").isInt({ min: 1 })],
+  validate,
+  asyncHandler(async (req, res) => {
+    const streamId = Number(req.params.id);
+    const lastCallIndex = await attestationRepository.highestCallIndex(streamId);
+    res.json({
+      streamId,
+      // -1 for a stream that has never been metered, so the next index is 0.
+      lastCallIndex: lastCallIndex === null ? -1 : lastCallIndex,
+      nextCallIndex: lastCallIndex === null ? 0 : lastCallIndex + 1,
+    });
+  })
+);
+
+/**
+ * GET /api/v1/protocol/stream/:id/attestations/pending
+ * The un-batched tail plus the exact bytes the seller must sign to commit it.
+ * The backend never holds the seller's key, so this is as far as it can go.
+ */
+router.get(
+  "/stream/:id/attestations/pending",
+  [param("id").isInt({ min: 1 })],
+  validate,
+  asyncHandler(async (req, res) => {
+    const streamId = Number(req.params.id);
+    const maxSize = Math.min(512, Math.max(1, Number(req.query.max) || 128));
+
+    const prepared = await archive.prepareBatch(streamId, { maxSize });
+    if (!prepared) {
+      return res.json({ streamId, pending: 0, tree: null, message: null });
+    }
+
+    res.json({
+      streamId,
+      pending: prepared.tree.callCount,
+      merkleRoot: prepared.tree.root,
+      callCount: prepared.tree.callCount,
+      firstCallIndex: prepared.tree.firstCallIndex,
+      lastCallIndex: prepared.tree.lastCallIndex,
+      message: prepared.message,
+      attestations: prepared.tree.attestations,
+    });
+  })
+);
+
+/**
+ * POST /api/v1/protocol/stream/:id/attestations/batch
+ * Persist a batch the seller has signed. The signature is re-verified here,
+ * so the archive never records a commitment the seller did not actually make.
+ */
+router.post(
+  "/stream/:id/attestations/batch",
+  [
+    param("id").isInt({ min: 1 }),
+    body("seller").isString().notEmpty(),
+    body("batchSignature").matches(/^[0-9a-f]{128}$/i),
+  ],
+  validate,
+  asyncHandler(async (req, res) => {
+    const streamId = Number(req.params.id);
+    const { seller, batchSignature, merkleRoot } = req.body;
+
+    const prepared = await archive.prepareBatch(streamId, { maxSize: 512 });
+    if (!prepared) {
+      return res.status(409).json({ error: "No un-batched attestations for this stream" });
+    }
+
+    // The seller signed a specific root. If new calls landed in between, the
+    // tail has moved and the signature covers the wrong set — better a 409 than
+    // a batch that fails on-chain after the seller has paid the fee.
+    if (merkleRoot && merkleRoot.toLowerCase() !== prepared.tree.root) {
+      return res.status(409).json({
+        error: "The pending batch changed since it was prepared; re-fetch and re-sign",
+        expected: prepared.tree.root,
+        received: merkleRoot.toLowerCase(),
+      });
+    }
+
+    try {
+      const batch = await archive.commitBatch(streamId, prepared.tree, {
+        seller,
+        batchSignature: batchSignature.toLowerCase(),
+      });
+      res.status(201).json({ batch, attestations: prepared.tree.attestations });
+    } catch (err) {
+      if (err.status === 400) {
+        return res.status(400).json({ error: err.message, reason: err.reason });
+      }
+      throw err;
+    }
+  })
+);
+
+/**
+ * POST /api/v1/protocol/stream/:id/attestations/:batchRef/recorded
+ * Mirror an on-chain record_usage_batch back into the archive, binding the
+ * local row to the batch id the contract assigned it.
+ */
+router.post(
+  "/stream/:id/attestations/:batchRef/recorded",
+  [
+    param("id").isInt({ min: 1 }),
+    param("batchRef").isInt({ min: 1 }),
+    body("batchId").isInt({ min: 1 }),
+  ],
+  validate,
+  asyncHandler(async (req, res) => {
+    const batchRef = Number(req.params.batchRef);
+    const existing = await attestationRepository.findBatchById(batchRef);
+    if (!existing || existing.streamId !== Number(req.params.id)) {
+      return res.status(404).json({ error: "Batch not found on this stream" });
+    }
+
+    const batch = await archive.markRecorded(batchRef, {
+      batchId: Number(req.body.batchId),
+      txHash: req.body.txHash || null,
+    });
+    res.json({ batch });
+  })
+);
+
+/**
+ * GET /api/v1/protocol/stream/:id/attestations/:batchId
+ * The full archived set behind one committed root, with the audit verdict.
+ * This is what `verifyBatch` downloads to check the commitment independently.
+ */
+router.get(
+  "/stream/:id/attestations/:batchId",
+  [param("id").isInt({ min: 1 }), param("batchId").isInt({ min: 1 })],
+  validate,
+  asyncHandler(async (req, res) => {
+    const streamId = Number(req.params.id);
+    const batchId = Number(req.params.batchId);
+
+    const audit = await archive.audit(streamId, batchId);
+    if (!audit.found) {
+      return res.status(404).json({ error: "Batch not found" });
+    }
+
+    const loaded = await archive.loadBatch(streamId, batchId);
+    res.json({
+      batch: audit.batch,
+      attestations: loaded.leaves.map(AttestationArchive.toWireAttestation),
+      audit: {
+        valid: audit.valid,
+        reason: audit.reason,
+        committedRoot: audit.committedRoot,
+        recomputedRoot: audit.recomputedRoot,
+        rootMatches: audit.rootMatches,
+        commitmentValid: audit.commitmentValid,
+        leafResults: audit.leafResults,
+        firstInvalidIndex: audit.firstInvalidIndex,
+        disputableCallIndex: audit.disputableCallIndex,
+      },
+    });
+  })
+);
+
+/**
+ * GET /api/v1/protocol/stream/:id/attestations/:batchId/proof/:callIndex
+ * Everything challenge_usage_batch needs for one call: the leaf, its sibling
+ * hashes, and how many calls a successful challenge would reverse.
+ */
+router.get(
+  "/stream/:id/attestations/:batchId/proof/:callIndex",
+  [
+    param("id").isInt({ min: 1 }),
+    param("batchId").isInt({ min: 1 }),
+    param("callIndex").isInt({ min: 0 }),
+  ],
+  validate,
+  asyncHandler(async (req, res) => {
+    const proof = await archive.getProof(
+      Number(req.params.id),
+      Number(req.params.batchId),
+      Number(req.params.callIndex)
+    );
+
+    if (!proof) {
+      return res.status(404).json({ error: "No archived attestation for that call" });
+    }
+
+    res.json(proof);
   })
 );
 

--- a/backend/src/sdk/CortexAgentSDK.js
+++ b/backend/src/sdk/CortexAgentSDK.js
@@ -9,6 +9,10 @@ const {
 } = require("@stellar/stellar-sdk");
 const SorobanRpc = rpc || require("@stellar/stellar-sdk").SorobanRpc;
 const { logger } = require("../utils/logger");
+const AttestationBuilder = require("../attestation/AttestationBuilder");
+const AttestationVerifier = require("../attestation/AttestationVerifier");
+const MerkleBatchBuilder = require("../attestation/MerkleBatchBuilder");
+const { toFixedBuffer } = require("../attestation/canonical");
 
 class CortexAgentSDK {
   /**
@@ -20,6 +24,11 @@ class CortexAgentSDK {
    * @param {string} [config.micropaymentsContractId] - Deployed micropayments contract address
    * @param {string} [config.tokenAddress] - Token asset address (default 'native' for XLM)
    * @param {Keypair} config.buyerKeypair - Buyer keypair for signing transactions
+   * @param {Keypair} [config.sellerKeypair] - Seller keypair, required only for
+   *   the seller-side `attestCall`. A seller's G... address is an Ed25519
+   *   public key, so the key that receives payment is also the one that signs
+   *   attestations; pass a different keypair only if you have registered it
+   *   on-chain with register_attestation_key.
    */
   constructor(config) {
     if (!config.backendUrl) {
@@ -39,6 +48,16 @@ class CortexAgentSDK {
 
     // Lazy load server instances
     this.rpcServer = new SorobanRpc.Server(this.rpcUrl);
+
+    // Seller-side signing is optional: a buyer-only agent never needs a key it
+    // does not have, so the builder is only constructed when one is supplied.
+    this.sellerKeypair = config.sellerKeypair || null;
+    this._attestationBuilder = this.sellerKeypair
+      ? new AttestationBuilder({ signer: this.sellerKeypair })
+      : null;
+
+    // Verification is stateless and needs no key, so every agent gets one.
+    this._attestationVerifier = new AttestationVerifier();
   }
 
   /**
@@ -229,9 +248,12 @@ class CortexAgentSDK {
    * Make a metered API call using the stream token.
    * Handles 402 Payment Required errors automatically.
    */
-  async call(streamToken, payload) {
+  async call(streamToken, payload, { attestation = null } = {}) {
     try {
-      return await this._request("POST", "/api/v1/protocol/meter", payload, {
+      // Metering refuses unattested calls, so the seller's attestation rides
+      // along with the meter request rather than being reported separately.
+      const body = attestation ? { ...payload, attestation } : payload;
+      return await this._request("POST", "/api/v1/protocol/meter", body, {
         Authorization: `Bearer ${streamToken}`,
       });
     } catch (err) {
@@ -248,6 +270,244 @@ class CortexAgentSDK {
   async getBalance(streamId) {
     const res = await this._request("GET", `/api/v1/protocol/stream/${streamId}/balance`);
     return res.claimable;
+  }
+
+  // ── Attestation: seller side ───────────────────────────────────────────────
+
+  /**
+   * Sign an attestation for a call this agent just served.
+   *
+   * Attach the result to the API response and the buyer can prove, without
+   * trusting the backend or this SDK, that the call happened and that it was
+   * this seller who said so.
+   *
+   *   const result = await handleRequest(req);
+   *   return { ...result, attestation: sdk.attestCall(streamId, req, result) };
+   *
+   * The call index advances locally. After a restart, seed it from the last
+   * index the backend archived (`GET .../attestations/next-index`) via
+   * `seedAttestationIndex`, or the first attestation after the restart is
+   * rejected as non-monotonic.
+   */
+  attestCall(streamId, request, response) {
+    if (!this._attestationBuilder) {
+      throw new Error("sellerKeypair is required to attest calls");
+    }
+    return this._attestationBuilder.attest({ streamId, request, response });
+  }
+
+  /**
+   * Wrap an existing response handler so every response carries an attestation.
+   *
+   * This is the drop-in path: the handler keeps its signature and its return
+   * shape, and gains an `attestation` field.
+   */
+  attestHandler(handler, options) {
+    if (!this._attestationBuilder) {
+      throw new Error("sellerKeypair is required to attest calls");
+    }
+    return this._attestationBuilder.wrap(handler, options);
+  }
+
+  /** Restore the local call-index counter after a restart. */
+  async seedAttestationIndex(streamId) {
+    const res = await this._request(
+      "GET",
+      `/api/v1/protocol/stream/${streamId}/attestations/next-index`
+    );
+    this._attestationBuilder?.seed(streamId, res.lastCallIndex);
+    return res.lastCallIndex;
+  }
+
+  // ── Attestation: buyer side ────────────────────────────────────────────────
+
+  /**
+   * Verify one attestation against the seller's public key.
+   *
+   * Entirely local: no network, no backend, no trust. `sellerPublicKey`
+   * defaults to whatever the attestation claims, which is only meaningful if
+   * you already know the seller's address — pass it explicitly to check that
+   * the attestation came from the party you are actually paying.
+   *
+   * @returns {{valid: boolean, reason: string, message: string|null,
+   *   provableOnChain: boolean}}
+   */
+  verifyAttestation(attestation, sellerPublicKey) {
+    return this._attestationVerifier.check(attestation, { signer: sellerPublicKey });
+  }
+
+  /**
+   * Verify a whole archived batch against its on-chain commitment.
+   *
+   * Fetches the archived attestations, re-derives the Merkle root locally, and
+   * compares it to the root the backend claims was committed. A mismatch means
+   * the archive and the commitment disagree — whether because the seller lied
+   * or the backend tampered, the batch should not be trusted either way.
+   */
+  async verifyBatch(streamId, batchId, sellerPublicKey) {
+    const archived = await this._request(
+      "GET",
+      `/api/v1/protocol/stream/${streamId}/attestations/${batchId}`
+    );
+
+    const signer = sellerPublicKey || archived.batch.seller;
+    const setResult = this._attestationVerifier.checkSet(archived.attestations, {
+      signer,
+      streamId: Number(streamId),
+      startingIndex: archived.batch.firstCallIndex - 1,
+    });
+
+    let recomputedRoot = null;
+    try {
+      recomputedRoot = MerkleBatchBuilder.build(archived.attestations).root;
+    } catch {
+      // A set that will not form a tree (a gap in the indices, say) is itself
+      // the finding; recomputedRoot stays null and rootMatches stays false.
+    }
+
+    const commitmentValid = MerkleBatchBuilder.verifyBatchSignature(
+      {
+        streamId: Number(streamId),
+        merkleRoot: archived.batch.merkleRoot,
+        callCount: archived.batch.callCount,
+        batchSignature: archived.batch.batchSignature,
+      },
+      signer
+    );
+
+    return {
+      batch: archived.batch,
+      valid:
+        recomputedRoot === archived.batch.merkleRoot && commitmentValid && setResult.valid,
+      recomputedRoot,
+      committedRoot: archived.batch.merkleRoot,
+      rootMatches: recomputedRoot === archived.batch.merkleRoot,
+      commitmentValid,
+      leafResults: setResult.results,
+      firstInvalidIndex: setResult.firstInvalidIndex,
+      disputableCallIndex:
+        setResult.firstInvalidIndex === null
+          ? null
+          : archived.batch.firstCallIndex + setResult.firstInvalidIndex,
+    };
+  }
+
+  /**
+   * Challenge a specific call in a committed batch, on-chain.
+   *
+   * Fetches the archived proof, checks locally that it actually reproduces the
+   * committed root, and only then spends a transaction on it — a proof that
+   * cannot reach the root would be rejected by the contract anyway, and the
+   * buyer would have paid for the privilege.
+   *
+   * @param {number} streamId
+   * @param {number} batchId - the on-chain batch id
+   * @param {number} callIndex - the call being contested
+   * @returns {{txHash: string, voidedCalls: number}}
+   */
+  async challengeBatch(streamId, batchId, callIndex) {
+    const contractId = this.micropaymentsContractId;
+    if (!contractId) {
+      throw new Error("micropaymentsContractId is required to submit a challenge");
+    }
+
+    const { attestation, proof, rootMatches, verdict, voidableCalls } = await this._request(
+      "GET",
+      `/api/v1/protocol/stream/${streamId}/attestations/${batchId}/proof/${callIndex}`
+    );
+
+    if (!rootMatches) {
+      throw new Error(
+        "Archived attestations do not reproduce the committed root; the archive " +
+          "itself is inconsistent and this proof would be rejected on-chain"
+      );
+    }
+    if (verdict.valid) {
+      throw new Error(
+        `Call ${callIndex} carries a valid attestation; there is nothing to challenge`
+      );
+    }
+
+    const buyerAddr = this.buyerKeypair.publicKey();
+    const account = await this.rpcServer.getAccount(buyerAddr);
+
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(
+        new Contract(contractId).call(
+          "challenge_usage_batch",
+          Address.fromString(buyerAddr).toScVal(),
+          nativeToScVal(BigInt(streamId), { type: "u64" }),
+          nativeToScVal(BigInt(batchId), { type: "u64" }),
+          this._attestationLeafToScVal(attestation),
+          nativeToScVal(
+            proof.map((hash) => toFixedBuffer(hash, 32, "proof element")),
+            { type: "bytes" }
+          )
+        )
+      )
+      .setTimeout(60)
+      .build();
+
+    const prepared = await this.rpcServer.prepareTransaction(tx);
+    prepared.sign(this.buyerKeypair);
+
+    const submit = await this.rpcServer.sendTransaction(prepared);
+    if (submit.status === "ERROR") {
+      throw new Error(`Challenge submission failed: ${JSON.stringify(submit.errorResult)}`);
+    }
+
+    let status = await this.rpcServer.getTransaction(submit.hash);
+    let retries = 0;
+    while (status.status === "NOT_FOUND" && retries < 10) {
+      await new Promise((r) => setTimeout(r, 2000));
+      status = await this.rpcServer.getTransaction(submit.hash);
+      retries++;
+    }
+
+    if (status.status !== "SUCCESS") {
+      throw new Error(`Challenge rejected on-chain with status: ${status.status}`);
+    }
+
+    return {
+      txHash: submit.hash,
+      voidedCalls: Number(scValToNative(status.returnValue)),
+      expectedVoidedCalls: voidableCalls,
+    };
+  }
+
+  /**
+   * Marshal an attestation into the contract's AttestationLeaf struct.
+   *
+   * Field names and types have to match the #[contracttype] exactly — Soroban
+   * maps a struct to a symbol-keyed map, so a misspelled key is a decode error
+   * rather than a silently ignored field.
+   */
+  _attestationLeafToScVal(attestation) {
+    return nativeToScVal(
+      {
+        stream_id: BigInt(attestation.stream_id),
+        call_index: BigInt(attestation.call_index),
+        request_hash: toFixedBuffer(attestation.request_hash, 32, "request_hash"),
+        response_hash: toFixedBuffer(attestation.response_hash, 32, "response_hash"),
+        timestamp: BigInt(attestation.timestamp),
+        nonce: toFixedBuffer(attestation.nonce, 32, "nonce"),
+        signature: toFixedBuffer(attestation.signature, 64, "signature"),
+      },
+      {
+        type: {
+          stream_id: ["symbol", "u64"],
+          call_index: ["symbol", "u64"],
+          request_hash: ["symbol", "bytes"],
+          response_hash: ["symbol", "bytes"],
+          timestamp: ["symbol", "u64"],
+          nonce: ["symbol", "bytes"],
+          signature: ["symbol", "bytes"],
+        },
+      }
+    );
   }
 
   /**

--- a/contract/Cargo.lock
+++ b/contract/Cargo.lock
@@ -158,6 +158,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "audit-anchor"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,6 +843,8 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 name = "micropayments"
 version = "0.1.0"
 dependencies = [
+ "ed25519-dalek",
+ "sig_check",
  "soroban-sdk",
 ]
 
@@ -1195,6 +1204,13 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "sig_check"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
 
 [[package]]
 name = "signature"

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "contracts/micropayments",
   "contracts/agent_registry",
   "contracts/audit_anchor",
+  "contracts/sig_check",
 ]
 
 [workspace.dependencies]

--- a/contract/contracts/micropayments/Cargo.toml
+++ b/contract/contracts/micropayments/Cargo.toml
@@ -11,3 +11,7 @@ soroban-sdk = { workspace = true, features = ["alloc"] }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+# Tests need to *produce* Ed25519 signatures (and deliberately bad ones); the
+# contract itself only verifies, so this stays out of the wasm build.
+ed25519-dalek = { workspace = true }
+sig_check = { path = "../sig_check" }

--- a/contract/contracts/micropayments/src/attestation.rs
+++ b/contract/contracts/micropayments/src/attestation.rs
@@ -1,0 +1,800 @@
+//! Proof-of-execution attestation: zero-trust usage metering.
+//!
+//! Ordinary metering asks everyone to trust the backend's counters. This module
+//! replaces that trust with two cryptographic commitments:
+//!
+//!   1. Per call, the seller's own service signs an attestation describing what
+//!      it served. The backend never holds that key and cannot fabricate one.
+//!   2. Per batch, the seller commits a Merkle root over N such attestations
+//!      and is charged for exactly N calls. One 32-byte write covers the batch.
+//!
+//! A buyer who thinks a batch is padded fetches the archived attestations,
+//! finds the bad one, and proves it — `challenge_usage_batch` re-derives the
+//! root from the disputed leaf and reverses the charge.
+//!
+//! ## Wire format
+//!
+//! Byte-for-byte identical to `backend/src/attestation/canonical.js`; that file
+//! carries the full field table. In brief, a leaf preimage is 120 fixed-width
+//! big-endian bytes and every hash is domain-tagged:
+//!
+//!   leaf      sha256(0x00 || stream_id | call_index | req | resp | ts | nonce)
+//!   internal  sha256(0x01 || min(a,b) || max(a,b))
+//!   batch     signed over 0x02 || stream_id || merkle_root || call_count
+//!
+//! Internal nodes sort their children so a proof needs no direction bits, which
+//! is what lets `merkle_proof` be a bare `Vec<BytesN<32>>`. Position is not
+//! taken from the proof — it comes from the leaf's own `call_index` measured
+//! against the batch's committed `first_call_index`.
+//!
+//! ## Funds
+//!
+//! Usage billing runs beside the time-based stream rather than through it: a
+//! buyer escrows an allowance with `fund_usage_meter`, `record_usage_batch`
+//! moves `call_count * price_per_call` from that allowance into the seller's
+//! claimable column, and the seller can only take it once the challenge window
+//! has closed. That window is the whole reason a dispute can be funds-correct:
+//! money that has already left cannot be clawed back, so it is made to wait.
+//!
+//! ## Partial voiding
+//!
+//! A successful challenge voids the disputed call *and every call after it in
+//! the batch* — a suffix, not just the one leaf. Once a seller is shown to have
+//! inserted a fabricated call at position k, the indices of everything at k+1
+//! and beyond are no longer evidence of anything: they are numbered relative to
+//! a sequence that is known to contain an invention. Voiding the whole batch
+//! instead would over-refund the calls before k, which really were attested.
+
+use soroban_sdk::{
+    contractimpl, contracttype, symbol_short, token, Address, Bytes, BytesN, Env, IntoVal, Symbol,
+    Vec,
+};
+
+use crate::{MicropaymentsContract, MicropaymentsContractArgs, MicropaymentsContractClient};
+use crate::{PaymentStream, StreamStatus, STREAMS};
+
+/// Domain tags. Keep in lockstep with canonical.js.
+const DOMAIN_LEAF: u8 = 0x00;
+const DOMAIN_INTERNAL: u8 = 0x01;
+const DOMAIN_BATCH: u8 = 0x02;
+
+/// How long after `record_usage_batch` a buyer may still dispute, in seconds.
+///
+/// The seller cannot claim inside this window. Long enough for a buyer to pull
+/// the archive and check 128 signatures without racing anyone; short enough
+/// that an honest seller is not financing the protocol.
+pub const CHALLENGE_WINDOW_SECS: u64 = 86_400;
+
+const SIG_CHECKER: Symbol = symbol_short!("SIGCHK");
+
+/// One signed statement that a specific call happened.
+///
+/// Every field except `signature` is covered by `signature`, so a leaf that has
+/// been altered anywhere fails verification exactly as a forged one does.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AttestationLeaf {
+    pub stream_id: u64,
+    /// Strictly increasing per stream. Its distance from the batch's
+    /// `first_call_index` is the leaf's position, and therefore the refund.
+    pub call_index: u64,
+    pub request_hash: BytesN<32>,
+    pub response_hash: BytesN<32>,
+    pub timestamp: u64,
+    pub nonce: BytesN<32>,
+    pub signature: BytesN<64>,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BatchStatus {
+    /// Committed and charged; inside or past the challenge window.
+    Recorded,
+    /// A challenge succeeded but some earlier calls in the batch still stand.
+    Challenged,
+    /// Every call in the batch was reversed.
+    Voided,
+    /// Paid out to the seller; no longer disputable.
+    Claimed,
+}
+
+/// An on-chain usage commitment.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct UsageBatch {
+    pub id: u64,
+    pub stream_id: u64,
+    pub seller: Address,
+    pub merkle_root: BytesN<32>,
+    pub call_count: u64,
+    /// `call_index` of the batch's first leaf. Batches are contiguous, so this
+    /// plus `call_count` fully describes which calls the root covers.
+    pub first_call_index: u64,
+    /// What the batch cost the buyer when recorded.
+    pub charged: i128,
+    /// Length of the voided suffix; 0 while the batch stands whole.
+    pub voided_calls: u64,
+    pub refunded: i128,
+    pub recorded_at: u64,
+    pub status: BatchStatus,
+}
+
+/// Per-stream usage accounting.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct UsageMeter {
+    pub price_per_call: i128,
+    /// The buyer's remaining allowance — what `record_usage_batch` draws down.
+    pub escrowed: i128,
+    /// Charged to the seller's claimable column, net of refunds.
+    pub charged: i128,
+    /// Already paid out.
+    pub claimed: i128,
+    /// The `call_index` the next batch must start at.
+    pub next_call_index: u64,
+    pub batch_count: u64,
+}
+
+#[contracttype]
+pub enum AttKey {
+    /// stream_id -> UsageMeter
+    Meter(u64),
+    /// (stream_id, batch_id) -> UsageBatch
+    Batch(u64, u64),
+    /// seller -> the Ed25519 key its attestations are signed with
+    SellerKey(Address),
+}
+
+// ── Hashing ──────────────────────────────────────────────────────────────────
+
+/// `0x00 || LEAF_PREIMAGE` — both the signed message and the leaf-hash input.
+///
+/// Making those the same bytes is deliberate: a leaf that verifies as signed is
+/// necessarily the leaf that was committed, with no room for the two views to
+/// disagree.
+pub(crate) fn leaf_message(env: &Env, leaf: &AttestationLeaf) -> Bytes {
+    let mut msg = Bytes::new(env);
+    msg.extend_from_array(&[DOMAIN_LEAF]);
+    msg.extend_from_array(&leaf.stream_id.to_be_bytes());
+    msg.extend_from_array(&leaf.call_index.to_be_bytes());
+    msg.extend_from_array(&leaf.request_hash.to_array());
+    msg.extend_from_array(&leaf.response_hash.to_array());
+    msg.extend_from_array(&leaf.timestamp.to_be_bytes());
+    msg.extend_from_array(&leaf.nonce.to_array());
+    msg
+}
+
+pub(crate) fn leaf_hash(env: &Env, leaf: &AttestationLeaf) -> BytesN<32> {
+    env.crypto().sha256(&leaf_message(env, leaf)).into()
+}
+
+/// sha256(0x01 || min(a,b) || max(a,b)) — children ordered by byte value.
+pub(crate) fn hash_internal(env: &Env, a: &BytesN<32>, b: &BytesN<32>) -> BytesN<32> {
+    let (lo, hi) = if a.to_array() <= b.to_array() {
+        (a.to_array(), b.to_array())
+    } else {
+        (b.to_array(), a.to_array())
+    };
+
+    let mut buf = Bytes::new(env);
+    buf.extend_from_array(&[DOMAIN_INTERNAL]);
+    buf.extend_from_array(&lo);
+    buf.extend_from_array(&hi);
+    env.crypto().sha256(&buf).into()
+}
+
+/// Walk a leaf up to a root through its sibling hashes.
+pub(crate) fn root_from_proof(env: &Env, leaf: &BytesN<32>, proof: &Vec<BytesN<32>>) -> BytesN<32> {
+    let mut node = leaf.clone();
+    for sibling in proof.iter() {
+        node = hash_internal(env, &node, &sibling);
+    }
+    node
+}
+
+/// The bytes a seller signs to commit a batch.
+///
+/// `stream_id` is folded in alongside the (merkle_root, call_count) pair the
+/// protocol nominally commits to, so a signature captured on one stream cannot
+/// be replayed to charge another that happens to share a root.
+pub(crate) fn batch_message(env: &Env, stream_id: u64, root: &BytesN<32>, call_count: u64) -> Bytes {
+    let mut msg = Bytes::new(env);
+    msg.extend_from_array(&[DOMAIN_BATCH]);
+    msg.extend_from_array(&stream_id.to_be_bytes());
+    msg.extend_from_array(&root.to_array());
+    msg.extend_from_array(&call_count.to_be_bytes());
+    msg
+}
+
+// ── Storage helpers ──────────────────────────────────────────────────────────
+
+fn load_stream(env: &Env, stream_id: u64) -> PaymentStream {
+    let streams: soroban_sdk::Map<u64, PaymentStream> = env
+        .storage()
+        .persistent()
+        .get(&STREAMS)
+        .unwrap_or(soroban_sdk::Map::new(env));
+    streams.get(stream_id).expect("stream not found")
+}
+
+fn load_meter(env: &Env, stream_id: u64) -> UsageMeter {
+    env.storage()
+        .persistent()
+        .get(&AttKey::Meter(stream_id))
+        .expect("usage meter not funded for this stream")
+}
+
+fn save_meter(env: &Env, stream_id: u64, meter: &UsageMeter) {
+    env.storage()
+        .persistent()
+        .set(&AttKey::Meter(stream_id), meter);
+}
+
+fn load_batch(env: &Env, stream_id: u64, batch_id: u64) -> UsageBatch {
+    env.storage()
+        .persistent()
+        .get(&AttKey::Batch(stream_id, batch_id))
+        .expect("usage batch not found")
+}
+
+fn save_batch(env: &Env, batch: &UsageBatch) {
+    env.storage()
+        .persistent()
+        .set(&AttKey::Batch(batch.stream_id, batch.id), batch);
+}
+
+/// True when `signature` is a good Ed25519 signature over `message`.
+///
+/// Routed through the registered sig_check contract because
+/// `env.crypto().ed25519_verify` panics on a bad signature and Soroban forbids
+/// re-entering this contract to catch it. See contracts/sig_check.
+fn signature_is_valid(
+    env: &Env,
+    public_key: &BytesN<32>,
+    message: &Bytes,
+    signature: &BytesN<64>,
+) -> bool {
+    let checker: Address = env
+        .storage()
+        .instance()
+        .get(&SIG_CHECKER)
+        .expect("sig checker not configured; call set_sig_checker first");
+
+    env.try_invoke_contract::<(), soroban_sdk::Error>(
+        &checker,
+        &Symbol::new(env, "verify"),
+        soroban_sdk::vec![
+            env,
+            public_key.into_val(env),
+            message.into_val(env),
+            signature.into_val(env)
+        ],
+    )
+    .is_ok()
+}
+
+/// The leaf's 0-based position within its batch.
+///
+/// Derived from committed values only — `first_call_index` is fixed at record
+/// time and `call_index` is inside the signed leaf — so a challenger cannot
+/// choose a position that inflates their refund.
+fn position_in_batch(batch: &UsageBatch, leaf: &AttestationLeaf) -> u64 {
+    assert!(
+        leaf.call_index >= batch.first_call_index,
+        "leaf precedes the batch"
+    );
+    let position = leaf.call_index - batch.first_call_index;
+    assert!(position < batch.call_count, "leaf is past the end of the batch");
+    position
+}
+
+/// Reverse the suffix starting at `position` and move the money back.
+///
+/// Idempotent in the sense that matters: a second challenge naming a *later*
+/// call is rejected (the suffix would shrink), and one naming an earlier call
+/// only refunds the difference, so a batch can never refund more than it
+/// charged.
+fn void_suffix(batch: &mut UsageBatch, meter: &mut UsageMeter, position: u64) -> u64 {
+    let new_voided = batch.call_count - position;
+    assert!(
+        new_voided > batch.voided_calls,
+        "this call is already covered by an earlier successful challenge"
+    );
+
+    let newly_voided = new_voided - batch.voided_calls;
+    let refund = (newly_voided as i128) * meter.price_per_call;
+
+    // Charge leaves the seller's claimable column and returns to the buyer's
+    // allowance, where it can be spent on further calls or withdrawn.
+    meter.charged -= refund;
+    meter.escrowed += refund;
+
+    batch.voided_calls = new_voided;
+    batch.refunded += refund;
+    batch.status = if new_voided == batch.call_count {
+        BatchStatus::Voided
+    } else {
+        BatchStatus::Challenged
+    };
+
+    newly_voided
+}
+
+#[contractimpl]
+impl MicropaymentsContract {
+    // ── Configuration ────────────────────────────────────────────────────────
+
+    /// Point the contract at its Ed25519 checker.
+    ///
+    /// Write-once. The checker decides every challenge, so a swappable one
+    /// would let whoever could swap it either void honest batches or protect
+    /// fraudulent ones. Set at deploy, then it is settled.
+    pub fn set_sig_checker(env: Env, checker: Address) {
+        assert!(
+            !env.storage().instance().has(&SIG_CHECKER),
+            "sig checker already set"
+        );
+        env.storage().instance().set(&SIG_CHECKER, &checker);
+    }
+
+    pub fn get_sig_checker(env: Env) -> Option<Address> {
+        env.storage().instance().get(&SIG_CHECKER)
+    }
+
+    /// Register the Ed25519 key a seller signs attestations with.
+    ///
+    /// A Soroban `Address` does not expose the raw key behind it, so the
+    /// mapping has to be declared. `require_auth` means only the seller can
+    /// declare it — nobody can bind a key they do not control to someone else's
+    /// address, and a seller re-keying invalidates only their own future
+    /// batches.
+    pub fn register_attestation_key(env: Env, seller: Address, public_key: BytesN<32>) {
+        seller.require_auth();
+        env.storage()
+            .persistent()
+            .set(&AttKey::SellerKey(seller.clone()), &public_key);
+
+        env.events()
+            .publish((Symbol::new(&env, "ATTEST_KEY_REGISTERED"), seller), public_key);
+    }
+
+    pub fn get_attestation_key(env: Env, seller: Address) -> Option<BytesN<32>> {
+        env.storage().persistent().get(&AttKey::SellerKey(seller))
+    }
+
+    // ── Buyer: funding the allowance ─────────────────────────────────────────
+
+    /// Escrow an allowance for per-call billing on a stream.
+    ///
+    /// `price_per_call` is fixed by the first funding. Letting a later top-up
+    /// change it would silently reprice calls that were already attested but
+    /// not yet batched.
+    pub fn fund_usage_meter(
+        env: Env,
+        buyer: Address,
+        stream_id: u64,
+        price_per_call: i128,
+        amount: i128,
+    ) -> i128 {
+        buyer.require_auth();
+        assert!(price_per_call > 0, "price_per_call must be positive");
+        assert!(amount > 0, "amount must be positive");
+
+        let stream = load_stream(&env, stream_id);
+        assert!(stream.sender == buyer, "not the stream sender");
+        assert!(
+            stream.status == StreamStatus::Active || stream.status == StreamStatus::Paused,
+            "stream is closed"
+        );
+
+        let token_client = token::Client::new(&env, &stream.token);
+        token_client.transfer(&buyer, &env.current_contract_address(), &amount);
+
+        let mut meter = env
+            .storage()
+            .persistent()
+            .get(&AttKey::Meter(stream_id))
+            .unwrap_or(UsageMeter {
+                price_per_call,
+                escrowed: 0,
+                charged: 0,
+                claimed: 0,
+                next_call_index: 0,
+                batch_count: 0,
+            });
+
+        assert!(
+            meter.price_per_call == price_per_call,
+            "price_per_call is fixed for the life of the meter"
+        );
+
+        meter.escrowed += amount;
+        save_meter(&env, stream_id, &meter);
+
+        env.events().publish(
+            (Symbol::new(&env, "USAGE_METER_FUNDED"), buyer),
+            (stream_id, amount, meter.escrowed),
+        );
+
+        meter.escrowed
+    }
+
+    /// Withdraw unspent allowance. Only touches `escrowed`, so money already
+    /// charged for recorded calls is out of reach until it is voided.
+    pub fn withdraw_usage_escrow(env: Env, buyer: Address, stream_id: u64, amount: i128) -> i128 {
+        buyer.require_auth();
+        assert!(amount > 0, "amount must be positive");
+
+        let stream = load_stream(&env, stream_id);
+        assert!(stream.sender == buyer, "not the stream sender");
+
+        let mut meter = load_meter(&env, stream_id);
+        assert!(meter.escrowed >= amount, "insufficient unspent allowance");
+
+        meter.escrowed -= amount;
+        save_meter(&env, stream_id, &meter);
+
+        let token_client = token::Client::new(&env, &stream.token);
+        token_client.transfer(&env.current_contract_address(), &buyer, &amount);
+
+        meter.escrowed
+    }
+
+    // ── Seller: committing usage ─────────────────────────────────────────────
+
+    /// Commit a Merkle root over `call_count` attestations and charge for them.
+    ///
+    /// The signature check here is the strict one: a batch whose commitment
+    /// does not verify must not be recorded at all, so a panic is the correct
+    /// outcome and `ed25519_verify` is called directly.
+    ///
+    /// Returns the new batch id.
+    pub fn record_usage_batch(
+        env: Env,
+        seller: Address,
+        stream_id: u64,
+        merkle_root: BytesN<32>,
+        call_count: u64,
+        batch_signature: BytesN<64>,
+    ) -> u64 {
+        seller.require_auth();
+        assert!(call_count > 0, "a batch must cover at least one call");
+
+        let stream = load_stream(&env, stream_id);
+        assert!(stream.recipient == seller, "not the stream recipient");
+        assert!(
+            stream.status == StreamStatus::Active,
+            "stream is not active"
+        );
+
+        let public_key: BytesN<32> = env
+            .storage()
+            .persistent()
+            .get(&AttKey::SellerKey(seller.clone()))
+            .expect("seller has no registered attestation key");
+
+        env.crypto().ed25519_verify(
+            &public_key,
+            &batch_message(&env, stream_id, &merkle_root, call_count),
+            &batch_signature,
+        );
+
+        let mut meter = load_meter(&env, stream_id);
+        let charge = (call_count as i128) * meter.price_per_call;
+        assert!(
+            meter.escrowed >= charge,
+            "usage allowance exhausted: fund the meter before recording"
+        );
+
+        meter.escrowed -= charge;
+        meter.charged += charge;
+
+        let batch_id = meter.batch_count + 1;
+        let first_call_index = meter.next_call_index;
+        meter.batch_count = batch_id;
+        meter.next_call_index = first_call_index + call_count;
+        save_meter(&env, stream_id, &meter);
+
+        let batch = UsageBatch {
+            id: batch_id,
+            stream_id,
+            seller: seller.clone(),
+            merkle_root: merkle_root.clone(),
+            call_count,
+            first_call_index,
+            charged: charge,
+            voided_calls: 0,
+            refunded: 0,
+            recorded_at: env.ledger().timestamp(),
+            status: BatchStatus::Recorded,
+        };
+        save_batch(&env, &batch);
+
+        env.events().publish(
+            (Symbol::new(&env, "USAGE_BATCH_RECORDED"), seller),
+            (stream_id, batch_id, merkle_root, call_count, charge),
+        );
+
+        batch_id
+    }
+
+    /// Pay out a batch, once its challenge window has closed.
+    ///
+    /// Per batch rather than per stream so one disputed batch cannot hold an
+    /// honest seller's other batches hostage.
+    pub fn claim_usage_batch(env: Env, seller: Address, stream_id: u64, batch_id: u64) -> i128 {
+        seller.require_auth();
+
+        let stream = load_stream(&env, stream_id);
+        assert!(stream.recipient == seller, "not the stream recipient");
+
+        let mut batch = load_batch(&env, stream_id, batch_id);
+        assert!(batch.seller == seller, "not the batch seller");
+        assert!(
+            batch.status != BatchStatus::Claimed,
+            "batch already claimed"
+        );
+        assert!(
+            env.ledger().timestamp() >= batch.recorded_at + CHALLENGE_WINDOW_SECS,
+            "challenge window is still open"
+        );
+
+        let payable = batch.charged - batch.refunded;
+        batch.status = BatchStatus::Claimed;
+        save_batch(&env, &batch);
+
+        if payable <= 0 {
+            // Fully voided: nothing to pay, but the batch is closed out so it
+            // cannot be re-challenged or re-claimed.
+            return 0;
+        }
+
+        let mut meter = load_meter(&env, stream_id);
+        meter.charged -= payable;
+        meter.claimed += payable;
+        save_meter(&env, stream_id, &meter);
+
+        let token_client = token::Client::new(&env, &stream.token);
+        token_client.transfer(&env.current_contract_address(), &seller, &payable);
+
+        env.events().publish(
+            (Symbol::new(&env, "USAGE_BATCH_CLAIMED"), seller),
+            (stream_id, batch_id, payable),
+        );
+
+        payable
+    }
+
+    // ── Buyer: disputes ──────────────────────────────────────────────────────
+
+    /// Dispute one attestation inside a committed batch.
+    ///
+    /// The buyer supplies the leaf they contest plus the sibling hashes tying
+    /// it to the committed root. Two things then have to be true for the
+    /// challenge to succeed:
+    ///
+    ///   - the proof re-derives the batch's committed root, so the seller
+    ///     really did commit to this exact leaf, and
+    ///   - the leaf's signature does *not* verify under the seller's registered
+    ///     key, so the seller committed to something they never signed.
+    ///
+    /// A proof that does not reach the root is rejected outright. A leaf that
+    /// *does* verify means the buyer challenged an honest call, and the call
+    /// panics rather than voiding anything.
+    ///
+    /// Returns how many calls this challenge newly voided.
+    pub fn challenge_usage_batch(
+        env: Env,
+        buyer: Address,
+        stream_id: u64,
+        batch_id: u64,
+        disputed_leaf: AttestationLeaf,
+        merkle_proof: Vec<BytesN<32>>,
+    ) -> u64 {
+        buyer.require_auth();
+
+        let stream = load_stream(&env, stream_id);
+        assert!(stream.sender == buyer, "not the stream sender");
+        assert!(
+            disputed_leaf.stream_id == stream_id,
+            "leaf belongs to a different stream"
+        );
+
+        let mut batch = load_batch(&env, stream_id, batch_id);
+        assert!(
+            batch.status != BatchStatus::Claimed,
+            "batch already claimed; the challenge window has closed"
+        );
+        assert!(
+            env.ledger().timestamp() < batch.recorded_at + CHALLENGE_WINDOW_SECS,
+            "challenge window has closed"
+        );
+
+        // 1. Is this leaf actually under the committed root?
+        let leaf = leaf_hash(&env, &disputed_leaf);
+        let derived_root = root_from_proof(&env, &leaf, &merkle_proof);
+        assert!(
+            derived_root == batch.merkle_root,
+            "merkle proof does not reproduce the committed root"
+        );
+
+        // 2. Did the seller sign it? If they did, the batch stands.
+        let public_key: BytesN<32> = env
+            .storage()
+            .persistent()
+            .get(&AttKey::SellerKey(batch.seller.clone()))
+            .expect("seller has no registered attestation key");
+
+        let signed = signature_is_valid(
+            &env,
+            &public_key,
+            &leaf_message(&env, &disputed_leaf),
+            &disputed_leaf.signature,
+        );
+        assert!(
+            !signed,
+            "attestation is validly signed; nothing to challenge"
+        );
+
+        let position = position_in_batch(&batch, &disputed_leaf);
+        let mut meter = load_meter(&env, stream_id);
+        let newly_voided = void_suffix(&mut batch, &mut meter, position);
+
+        save_meter(&env, stream_id, &meter);
+        save_batch(&env, &batch);
+
+        env.events().publish(
+            (Symbol::new(&env, "USAGE_BATCH_VOIDED"), buyer),
+            (
+                stream_id,
+                batch_id,
+                disputed_leaf.call_index,
+                newly_voided,
+                batch.refunded,
+            ),
+        );
+
+        newly_voided
+    }
+
+    /// Dispute a nonce replayed across two committed batches.
+    ///
+    /// A reused nonce needs no signature check to be damning: both leaves are
+    /// provably committed, and both carry the same nonce, which an honest
+    /// seller never emits twice on one stream. The *later* leaf is the
+    /// fraudulent one, so its batch takes the void.
+    ///
+    /// This is a second entrypoint rather than a branch inside
+    /// `challenge_usage_batch` because proving replay takes two leaves and two
+    /// proofs, and folding them into a signature whose shape says "one disputed
+    /// leaf" would make both paths harder to read.
+    pub fn challenge_nonce_replay(
+        env: Env,
+        buyer: Address,
+        stream_id: u64,
+        original_batch_id: u64,
+        original_leaf: AttestationLeaf,
+        original_proof: Vec<BytesN<32>>,
+        replay_batch_id: u64,
+        replay_leaf: AttestationLeaf,
+        replay_proof: Vec<BytesN<32>>,
+    ) -> u64 {
+        buyer.require_auth();
+
+        let stream = load_stream(&env, stream_id);
+        assert!(stream.sender == buyer, "not the stream sender");
+        assert!(
+            original_leaf.stream_id == stream_id && replay_leaf.stream_id == stream_id,
+            "leaves belong to a different stream"
+        );
+        assert!(
+            original_leaf.nonce == replay_leaf.nonce,
+            "leaves do not share a nonce; nothing was replayed"
+        );
+        assert!(
+            original_leaf.call_index != replay_leaf.call_index,
+            "both leaves are the same call"
+        );
+        assert!(
+            original_leaf.call_index < replay_leaf.call_index,
+            "the replay must be the later call"
+        );
+
+        // Both leaves must really be committed — otherwise a buyer could invent
+        // a "duplicate" out of thin air.
+        let original_batch = load_batch(&env, stream_id, original_batch_id);
+        let original_hash = leaf_hash(&env, &original_leaf);
+        assert!(
+            root_from_proof(&env, &original_hash, &original_proof) == original_batch.merkle_root,
+            "original leaf is not committed in its batch"
+        );
+
+        let mut replay_batch = load_batch(&env, stream_id, replay_batch_id);
+        assert!(
+            replay_batch.status != BatchStatus::Claimed,
+            "batch already claimed; the challenge window has closed"
+        );
+        assert!(
+            env.ledger().timestamp() < replay_batch.recorded_at + CHALLENGE_WINDOW_SECS,
+            "challenge window has closed"
+        );
+
+        let replay_hash = leaf_hash(&env, &replay_leaf);
+        assert!(
+            root_from_proof(&env, &replay_hash, &replay_proof) == replay_batch.merkle_root,
+            "replayed leaf is not committed in its batch"
+        );
+
+        let position = position_in_batch(&replay_batch, &replay_leaf);
+        let mut meter = load_meter(&env, stream_id);
+        let newly_voided = void_suffix(&mut replay_batch, &mut meter, position);
+
+        save_meter(&env, stream_id, &meter);
+        save_batch(&env, &replay_batch);
+
+        env.events().publish(
+            (Symbol::new(&env, "USAGE_NONCE_REPLAYED"), buyer),
+            (
+                stream_id,
+                replay_batch_id,
+                replay_leaf.call_index,
+                newly_voided,
+            ),
+        );
+
+        newly_voided
+    }
+
+    // ── Views ────────────────────────────────────────────────────────────────
+
+    pub fn get_usage_meter(env: Env, stream_id: u64) -> Option<UsageMeter> {
+        env.storage().persistent().get(&AttKey::Meter(stream_id))
+    }
+
+    pub fn get_usage_batch(env: Env, stream_id: u64, batch_id: u64) -> Option<UsageBatch> {
+        env.storage()
+            .persistent()
+            .get(&AttKey::Batch(stream_id, batch_id))
+    }
+
+    /// How many more calls the buyer's escrowed allowance covers.
+    pub fn usage_calls_remaining(env: Env, stream_id: u64) -> u64 {
+        match env
+            .storage()
+            .persistent()
+            .get::<AttKey, UsageMeter>(&AttKey::Meter(stream_id))
+        {
+            Some(meter) if meter.price_per_call > 0 => (meter.escrowed / meter.price_per_call) as u64,
+            _ => 0,
+        }
+    }
+
+    /// Check a Merkle proof without spending anything — the read-only twin of
+    /// the first half of `challenge_usage_batch`, so a buyer can confirm their
+    /// proof is well-formed before paying to submit it.
+    pub fn verify_usage_proof(
+        env: Env,
+        stream_id: u64,
+        batch_id: u64,
+        leaf: AttestationLeaf,
+        merkle_proof: Vec<BytesN<32>>,
+    ) -> bool {
+        match env
+            .storage()
+            .persistent()
+            .get::<AttKey, UsageBatch>(&AttKey::Batch(stream_id, batch_id))
+        {
+            Some(batch) => {
+                let hash = leaf_hash(&env, &leaf);
+                root_from_proof(&env, &hash, &merkle_proof) == batch.merkle_root
+            }
+            None => false,
+        }
+    }
+
+    /// The leaf hash for an attestation, exposed so an off-chain verifier can
+    /// confirm it derives leaves the same way the contract does.
+    pub fn attestation_leaf_hash(env: Env, leaf: AttestationLeaf) -> BytesN<32> {
+        leaf_hash(&env, &leaf)
+    }
+}

--- a/contract/contracts/micropayments/src/attestation_test.rs
+++ b/contract/contracts/micropayments/src/attestation_test.rs
@@ -1,0 +1,789 @@
+//! Tests for proof-of-execution attestation.
+//!
+//! The suite is built around one scenario — a seller commits a batch of signed
+//! calls and a buyer tries to break it — exercised from both sides: honest
+//! batches must survive every challenge, and dishonest ones must lose exactly
+//! the right amount of money.
+//!
+//! Signing happens with ed25519-dalek rather than through soroban's testutils
+//! because the interesting cases need signatures that are *wrong* in specific
+//! ways: signed by the wrong key, over the wrong bytes, or absent entirely.
+
+extern crate alloc;
+
+use super::*;
+use crate::attestation::{batch_message, hash_internal, leaf_hash, leaf_message};
+use alloc::vec::Vec as StdVec;
+use ed25519_dalek::{Signer, SigningKey};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger, LedgerInfo},
+    token, Address, Bytes, BytesN, Env, Vec,
+};
+
+const PRICE: i128 = 1_000;
+
+// ── Harness ──────────────────────────────────────────────────────────────────
+
+struct Fixture {
+    env: Env,
+    client: MicropaymentsContractClient<'static>,
+    buyer: Address,
+    seller: Address,
+    signing_key: SigningKey,
+    stream_id: u64,
+}
+
+fn to_vec(bytes: &Bytes) -> StdVec<u8> {
+    bytes.iter().collect()
+}
+
+/// A deterministic Ed25519 key. Fixed seeds keep failures reproducible.
+fn signing_key(seed: u8) -> SigningKey {
+    SigningKey::from_bytes(&[seed; 32])
+}
+
+fn public_key(env: &Env, key: &SigningKey) -> BytesN<32> {
+    BytesN::from_array(env, &key.verifying_key().to_bytes())
+}
+
+fn sign(env: &Env, key: &SigningKey, message: &Bytes) -> BytesN<64> {
+    BytesN::from_array(env, &key.sign(&to_vec(message)).to_bytes())
+}
+
+/// A funded stream with a registered attestation key and an escrowed allowance.
+fn setup(allowance_calls: u64) -> Fixture {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(MicropaymentsContract, ());
+    let client = MicropaymentsContractClient::new(&env, &contract_id);
+
+    // The signature checker has to exist before any challenge can be resolved.
+    let checker = env.register(sig_check::SigCheckContract, ());
+    client.set_sig_checker(&checker);
+
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_address = token_contract.address();
+    token::StellarAssetClient::new(&env, &token_address).mint(&buyer, &100_000_000);
+
+    let stream_id = client.open_stream(&buyer, &seller, &token_address, &10_000_000, &100, &3600);
+
+    let signing_key = signing_key(7);
+    client.register_attestation_key(&seller, &public_key(&env, &signing_key));
+    client.fund_usage_meter(&buyer, &stream_id, &PRICE, &((allowance_calls as i128) * PRICE));
+
+    Fixture {
+        env,
+        client,
+        buyer,
+        seller,
+        signing_key,
+        stream_id,
+    }
+}
+
+/// Build an attestation leaf, signed by `key` unless `key` is None.
+///
+/// A `None` key produces a leaf carrying a syntactically valid but meaningless
+/// signature — the shape of a fabricated call the seller committed to without
+/// ever having served it.
+fn make_leaf(
+    env: &Env,
+    stream_id: u64,
+    call_index: u64,
+    nonce_seed: u8,
+    key: Option<&SigningKey>,
+) -> AttestationLeaf {
+    let mut leaf = AttestationLeaf {
+        stream_id,
+        call_index,
+        request_hash: BytesN::from_array(env, &[call_index as u8; 32]),
+        response_hash: BytesN::from_array(env, &[(call_index as u8).wrapping_add(128); 32]),
+        timestamp: 1_700_000_000 + call_index,
+        nonce: BytesN::from_array(env, &[nonce_seed; 32]),
+        signature: BytesN::from_array(env, &[0u8; 64]),
+    };
+
+    leaf.signature = match key {
+        Some(k) => sign(env, k, &leaf_message(env, &leaf)),
+        None => BytesN::from_array(env, &[0xABu8; 64]),
+    };
+    leaf
+}
+
+/// A run of honestly signed leaves starting at `first_call_index`.
+fn honest_leaves(fx: &Fixture, first_call_index: u64, count: u64) -> StdVec<AttestationLeaf> {
+    (0..count)
+        .map(|i| {
+            make_leaf(
+                &fx.env,
+                fx.stream_id,
+                first_call_index + i,
+                (first_call_index + i) as u8,
+                Some(&fx.signing_key),
+            )
+        })
+        .collect()
+}
+
+/// Merkle levels, leaves first. Mirrors MerkleBatchBuilder: odd tails pair with
+/// themselves and children are ordered by byte value.
+fn build_levels(env: &Env, leaves: &[AttestationLeaf]) -> StdVec<StdVec<BytesN<32>>> {
+    let bottom: StdVec<BytesN<32>> = leaves.iter().map(|l| leaf_hash(env, l)).collect();
+    let mut levels: StdVec<StdVec<BytesN<32>>> = StdVec::new();
+    levels.push(bottom);
+
+    while levels[levels.len() - 1].len() > 1 {
+        let current = levels[levels.len() - 1].clone();
+        let mut next: StdVec<BytesN<32>> = StdVec::new();
+        let mut i = 0usize;
+        while i < current.len() {
+            let left = &current[i];
+            let right = if i + 1 < current.len() { &current[i + 1] } else { left };
+            next.push(hash_internal(env, left, right));
+            i += 2;
+        }
+        levels.push(next);
+    }
+    levels
+}
+
+fn merkle_root(env: &Env, leaves: &[AttestationLeaf]) -> BytesN<32> {
+    let levels = build_levels(env, leaves);
+    levels[levels.len() - 1][0].clone()
+}
+
+fn merkle_proof(env: &Env, leaves: &[AttestationLeaf], position: usize) -> Vec<BytesN<32>> {
+    let levels = build_levels(env, leaves);
+    let mut proof: Vec<BytesN<32>> = Vec::new(env);
+    let mut index = position;
+
+    // Every level but the root contributes one sibling.
+    for depth in 0..levels.len() - 1 {
+        let level = &levels[depth];
+        let sibling = if index % 2 == 1 { index - 1 } else { index + 1 };
+        let node = if sibling < level.len() {
+            level[sibling].clone()
+        } else {
+            // Odd tail: it was paired with itself.
+            level[index].clone()
+        };
+        proof.push_back(node);
+        index /= 2;
+    }
+    proof
+}
+
+/// Commit a batch on-chain and hand back its id.
+fn record(fx: &Fixture, leaves: &[AttestationLeaf]) -> u64 {
+    let root = merkle_root(&fx.env, leaves);
+    let message = batch_message(&fx.env, fx.stream_id, &root, leaves.len() as u64);
+    let signature = sign(&fx.env, &fx.signing_key, &message);
+
+    fx.client.record_usage_batch(
+        &fx.seller,
+        &fx.stream_id,
+        &root,
+        &(leaves.len() as u64),
+        &signature,
+    )
+}
+
+fn advance_to(env: &Env, timestamp: u64) {
+    env.ledger().set(LedgerInfo {
+        timestamp,
+        protocol_version: 22,
+        sequence_number: 10,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 16,
+        min_persistent_entry_ttl: 100_000,
+        max_entry_ttl: 6_312_000,
+    });
+}
+
+// ── Registration and funding ─────────────────────────────────────────────────
+
+#[test]
+fn registers_the_sellers_attestation_key() {
+    let fx = setup(10);
+    let stored = fx.client.get_attestation_key(&fx.seller).unwrap();
+    assert_eq!(stored, public_key(&fx.env, &fx.signing_key));
+}
+
+#[test]
+fn funding_sets_the_call_allowance() {
+    let fx = setup(10);
+
+    let meter = fx.client.get_usage_meter(&fx.stream_id).unwrap();
+    assert_eq!(meter.escrowed, 10 * PRICE);
+    assert_eq!(meter.price_per_call, PRICE);
+    assert_eq!(meter.next_call_index, 0);
+    assert_eq!(fx.client.usage_calls_remaining(&fx.stream_id), 10);
+}
+
+#[test]
+#[should_panic(expected = "price_per_call is fixed")]
+fn a_top_up_cannot_reprice_calls() {
+    let fx = setup(10);
+    // Repricing mid-meter would silently change what already-attested but
+    // not-yet-batched calls cost.
+    fx.client
+        .fund_usage_meter(&fx.buyer, &fx.stream_id, &(PRICE * 2), &(PRICE * 2));
+}
+
+// ── Recording ────────────────────────────────────────────────────────────────
+
+#[test]
+fn recording_a_batch_charges_exactly_call_count() {
+    let fx = setup(50);
+    let leaves = honest_leaves(&fx, 0, 20);
+
+    let batch_id = record(&fx, &leaves);
+    assert_eq!(batch_id, 1);
+
+    let meter = fx.client.get_usage_meter(&fx.stream_id).unwrap();
+    assert_eq!(meter.escrowed, 30 * PRICE, "20 of 50 calls consumed");
+    assert_eq!(meter.charged, 20 * PRICE);
+    assert_eq!(meter.next_call_index, 20);
+    assert_eq!(fx.client.usage_calls_remaining(&fx.stream_id), 30);
+
+    let batch = fx.client.get_usage_batch(&fx.stream_id, &batch_id).unwrap();
+    assert_eq!(batch.call_count, 20);
+    assert_eq!(batch.first_call_index, 0);
+    assert_eq!(batch.charged, 20 * PRICE);
+    assert_eq!(batch.status, BatchStatus::Recorded);
+}
+
+#[test]
+fn consecutive_batches_continue_the_index_run() {
+    let fx = setup(50);
+    record(&fx, &honest_leaves(&fx, 0, 5));
+    let second = record(&fx, &honest_leaves(&fx, 5, 7));
+
+    let batch = fx.client.get_usage_batch(&fx.stream_id, &second).unwrap();
+    assert_eq!(batch.first_call_index, 5);
+    assert_eq!(batch.call_count, 7);
+    assert_eq!(
+        fx.client.get_usage_meter(&fx.stream_id).unwrap().next_call_index,
+        12
+    );
+}
+
+#[test]
+#[should_panic]
+fn a_forged_batch_signature_cannot_be_recorded() {
+    let fx = setup(50);
+    let leaves = honest_leaves(&fx, 0, 4);
+    let root = merkle_root(&fx.env, &leaves);
+
+    // Signed by a key the seller never registered.
+    let impostor = signing_key(99);
+    let signature = sign(
+        &fx.env,
+        &impostor,
+        &batch_message(&fx.env, fx.stream_id, &root, 4),
+    );
+
+    fx.client
+        .record_usage_batch(&fx.seller, &fx.stream_id, &root, &4, &signature);
+}
+
+#[test]
+#[should_panic]
+fn a_batch_signature_over_a_different_call_count_is_rejected() {
+    let fx = setup(50);
+    let leaves = honest_leaves(&fx, 0, 4);
+    let root = merkle_root(&fx.env, &leaves);
+
+    // Sign for 4 calls, then try to charge for 40. The count is inside the
+    // signed bytes precisely so this fails.
+    let signature = sign(
+        &fx.env,
+        &fx.signing_key,
+        &batch_message(&fx.env, fx.stream_id, &root, 4),
+    );
+
+    fx.client
+        .record_usage_batch(&fx.seller, &fx.stream_id, &root, &40, &signature);
+}
+
+#[test]
+#[should_panic(expected = "usage allowance exhausted")]
+fn a_batch_larger_than_the_allowance_is_rejected() {
+    let fx = setup(5);
+    record(&fx, &honest_leaves(&fx, 0, 6));
+}
+
+// ── Merkle proofs ────────────────────────────────────────────────────────────
+
+#[test]
+fn every_leaf_in_a_batch_verifies_against_the_committed_root() {
+    // Sizes chosen to cover a perfect tree, both odd-tail shapes, and a
+    // single-leaf tree with an empty proof.
+    for count in [1u64, 2, 3, 5, 8, 11] {
+        let fx = setup(200);
+        let leaves = honest_leaves(&fx, 0, count);
+        let batch_id = record(&fx, &leaves);
+
+        for (position, leaf) in leaves.iter().enumerate() {
+            let proof = merkle_proof(&fx.env, &leaves, position);
+            assert!(
+                fx.client
+                    .verify_usage_proof(&fx.stream_id, &batch_id, leaf, &proof),
+                "leaf {position} of {count} failed to verify"
+            );
+        }
+    }
+}
+
+#[test]
+fn a_leaf_that_was_never_committed_fails_to_verify() {
+    let fx = setup(50);
+    let leaves = honest_leaves(&fx, 0, 8);
+    let batch_id = record(&fx, &leaves);
+
+    // A properly signed leaf that simply is not in this batch, presented with
+    // another leaf's proof.
+    let outsider = make_leaf(&fx.env, fx.stream_id, 3, 200, Some(&fx.signing_key));
+    let proof = merkle_proof(&fx.env, &leaves, 3);
+
+    assert!(!fx
+        .client
+        .verify_usage_proof(&fx.stream_id, &batch_id, &outsider, &proof));
+}
+
+// ── Challenges: forged attestations ──────────────────────────────────────────
+
+#[test]
+fn a_forged_attestation_voids_the_batch_suffix() {
+    let fx = setup(50);
+
+    // 10 calls, of which the seller fabricated the one at index 6.
+    let mut leaves = honest_leaves(&fx, 0, 10);
+    leaves[6] = make_leaf(&fx.env, fx.stream_id, 6, 6, None);
+    let batch_id = record(&fx, &leaves);
+
+    let proof = merkle_proof(&fx.env, &leaves, 6);
+    let voided = fx.client.challenge_usage_batch(
+        &fx.buyer,
+        &fx.stream_id,
+        &batch_id,
+        &leaves[6],
+        &proof,
+    );
+
+    // Positions 6..9 inclusive — the forged call and everything numbered after
+    // it — are reversed. Positions 0..5 were honestly attested and still stand.
+    assert_eq!(voided, 4);
+
+    let batch = fx.client.get_usage_batch(&fx.stream_id, &batch_id).unwrap();
+    assert_eq!(batch.voided_calls, 4);
+    assert_eq!(batch.refunded, 4 * PRICE);
+    assert_eq!(batch.status, BatchStatus::Challenged);
+}
+
+#[test]
+fn a_forgery_at_the_first_call_voids_the_whole_batch() {
+    let fx = setup(50);
+    let mut leaves = honest_leaves(&fx, 0, 10);
+    leaves[0] = make_leaf(&fx.env, fx.stream_id, 0, 0, None);
+    let batch_id = record(&fx, &leaves);
+
+    let proof = merkle_proof(&fx.env, &leaves, 0);
+    let voided =
+        fx.client
+            .challenge_usage_batch(&fx.buyer, &fx.stream_id, &batch_id, &leaves[0], &proof);
+
+    assert_eq!(voided, 10);
+    let batch = fx.client.get_usage_batch(&fx.stream_id, &batch_id).unwrap();
+    assert_eq!(batch.status, BatchStatus::Voided);
+    assert_eq!(batch.refunded, batch.charged);
+}
+
+#[test]
+fn voided_funds_return_to_the_buyers_allowance() {
+    let fx = setup(50);
+    let mut leaves = honest_leaves(&fx, 0, 10);
+    leaves[6] = make_leaf(&fx.env, fx.stream_id, 6, 6, None);
+    let batch_id = record(&fx, &leaves);
+
+    let after_record = fx.client.get_usage_meter(&fx.stream_id).unwrap();
+    assert_eq!(after_record.escrowed, 40 * PRICE);
+    assert_eq!(after_record.charged, 10 * PRICE);
+
+    let proof = merkle_proof(&fx.env, &leaves, 6);
+    fx.client
+        .challenge_usage_batch(&fx.buyer, &fx.stream_id, &batch_id, &leaves[6], &proof);
+
+    let after_void = fx.client.get_usage_meter(&fx.stream_id).unwrap();
+    // The 4 voided calls move back out of the seller's column and into the
+    // buyer's spendable allowance. Nothing is created or destroyed.
+    assert_eq!(after_void.escrowed, 44 * PRICE);
+    assert_eq!(after_void.charged, 6 * PRICE);
+    assert_eq!(
+        after_void.escrowed + after_void.charged,
+        after_record.escrowed + after_record.charged
+    );
+}
+
+#[test]
+fn partial_void_arithmetic_holds_at_every_position() {
+    // The refund is a pure function of where the forgery sits, so check the
+    // whole range rather than one convenient case.
+    for position in 0..8u64 {
+        let fx = setup(100);
+        let mut leaves = honest_leaves(&fx, 0, 8);
+        leaves[position as usize] =
+            make_leaf(&fx.env, fx.stream_id, position, position as u8, None);
+        let batch_id = record(&fx, &leaves);
+
+        let proof = merkle_proof(&fx.env, &leaves, position as usize);
+        let voided = fx.client.challenge_usage_batch(
+            &fx.buyer,
+            &fx.stream_id,
+            &batch_id,
+            &leaves[position as usize],
+            &proof,
+        );
+
+        let expected = 8 - position;
+        assert_eq!(voided, expected, "forgery at position {position}");
+
+        let meter = fx.client.get_usage_meter(&fx.stream_id).unwrap();
+        assert_eq!(meter.charged, ((8 - expected) as i128) * PRICE);
+        assert_eq!(meter.escrowed, (92 + expected as i128) * PRICE);
+    }
+}
+
+#[test]
+fn a_batch_offset_from_zero_prices_its_void_correctly() {
+    // first_call_index is what turns a call_index into a position; a batch that
+    // does not start at zero is where an off-by-one would show up.
+    let fx = setup(100);
+    record(&fx, &honest_leaves(&fx, 0, 12));
+
+    let mut leaves = honest_leaves(&fx, 12, 6);
+    leaves[4] = make_leaf(&fx.env, fx.stream_id, 16, 16, None);
+    let batch_id = record(&fx, &leaves);
+
+    let proof = merkle_proof(&fx.env, &leaves, 4);
+    let voided =
+        fx.client
+            .challenge_usage_batch(&fx.buyer, &fx.stream_id, &batch_id, &leaves[4], &proof);
+
+    // call_index 16 sits at position 16 - 12 = 4 in a 6-call batch.
+    assert_eq!(voided, 2);
+}
+
+#[test]
+#[should_panic(expected = "attestation is validly signed")]
+fn challenging_an_honest_attestation_fails() {
+    let fx = setup(50);
+    let leaves = honest_leaves(&fx, 0, 6);
+    let batch_id = record(&fx, &leaves);
+
+    let proof = merkle_proof(&fx.env, &leaves, 2);
+    fx.client
+        .challenge_usage_batch(&fx.buyer, &fx.stream_id, &batch_id, &leaves[2], &proof);
+}
+
+#[test]
+#[should_panic(expected = "merkle proof does not reproduce")]
+fn challenging_with_a_leaf_outside_the_batch_fails() {
+    let fx = setup(50);
+    let leaves = honest_leaves(&fx, 0, 6);
+    let batch_id = record(&fx, &leaves);
+
+    // An unsigned leaf the seller never committed. Without the proof check a
+    // buyer could void any batch by inventing a bad leaf out of nothing.
+    let invented = make_leaf(&fx.env, fx.stream_id, 2, 250, None);
+    let proof = merkle_proof(&fx.env, &leaves, 2);
+
+    fx.client
+        .challenge_usage_batch(&fx.buyer, &fx.stream_id, &batch_id, &invented, &proof);
+}
+
+#[test]
+#[should_panic(expected = "already covered by an earlier successful challenge")]
+fn a_second_challenge_cannot_shrink_the_voided_suffix() {
+    let fx = setup(50);
+    let mut leaves = honest_leaves(&fx, 0, 10);
+    leaves[3] = make_leaf(&fx.env, fx.stream_id, 3, 3, None);
+    leaves[7] = make_leaf(&fx.env, fx.stream_id, 7, 7, None);
+    let batch_id = record(&fx, &leaves);
+
+    // Voiding from position 3 already covers position 7.
+    fx.client.challenge_usage_batch(
+        &fx.buyer,
+        &fx.stream_id,
+        &batch_id,
+        &leaves[3],
+        &merkle_proof(&fx.env, &leaves, 3),
+    );
+    fx.client.challenge_usage_batch(
+        &fx.buyer,
+        &fx.stream_id,
+        &batch_id,
+        &leaves[7],
+        &merkle_proof(&fx.env, &leaves, 7),
+    );
+}
+
+#[test]
+fn a_second_challenge_further_back_refunds_only_the_difference() {
+    let fx = setup(50);
+    let mut leaves = honest_leaves(&fx, 0, 10);
+    leaves[3] = make_leaf(&fx.env, fx.stream_id, 3, 3, None);
+    leaves[7] = make_leaf(&fx.env, fx.stream_id, 7, 7, None);
+    let batch_id = record(&fx, &leaves);
+
+    let first = fx.client.challenge_usage_batch(
+        &fx.buyer,
+        &fx.stream_id,
+        &batch_id,
+        &leaves[7],
+        &merkle_proof(&fx.env, &leaves, 7),
+    );
+    assert_eq!(first, 3, "positions 7..9");
+
+    let second = fx.client.challenge_usage_batch(
+        &fx.buyer,
+        &fx.stream_id,
+        &batch_id,
+        &leaves[3],
+        &merkle_proof(&fx.env, &leaves, 3),
+    );
+    assert_eq!(second, 4, "positions 3..6, the ones not already voided");
+
+    let batch = fx.client.get_usage_batch(&fx.stream_id, &batch_id).unwrap();
+    assert_eq!(batch.voided_calls, 7);
+    // 7 calls refunded in total, never 10 — the batch cannot over-refund.
+    assert_eq!(batch.refunded, 7 * PRICE);
+    assert!(batch.refunded < batch.charged);
+}
+
+// ── Challenges: replayed nonces ──────────────────────────────────────────────
+
+#[test]
+fn a_nonce_replayed_across_two_batches_is_voided() {
+    let fx = setup(50);
+
+    let first_leaves = honest_leaves(&fx, 0, 4);
+    let first_batch = record(&fx, &first_leaves);
+
+    // The seller re-serves call 0's nonce as a "new" call at index 5. Both
+    // leaves are honestly signed; the fraud is the repetition itself.
+    let mut second_leaves = honest_leaves(&fx, 4, 4);
+    second_leaves[1] = make_leaf(&fx.env, fx.stream_id, 5, 0, Some(&fx.signing_key));
+    let second_batch = record(&fx, &second_leaves);
+
+    let voided = fx.client.challenge_nonce_replay(
+        &fx.buyer,
+        &fx.stream_id,
+        &first_batch,
+        &first_leaves[0],
+        &merkle_proof(&fx.env, &first_leaves, 0),
+        &second_batch,
+        &second_leaves[1],
+        &merkle_proof(&fx.env, &second_leaves, 1),
+    );
+
+    // The replay sits at position 1 of a 4-call batch, so 3 calls reverse.
+    assert_eq!(voided, 3);
+
+    let batch = fx.client.get_usage_batch(&fx.stream_id, &second_batch).unwrap();
+    assert_eq!(batch.refunded, 3 * PRICE);
+    // The original batch is untouched: it did nothing wrong.
+    let untouched = fx.client.get_usage_batch(&fx.stream_id, &first_batch).unwrap();
+    assert_eq!(untouched.voided_calls, 0);
+    assert_eq!(untouched.status, BatchStatus::Recorded);
+}
+
+#[test]
+#[should_panic(expected = "do not share a nonce")]
+fn a_replay_claim_over_two_distinct_nonces_is_rejected() {
+    let fx = setup(50);
+    let first_leaves = honest_leaves(&fx, 0, 4);
+    let first_batch = record(&fx, &first_leaves);
+    let second_leaves = honest_leaves(&fx, 4, 4);
+    let second_batch = record(&fx, &second_leaves);
+
+    fx.client.challenge_nonce_replay(
+        &fx.buyer,
+        &fx.stream_id,
+        &first_batch,
+        &first_leaves[0],
+        &merkle_proof(&fx.env, &first_leaves, 0),
+        &second_batch,
+        &second_leaves[1],
+        &merkle_proof(&fx.env, &second_leaves, 1),
+    );
+}
+
+#[test]
+#[should_panic(expected = "not committed in its batch")]
+fn a_replay_claim_needs_both_leaves_committed() {
+    let fx = setup(50);
+    let first_leaves = honest_leaves(&fx, 0, 4);
+    let first_batch = record(&fx, &first_leaves);
+    let second_leaves = honest_leaves(&fx, 4, 4);
+    let second_batch = record(&fx, &second_leaves);
+
+    // A fabricated "original" sharing the replayed leaf's nonce. Without the
+    // proof requirement this would void an honest batch.
+    let invented = make_leaf(&fx.env, fx.stream_id, 1, 5, Some(&fx.signing_key));
+
+    fx.client.challenge_nonce_replay(
+        &fx.buyer,
+        &fx.stream_id,
+        &first_batch,
+        &invented,
+        &merkle_proof(&fx.env, &first_leaves, 1),
+        &second_batch,
+        &second_leaves[1],
+        &merkle_proof(&fx.env, &second_leaves, 1),
+    );
+}
+
+// ── Claiming ─────────────────────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "challenge window is still open")]
+fn a_seller_cannot_claim_inside_the_challenge_window() {
+    let fx = setup(50);
+    let batch_id = record(&fx, &honest_leaves(&fx, 0, 5));
+    fx.client.claim_usage_batch(&fx.seller, &fx.stream_id, &batch_id);
+}
+
+#[test]
+fn a_seller_claims_the_batch_net_of_refunds_once_the_window_closes() {
+    let fx = setup(50);
+    let mut leaves = honest_leaves(&fx, 0, 10);
+    leaves[6] = make_leaf(&fx.env, fx.stream_id, 6, 6, None);
+    let batch_id = record(&fx, &leaves);
+
+    fx.client.challenge_usage_batch(
+        &fx.buyer,
+        &fx.stream_id,
+        &batch_id,
+        &leaves[6],
+        &merkle_proof(&fx.env, &leaves, 6),
+    );
+
+    advance_to(&fx.env, CHALLENGE_WINDOW_SECS + 1);
+    let paid = fx.client.claim_usage_batch(&fx.seller, &fx.stream_id, &batch_id);
+
+    // 10 charged, 4 voided, 6 paid.
+    assert_eq!(paid, 6 * PRICE);
+    let batch = fx.client.get_usage_batch(&fx.stream_id, &batch_id).unwrap();
+    assert_eq!(batch.status, BatchStatus::Claimed);
+}
+
+#[test]
+#[should_panic(expected = "challenge window has closed")]
+fn a_claimed_batch_can_no_longer_be_challenged() {
+    let fx = setup(50);
+    let mut leaves = honest_leaves(&fx, 0, 6);
+    leaves[2] = make_leaf(&fx.env, fx.stream_id, 2, 2, None);
+    let batch_id = record(&fx, &leaves);
+
+    advance_to(&fx.env, CHALLENGE_WINDOW_SECS + 1);
+    fx.client.claim_usage_batch(&fx.seller, &fx.stream_id, &batch_id);
+
+    fx.client.challenge_usage_batch(
+        &fx.buyer,
+        &fx.stream_id,
+        &batch_id,
+        &leaves[2],
+        &merkle_proof(&fx.env, &leaves, 2),
+    );
+}
+
+#[test]
+fn unspent_allowance_returns_to_the_buyer() {
+    let fx = setup(50);
+    record(&fx, &honest_leaves(&fx, 0, 10));
+
+    let remaining = fx.client.withdraw_usage_escrow(&fx.buyer, &fx.stream_id, &(40 * PRICE));
+    assert_eq!(remaining, 0);
+    assert_eq!(fx.client.usage_calls_remaining(&fx.stream_id), 0);
+}
+
+#[test]
+#[should_panic(expected = "insufficient unspent allowance")]
+fn a_buyer_cannot_withdraw_money_already_charged() {
+    let fx = setup(50);
+    record(&fx, &honest_leaves(&fx, 0, 10));
+    // 10 calls' worth is charged and sitting in the seller's column.
+    fx.client
+        .withdraw_usage_escrow(&fx.buyer, &fx.stream_id, &(50 * PRICE));
+}
+
+// ── Cross-language wire compatibility ────────────────────────────────────────
+
+/// Pinned vectors shared with `backend/src/attestation/__tests__`.
+///
+/// The whole scheme rests on the contract and the Node encoder producing
+/// identical bytes: a one-byte disagreement means every on-chain proof silently
+/// stops verifying while both sides still look internally consistent. These
+/// constants were produced by canonical.js and are asserted from both
+/// languages, so a change to either encoder fails a test instead of shipping.
+const VECTOR_LEAF_HASH: [u8; 32] = [
+    0xb4, 0xc1, 0x33, 0x0b, 0xdb, 0xc4, 0x83, 0x25, 0xbd, 0xa5, 0x53, 0x96, 0x52, 0xc3, 0x97, 0x93,
+    0xf3, 0xe7, 0xf4, 0x1d, 0x8d, 0x45, 0x4d, 0xd8, 0x77, 0x33, 0xad, 0xbf, 0x3e, 0xe0, 0x4d, 0x4c,
+];
+
+const VECTOR_INTERNAL_HASH: [u8; 32] = [
+    0x7b, 0xc0, 0x01, 0x03, 0xde, 0x12, 0x06, 0xe4, 0x94, 0x88, 0x08, 0xb1, 0x2b, 0xd2, 0x01, 0x6b,
+    0x69, 0x23, 0x25, 0x8e, 0x43, 0xb9, 0xc2, 0x37, 0x24, 0xed, 0x10, 0x4c, 0xfd, 0xd1, 0xfd, 0xea,
+];
+
+#[test]
+fn leaf_hashing_matches_the_javascript_encoder() {
+    let env = Env::default();
+    let leaf = AttestationLeaf {
+        stream_id: 42,
+        call_index: 7,
+        request_hash: BytesN::from_array(&env, &[0x07; 32]),
+        response_hash: BytesN::from_array(&env, &[0x87; 32]),
+        timestamp: 1_700_000_007,
+        nonce: BytesN::from_array(&env, &[0x07; 32]),
+        signature: BytesN::from_array(&env, &[0u8; 64]),
+    };
+
+    // The 120-byte preimage plus its one-byte domain tag.
+    assert_eq!(leaf_message(&env, &leaf).len(), 121);
+    assert_eq!(leaf_hash(&env, &leaf).to_array(), VECTOR_LEAF_HASH);
+}
+
+#[test]
+fn internal_hashing_is_order_independent_and_matches_javascript() {
+    let env = Env::default();
+    let a = BytesN::from_array(&env, &[0xAA; 32]);
+    let b = BytesN::from_array(&env, &[0x11; 32]);
+
+    // Sorted children: swapping the arguments must not move the root, which is
+    // what lets a proof travel as a bare list of siblings.
+    assert_eq!(hash_internal(&env, &a, &b), hash_internal(&env, &b, &a));
+    assert_eq!(hash_internal(&env, &a, &b).to_array(), VECTOR_INTERNAL_HASH);
+}
+
+#[test]
+fn batch_commitment_bytes_match_the_javascript_encoder() {
+    let env = Env::default();
+    let root = BytesN::from_array(&env, &[0xAB; 32]);
+    let message = batch_message(&env, 42, &root, 20);
+
+    // 0x02 || stream_id(8) || root(32) || call_count(8)
+    assert_eq!(message.len(), 49);
+    let bytes: StdVec<u8> = message.iter().collect();
+    assert_eq!(bytes[0], 0x02);
+    assert_eq!(&bytes[1..9], &42u64.to_be_bytes());
+    assert_eq!(&bytes[9..41], &[0xABu8; 32]);
+    assert_eq!(&bytes[41..49], &20u64.to_be_bytes());
+}

--- a/contract/contracts/micropayments/src/lib.rs
+++ b/contract/contracts/micropayments/src/lib.rs
@@ -411,5 +411,15 @@ impl MicropaymentsContract {
     }
 }
 
+/// Proof-of-execution attestation: Merkle-committed usage batches and the
+/// dispute path that makes them contestable. See attestation.rs.
+mod attestation;
+pub use attestation::{
+    AttestationLeaf, BatchStatus, UsageBatch, UsageMeter, CHALLENGE_WINDOW_SECS,
+};
+
 #[cfg(test)]
 mod test;
+
+#[cfg(test)]
+mod attestation_test;

--- a/contract/contracts/sig_check/Cargo.toml
+++ b/contract/contracts/sig_check/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "sig_check"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contract/contracts/sig_check/src/lib.rs
+++ b/contract/contracts/sig_check/src/lib.rs
@@ -1,0 +1,46 @@
+#![no_std]
+
+//! Ed25519 signature checker, isolated in its own contract so that a *failed*
+//! verification is observable instead of fatal.
+//!
+//! ## Why this contract exists
+//!
+//! `env.crypto().ed25519_verify` returns `()` and panics when a signature is
+//! bad. That is the right shape for the usual case — you want the transaction
+//! dead if the signature is wrong — but `challenge_usage_batch` needs the
+//! opposite: it is *looking* for a bad signature, and a panic would revert the
+//! very transaction meant to record the fraud.
+//!
+//! The standard escape is `env.try_invoke_contract`, which converts a callee's
+//! panic into an `Err`. It cannot be pointed at the calling contract itself:
+//! Soroban forbids contract re-entry, so a self-call is rejected before the
+//! signature is ever checked. So the check lives here, one hop away, where the
+//! panic is catchable.
+//!
+//! ## Trust
+//!
+//! Micropayments treats whatever address it has registered as the checker as
+//! trusted: a checker that never panics makes every challenge fail, and one
+//! that always panics makes every challenge succeed. `set_sig_checker` is
+//! therefore write-once — see the note there. This contract holds no state and
+//! has no admin, so the deployed WASM is the whole of what has to be trusted.
+
+use soroban_sdk::{contract, contractimpl, Bytes, BytesN, Env};
+
+#[contract]
+pub struct SigCheckContract;
+
+#[contractimpl]
+impl SigCheckContract {
+    /// Panics unless `signature` is a valid Ed25519 signature over `message`.
+    ///
+    /// Returning `()` rather than `bool` is deliberate: the caller learns the
+    /// answer from whether the invocation trapped, and a `bool` return would
+    /// invite a caller to ignore it.
+    pub fn verify(env: Env, public_key: BytesN<32>, message: Bytes, signature: BytesN<64>) {
+        env.crypto().ed25519_verify(&public_key, &message, &signature);
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contract/contracts/sig_check/src/test.rs
+++ b/contract/contracts/sig_check/src/test.rs
@@ -1,0 +1,20 @@
+use super::*;
+use soroban_sdk::{testutils::BytesN as _, Bytes, BytesN, Env};
+
+/// A signature over the wrong bytes must trap rather than return.
+///
+/// This is the property `challenge_usage_batch` relies on: it reads the trap,
+/// via try_invoke_contract, as "the seller did not sign this leaf".
+#[test]
+fn bad_signature_traps() {
+    let env = Env::default();
+    let contract_id = env.register(SigCheckContract, ());
+    let client = SigCheckContractClient::new(&env, &contract_id);
+
+    let public_key = BytesN::<32>::random(&env);
+    let signature = BytesN::<64>::random(&env);
+    let message = Bytes::from_array(&env, &[7u8; 32]);
+
+    // try_verify surfaces the trap as Err instead of unwinding the test.
+    assert!(client.try_verify(&public_key, &message, &signature).is_err());
+}


### PR DESCRIPTION
### Description
feat: implement cryptographic attestation and archival for metering calls to ensure data integrity and replay protection

### Backend Integration
Refactor MeteringEngine.js to require a valid attestation from the seller-side integration before crediting usage (sellers integrate via a small helper library that signs each response)
AttestationArchive.js — stores full attestation sets (not just the Merkle root) off-chain so buyers can request the underlying proof for any disputed batch
Migration backend/src/db/migrations/019_add_attestations.sql — attestation_batches, attestation_leaves, used_nonces tables

### SDK (backend/src/sdk/CortexAgentSDK.js)
Seller-side: attestCall(streamId, request, response) — signs and returns an attestation to attach to the API response
Buyer-side: verifyAttestation(attestation, sellerPublicKey) — lets a buyer independently verify a call was legitimately attested without trusting the backend
challengeBatch(streamId, batchId, callIndex) — fetches the archived proof and submits an on-chain challenge

closes #89 