### PR TITLE
feat: implement usage-based payment streaming

### DIFF
--- a/contract/contracts/micropayments/src/lib.rs
+++ b/contract/contracts/micropayments/src/lib.rs
@@ -40,6 +40,23 @@ pub enum SettlementError {
     PartialBatchFailure,
 }
 
+const USAGE_STREAMS: Symbol = symbol_short!("U_STREAMS");
+const USAGE_STREAM_CNT: Symbol = symbol_short!("US_CNT");
+
+/// A usage-based payment stream from a sender to a recipient
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct UsageStream {
+    pub id: u64,
+    pub sender: Address,
+    pub recipient: Address,
+    pub token: Address,
+    pub deposit: i128,
+    pub accrued: i128,
+    pub settled: i128,
+    pub status: StreamStatus,
+}
+
 /// A payment stream from a sender to a recipient
 #[contracttype]
 #[derive(Clone, Debug)]
@@ -83,6 +100,122 @@ pub struct MicropaymentsContract;
 
 #[contractimpl]
 impl MicropaymentsContract {
+    /// Open a usage-based stream.
+    pub fn open(
+        env: Env,
+        sender: Address,
+        recipient: Address,
+        token: Address,
+        deposit: i128,
+    ) -> u64 {
+        sender.require_auth();
+        assert!(deposit > 0, "deposit must be positive");
+
+        // Pull deposit from sender
+        let token_client = soroban_sdk::token::Client::new(&env, &token);
+        token_client.transfer(&sender, &env.current_contract_address(), &deposit);
+
+        let count: u64 = env.storage().instance().get(&USAGE_STREAM_CNT).unwrap_or(0u64);
+        let stream_id = count + 1;
+
+        let stream = UsageStream {
+            id: stream_id,
+            sender: sender.clone(),
+            recipient: recipient.clone(),
+            token,
+            deposit,
+            accrued: 0,
+            settled: 0,
+            status: StreamStatus::Active,
+        };
+
+        let mut streams: Map<u64, UsageStream> = env
+            .storage()
+            .persistent()
+            .get(&USAGE_STREAMS)
+            .unwrap_or(Map::new(&env));
+
+        streams.set(stream_id, stream);
+        env.storage().persistent().set(&USAGE_STREAMS, &streams);
+        env.storage().instance().set(&USAGE_STREAM_CNT, &stream_id);
+
+        env.events()
+            .publish((symbol_short!("U_OPENED"), sender), (stream_id, deposit));
+
+        stream_id
+    }
+
+    /// Accrue usage on a usage-based stream.
+    pub fn increment(env: Env, sender: Address, stream_id: u64, amount: i128) {
+        sender.require_auth();
+        assert!(amount > 0, "amount must be positive");
+
+        let mut streams: Map<u64, UsageStream> = env
+            .storage()
+            .persistent()
+            .get(&USAGE_STREAMS)
+            .unwrap_or(Map::new(&env));
+
+        let mut stream = streams.get(stream_id).unwrap();
+        assert!(stream.sender == sender, "not the stream sender");
+        assert!(stream.status == StreamStatus::Active, "stream not active");
+
+        stream.accrued += amount;
+        assert!(stream.accrued <= stream.deposit, "accrued exceeds deposit");
+
+        streams.set(stream_id, stream);
+        env.storage().persistent().set(&USAGE_STREAMS, &streams);
+
+        env.events()
+            .publish((symbol_short!("U_INCR"), sender), (stream_id, amount));
+    }
+
+    /// Settle a usage-based stream.
+    pub fn settle(env: Env, recipient: Address, stream_id: u64) -> i128 {
+        recipient.require_auth();
+
+        let mut streams: Map<u64, UsageStream> = env
+            .storage()
+            .persistent()
+            .get(&USAGE_STREAMS)
+            .unwrap_or(Map::new(&env));
+
+        let mut stream = streams.get(stream_id).unwrap();
+        assert!(stream.recipient == recipient, "not the stream recipient");
+
+        let claimable = stream.accrued - stream.settled;
+        if claimable <= 0 {
+            return 0;
+        }
+
+        let token_client = soroban_sdk::token::Client::new(&env, &stream.token);
+        token_client.transfer(&env.current_contract_address(), &recipient, &claimable);
+
+        stream.settled += claimable;
+
+        // Auto-complete if deposit exhausted
+        if stream.settled >= stream.deposit {
+            stream.status = StreamStatus::Completed;
+        }
+
+        streams.set(stream_id, stream.clone());
+        env.storage().persistent().set(&USAGE_STREAMS, &streams);
+
+        env.events()
+            .publish((symbol_short!("U_SETTLED"), recipient), (stream_id, claimable));
+
+        claimable
+    }
+
+    pub fn get_usage_stream(env: Env, stream_id: u64) -> Option<UsageStream> {
+        let streams: Map<u64, UsageStream> = env
+            .storage()
+            .persistent()
+            .get(&USAGE_STREAMS)
+            .unwrap_or(Map::new(&env));
+        streams.get(stream_id)
+    }
+
     /// Open a new payment stream.
     pub fn open_stream(
         env: Env,

--- a/contract/contracts/micropayments/src/test.rs
+++ b/contract/contracts/micropayments/src/test.rs
@@ -237,6 +237,201 @@ fn test_batch_settle_and_claimable_batch() {
     let mut query_ids = soroban_sdk::Vec::new(&env);
     query_ids.push_back(id1);
     query_ids.push_back(id2);
+    let token = create_token_and_mint(&env, &sender, 100_000_000);
+
+    let client = MicropaymentsContractClient::new(&env, &contract_id);
+    client.open_stream(&sender, &recipient, &token, &10_000_000, &1_000, &3600);
+
+    env.ledger().set(LedgerInfo {
+        timestamp: 100,
+        protocol_version: 22,
+        sequence_number: 10,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 16,
+        min_persistent_entry_ttl: 100_000,
+        max_entry_ttl: 6_312_000,
+    });
+
+    let withdrawn = client.withdraw(&recipient, &1);
+    assert_eq!(withdrawn, 100_000);
+}
+
+#[test]
+fn test_cancel_stream_refunds_sender() {
+    let (env, contract_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token_and_mint(&env, &sender, 100_000_000);
+
+    let client = MicropaymentsContractClient::new(&env, &contract_id);
+    client.open_stream(&sender, &recipient, &token, &10_000_000, &100, &3600);
+
+    client.cancel_stream(&sender, &1);
+
+    let stream = client.get_stream(&1).unwrap();
+    assert_eq!(stream.status, StreamStatus::Cancelled);
+}
+
+#[test]
+fn test_pause_and_resume() {
+    let (env, contract_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token_and_mint(&env, &sender, 100_000_000);
+
+    let client = MicropaymentsContractClient::new(&env, &contract_id);
+    client.open_stream(&sender, &recipient, &token, &10_000_000, &100, &7200);
+
+    client.pause_stream(&sender, &1);
+    let stream = client.get_stream(&1).unwrap();
+    assert_eq!(stream.status, StreamStatus::Paused);
+
+    client.resume_stream(&sender, &1);
+    let stream = client.get_stream(&1).unwrap();
+    assert_eq!(stream.status, StreamStatus::Active);
+}
+
+#[test]
+fn test_withdraw_before_time_elapsed() {
+    let (env, contract_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token_and_mint(&env, &sender, 100_000_000);
+
+    let client = MicropaymentsContractClient::new(&env, &contract_id);
+
+    client.open_stream(&sender, &recipient, &token, &10_000_000, &1_000, &3600);
+
+    let withdrawn = client.withdraw(&recipient, &1);
+
+    assert_eq!(withdrawn, 0);
+}
+
+#[test]
+fn test_multiple_withdrawals() {
+    let (env, contract_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token_and_mint(&env, &sender, 100_000_000);
+
+    let client = MicropaymentsContractClient::new(&env, &contract_id);
+
+    client.open_stream(&sender, &recipient, &token, &10_000_000, &1_000, &3600);
+
+    env.ledger().set(LedgerInfo {
+        timestamp: 100,
+        protocol_version: 22,
+        sequence_number: 10,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 16,
+        min_persistent_entry_ttl: 100_000,
+        max_entry_ttl: 6_312_000,
+    });
+
+    let first = client.withdraw(&recipient, &1);
+    assert_eq!(first, 100_000);
+
+    env.ledger().set(LedgerInfo {
+        timestamp: 200,
+        protocol_version: 22,
+        sequence_number: 11,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 16,
+        min_persistent_entry_ttl: 100_000,
+        max_entry_ttl: 6_312_000,
+    });
+
+    let second = client.withdraw(&recipient, &1);
+    assert_eq!(second, 100_000);
+}
+
+#[test]
+fn test_withdraw_capped_by_deposit() {
+    let (env, contract_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token_and_mint(&env, &sender, 100_000_000);
+
+    let client = MicropaymentsContractClient::new(&env, &contract_id);
+
+    client.open_stream(&sender, &recipient, &token, &10_000_000, &10_000, &1000);
+
+    env.ledger().set(LedgerInfo {
+        timestamp: 5000,
+        protocol_version: 22,
+        sequence_number: 20,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 16,
+        min_persistent_entry_ttl: 100_000,
+        max_entry_ttl: 6_312_000,
+    });
+
+    let withdrawn = client.withdraw(&recipient, &1);
+
+    assert_eq!(withdrawn, 10_000_000);
+}
+
+#[test]
+fn test_cancel_after_partial_withdrawal() {
+    let (env, contract_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token_and_mint(&env, &sender, 100_000_000);
+
+    let client = MicropaymentsContractClient::new(&env, &contract_id);
+
+    client.open_stream(&sender, &recipient, &token, &10_000_000, &1_000, &3600);
+
+    env.ledger().set(LedgerInfo {
+        timestamp: 100,
+        protocol_version: 22,
+        sequence_number: 10,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 16,
+        min_persistent_entry_ttl: 100_000,
+        max_entry_ttl: 6_312_000,
+    });
+
+    let withdrawn = client.withdraw(&recipient, &1);
+    assert_eq!(withdrawn, 100_000);
+
+    client.cancel_stream(&sender, &1);
+
+    let stream = client.get_stream(&1).unwrap();
+    assert_eq!(stream.status, StreamStatus::Cancelled);
+}
+
+#[test]
+fn test_batch_settle_and_claimable_batch() {
+    let (env, contract_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token_and_mint(&env, &sender, 100_000_000);
+
+    let client = MicropaymentsContractClient::new(&env, &contract_id);
+
+    let id1 = client.open_stream(&sender, &recipient, &token, &10_000_000, &1_000, &3600);
+    let id2 = client.open_stream(&sender, &recipient, &token, &20_000_000, &2_000, &3600);
+
+    env.ledger().set(LedgerInfo {
+        timestamp: 100,
+        protocol_version: 22,
+        sequence_number: 10,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 16,
+        min_persistent_entry_ttl: 100_000,
+        max_entry_ttl: 6_312_000,
+    });
+
+    let mut query_ids = soroban_sdk::Vec::new(&env);
+    query_ids.push_back(id1);
+    query_ids.push_back(id2);
 
     let claimables = client.get_claimable_batch(&query_ids);
     assert_eq!(claimables.get(id1).unwrap(), 100_000);
@@ -249,4 +444,64 @@ fn test_batch_settle_and_claimable_batch() {
     let stream1 = client.get_stream(&id1).unwrap();
     assert_eq!(stream1.withdrawn, 100_000);
     assert_eq!(stream1.last_settled, 100);
+}
+
+#[test]
+fn test_usage_stream_partial_settlement() {
+    let (env, contract_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token_and_mint(&env, &sender, 100_000_000);
+
+    let client = MicropaymentsContractClient::new(&env, &contract_id);
+    let stream_id = client.open(&sender, &recipient, &token, &10_000_000);
+
+    assert_eq!(stream_id, 1);
+
+    // Accrue partial usage
+    client.increment(&sender, &stream_id, &2_500_000);
+
+    let settled = client.settle(&recipient, &stream_id);
+    assert_eq!(settled, 2_500_000);
+
+    let stream = client.get_usage_stream(&stream_id).unwrap();
+    assert_eq!(stream.settled, 2_500_000);
+    assert_eq!(stream.accrued, 2_500_000);
+    assert_eq!(stream.status, StreamStatus::Active);
+}
+
+#[test]
+fn test_usage_stream_full_settlement() {
+    let (env, contract_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token_and_mint(&env, &sender, 100_000_000);
+
+    let client = MicropaymentsContractClient::new(&env, &contract_id);
+    let stream_id = client.open(&sender, &recipient, &token, &10_000_000);
+
+    // Accrue full usage
+    client.increment(&sender, &stream_id, &10_000_000);
+
+    let settled = client.settle(&recipient, &stream_id);
+    assert_eq!(settled, 10_000_000);
+
+    let stream = client.get_usage_stream(&stream_id).unwrap();
+    assert_eq!(stream.settled, 10_000_000);
+    assert_eq!(stream.status, StreamStatus::Completed);
+}
+
+#[test]
+#[should_panic(expected = "accrued exceeds deposit")]
+fn test_usage_stream_exceed_deposit() {
+    let (env, contract_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token_and_mint(&env, &sender, 100_000_000);
+
+    let client = MicropaymentsContractClient::new(&env, &contract_id);
+    let stream_id = client.open(&sender, &recipient, &token, &10_000_000);
+
+    // Accrue more than deposit
+    client.increment(&sender, &stream_id, &11_000_000);
 }


### PR DESCRIPTION
Closes #4 

Resolves the issue: Micropayments contract: usage-based payment streaming

This PR implements `open`, `increment`, and `settle` functions for streaming payments between agents based on usage. 

Changes included:
* **Open:** Allows the payer to open a stream with a deposit to a specific payee.
* **Increment:** Allows the payer to incrementally accrue usage on the active stream without on-chain transfer for each increment.
* **Settle:** Allows the payee to settle the accrued balance, transferring the earned amount to their account and partially/fully completing the stream.
* Added tests covering partial settlement, full settlement, and boundary errors (e.g. attempting to exceed deposit).