### PR TITLE
feat: Add tags support to asset listing on-chain

### DIFF
--- a/backend/src/routes/stellar.js
+++ b/backend/src/routes/stellar.js
@@ -169,6 +169,8 @@ const listingBodyRules = [
   body("assetType").isIn(ASSET_TYPES),
   body("licenseType").isIn(LICENSE_TYPES),
   body("price").isInt({ min: 1 }), // stroops; must be > 0 (InvalidPrice)
+  body("tags").isArray({ max: 10 }).optional(),
+  body("tags.*").isString().trim().isLength({ min: 1, max: 30 }),
 ];
 
 /**
@@ -178,7 +180,7 @@ const listingBodyRules = [
  */
 router.post("/list-asset/build", listingBodyRules, validate, async (req, res, next) => {
   try {
-    const { owner, name, description, assetType, licenseType, price } = req.body;
+    const { owner, name, description, assetType, licenseType, price, tags = [] } = req.body;
     const result = await buildListAssetTx({
       owner,
       name: name.trim(),
@@ -186,6 +188,7 @@ router.post("/list-asset/build", listingBodyRules, validate, async (req, res, ne
       assetType,
       licenseType,
       price: String(price),
+      tags,
     });
     res.json(result);
   } catch (err) {
@@ -211,7 +214,7 @@ router.post(
   validate,
   async (req, res, next) => {
     try {
-      const { signedXdr, owner, name, description, assetType, licenseType, price } = req.body;
+      const { signedXdr, owner, name, description, assetType, licenseType, price, tags = [] } = req.body;
       const { hash, assetId } = await submitSignedTx(signedXdr);
 
       let asset = null;
@@ -224,6 +227,7 @@ router.post(
           assetType,
           licenseType,
           price: Number(price),
+          tags,
         });
       }
 

--- a/backend/src/services/listingService.js
+++ b/backend/src/services/listingService.js
@@ -78,7 +78,7 @@ function enumScVal(variant) {
  * @param {string|number|bigint} params.price - Price in stroops.
  * @returns {Promise<{xdr:string, networkPassphrase:string, network:string}>}
  */
-async function buildListAssetTx({ owner, name, description, assetType, licenseType, price }) {
+async function buildListAssetTx({ owner, name, description, assetType, licenseType, price, tags = [] }) {
   const contractId = CONTRACT_IDS.marketplace;
   if (!contractId) {
     const err = new Error(
@@ -92,6 +92,8 @@ async function buildListAssetTx({ owner, name, description, assetType, licenseTy
   const account = await rpcServer.getAccount(owner);
   const contract = new Contract(contractId);
 
+  const tagsArray = tags.map(t => nativeToScVal(t, { type: "string" }));
+
   const args = [
     Address.fromString(owner).toScVal(),
     nativeToScVal(name, { type: "string" }),
@@ -99,6 +101,7 @@ async function buildListAssetTx({ owner, name, description, assetType, licenseTy
     enumScVal(assetType),
     enumScVal(licenseType),
     nativeToScVal(BigInt(price), { type: "i128" }),
+    xdr.ScVal.scvVec(tagsArray),
   ];
 
   const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase })

--- a/contract/contracts/marketplace/src/test.rs
+++ b/contract/contracts/marketplace/src/test.rs
@@ -619,6 +619,7 @@ fn test_list_asset_rejects_zero_price() {
         &AssetType::Prompt,
         &LicenseType::Perpetual,
         &0i128,
+        &soroban_sdk::Vec::new(&env),
     );
 
     assert_eq!(result.unwrap_err().unwrap(), MarketplaceError::InvalidPrice);
@@ -656,6 +657,7 @@ fn test_list_asset_accepts_price_of_one_stroop() {
         &AssetType::Tool,
         &LicenseType::Perpetual,
         &1i128,
+        &soroban_sdk::Vec::new(&env),
     );
 
     assert!(result.is_ok());
@@ -794,6 +796,7 @@ fn test_list_asset_rejects_when_limit_reached() {
         &AssetType::Prompt,
         &LicenseType::Perpetual,
         &1i128,
+        &soroban_sdk::Vec::new(&env),
     );
 
     assert_eq!(

--- a/contract/deploy/src/types.ts
+++ b/contract/deploy/src/types.ts
@@ -34,6 +34,7 @@ export interface IntelligenceAsset {
   is_active: boolean;
   created_at: bigint;
   version: number;
+  tags: string[];
 }
 
 export interface License {


### PR DESCRIPTION
Closes #30 

This pull request adds support for tagging Intelligence Assets natively on-chain. Tags are indexed off-chain and provided during listing for granular querying.

**Changes Include**:
- **Smart Contract**: Added `tags: Vec<String>` to the `IntelligenceAsset` struct.
- **Contract Validation**: `list_asset` now guarantees a maximum of 10 tags per asset with a maximum limit of 30 characters each.
- **Backend Sync**: Adjusted `stellar.js` and `listingService.js` endpoints to capture `tags` payloads, run Joi validations, safely perform `ScvVec` mapping for XDR construction, and forward to indexing upon success.
- **API Models**: Re-synchronized TypeScript definitions in `types.ts` to reflect the updated structure.