### PR TITLE
Add tests for micropayments streams as specified

### DIFF
--- a/contract/contracts/micropayments/src/lib.rs
+++ b/contract/contracts/micropayments/src/lib.rs
@@ -229,6 +229,7 @@ impl MicropaymentsContract {
         sender.require_auth();
         assert!(deposit > 0, "deposit must be positive");
         assert!(rate_per_second > 0, "rate must be positive");
+        assert!(duration_secs > 0, "duration must be positive");
 
         // Pull deposit from sender
         let token_client = soroban_sdk::token::Client::new(&env, &token);

--- a/contract/contracts/micropayments/src/test.rs
+++ b/contract/contracts/micropayments/src/test.rs
@@ -504,4 +504,144 @@ fn test_usage_stream_exceed_deposit() {
 
     // Accrue more than deposit
     client.increment(&sender, &stream_id, &11_000_000);
+}#[test]
+fn test_withdraw_after_stream_end_time_returns_remaining_deposit_only() {
+    let (env, contract_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token_and_mint(&env, &sender, 100_000_000);
+
+    let client = MicropaymentsContractClient::new(&env, &contract_id);
+    client.open_stream(&sender, &recipient, &token, &10_000_000, &10_000, &1000);
+
+    env.ledger().set(LedgerInfo {
+        timestamp: 5000,
+        protocol_version: 22,
+        sequence_number: 10,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 16,
+        min_persistent_entry_ttl: 100_000,
+        max_entry_ttl: 6_312_000,
+    });
+
+    let withdrawn = client.withdraw(&recipient, &1);
+    assert_eq!(withdrawn, 10_000_000);
+}
+
+#[test]
+fn test_cancel_stream_mid_stream_splits_amounts() {
+    let (env, contract_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token_and_mint(&env, &sender, 100_000_000);
+    
+    let token_client = token::StellarAssetClient::new(&env, &token);
+    let sender_balance_before = token_client.balance(&sender);
+    let recipient_balance_before = token_client.balance(&recipient);
+
+    let client = MicropaymentsContractClient::new(&env, &contract_id);
+    client.open_stream(&sender, &recipient, &token, &10_000_000, &10_000, &1000);
+
+    env.ledger().set(LedgerInfo {
+        timestamp: 500,
+        protocol_version: 22,
+        sequence_number: 10,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 16,
+        min_persistent_entry_ttl: 100_000,
+        max_entry_ttl: 6_312_000,
+    });
+
+    client.cancel_stream(&sender, &1);
+
+    assert_eq!(token_client.balance(&sender), sender_balance_before - 5_000_000);
+    assert_eq!(token_client.balance(&recipient), recipient_balance_before + 5_000_000);
+}
+
+#[test]
+fn test_withdraw_on_paused_stream_returns_0() {
+    let (env, contract_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token_and_mint(&env, &sender, 100_000_000);
+
+    let client = MicropaymentsContractClient::new(&env, &contract_id);
+    client.open_stream(&sender, &recipient, &token, &10_000_000, &10_000, &1000);
+
+    client.pause_stream(&sender, &1);
+
+    env.ledger().set(LedgerInfo {
+        timestamp: 500,
+        protocol_version: 22,
+        sequence_number: 10,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 16,
+        min_persistent_entry_ttl: 100_000,
+        max_entry_ttl: 6_312_000,
+    });
+
+    let withdrawn = client.withdraw(&recipient, &1);
+    assert_eq!(withdrawn, 0);
+}
+
+#[test]
+#[should_panic(expected = "duration must be positive")]
+fn test_open_stream_duration_zero_fails() {
+    let (env, contract_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token_and_mint(&env, &sender, 100_000_000);
+
+    let client = MicropaymentsContractClient::new(&env, &contract_id);
+    client.open_stream(&sender, &recipient, &token, &10_000_000, &10_000, &0);
+}
+
+#[test]
+fn test_stream_count_increments() {
+    let (env, contract_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token_and_mint(&env, &sender, 100_000_000);
+
+    let client = MicropaymentsContractClient::new(&env, &contract_id);
+    assert_eq!(client.stream_count(), 0);
+    
+    client.open_stream(&sender, &recipient, &token, &10_000_000, &10_000, &1000);
+    assert_eq!(client.stream_count(), 1);
+
+    client.open_stream(&sender, &recipient, &token, &10_000_000, &10_000, &1000);
+    assert_eq!(client.stream_count(), 2);
+}
+
+#[test]
+#[should_panic(expected = "stream already closed")]
+fn test_sender_cannot_cancel_completed_stream() {
+    let (env, contract_id) = setup();
+    let sender = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token = create_token_and_mint(&env, &sender, 100_000_000);
+
+    let client = MicropaymentsContractClient::new(&env, &contract_id);
+    client.open_stream(&sender, &recipient, &token, &10_000_000, &10_000, &1000);
+
+    env.ledger().set(LedgerInfo {
+        timestamp: 2000,
+        protocol_version: 22,
+        sequence_number: 10,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 16,
+        min_persistent_entry_ttl: 100_000,
+        max_entry_ttl: 6_312_000,
+    });
+
+    client.withdraw(&recipient, &1);
+
+    let stream = client.get_stream(&1).unwrap();
+    assert_eq!(stream.status, StreamStatus::Completed);
+
+    client.cancel_stream(&sender, &1);
 }


### PR DESCRIPTION
Closes #27 

## Objective
This pull request addresses the missing test coverage for edge cases within the `MicropaymentsContract` streaming functionality and patches a minor validation loophole. The goal is to ensure the payment streams correctly handle lifecycle limits, cancellations, and pauses, preventing unintended token transfers or panic behaviors.

## Changes Implemented

### 1. Contract Logic Adjustments
- **Added Stream Duration Validation (`micropayments/src/lib.rs`)**: 
  Introduced a new safety assertion `assert!(duration_secs > 0, "duration must be positive");` in the `open_stream` function. Previously, streams could potentially be initialized with a zero duration, which could lead to unpredictable withdrawal calculations.

### 2. Expanded Test Suite (`micropayments/src/test.rs`)
Six new explicit integration tests have been added to thoroughly validate the contract's edge cases:

- **`test_withdraw_after_stream_end_time_returns_remaining_deposit_only`**
  *Scenario*: A recipient attempts to withdraw from an active stream *after* its expected end time.
  *Verification*: Confirms the contract correctly caps the withdrawal at the total remaining stream deposit rather than indefinitely applying the `rate_per_second * elapsed` calculation. 

- **`test_cancel_stream_mid_stream_splits_amounts`**
  *Scenario*: A sender cancels an active stream exactly halfway through its duration.
  *Verification*: Asserts token balances prior to and after the cancellation to verify that the recipient receives exactly the tokens earned thus far, while the sender is correctly refunded the unearned remainder of their initial deposit.

- **`test_withdraw_on_paused_stream_returns_0`**
  *Scenario*: A recipient attempts to withdraw funds from a stream that has been paused by the sender.
  *Verification*: Ensures the `claimable()` logic correctly respects the `Paused` state and returns a `0` claimable balance, preventing withdrawals during a pause.

- **`test_open_stream_duration_zero_fails`**
  *Scenario*: A sender attempts to open a stream but passes `0` as the `duration_secs`.
  *Verification*: Validates that the contract correctly panics with `"duration must be positive"`, effectively blocking zero-duration edge cases.

- **`test_stream_count_increments`**
  *Scenario*: Multiple streams are opened sequentially on the same contract instance.
  *Verification*: Asserts that `stream_count()` linearly increments as expected, ensuring stream ID uniqueness across the contract's state.

- **`test_sender_cannot_cancel_completed_stream`**
  *Scenario*: A sender attempts to invoke `cancel_stream` on a stream that has already been fully withdrawn by the recipient (status is `Completed`).
  *Verification*: Verifies the contract gracefully prevents this action by panicking with `"stream already closed"`, preventing state corruption or invalid token refund attempts.

## Testing and Verification
- **Test Command**: `cargo test` inside the `micropayments` directory.
- **Coverage**: All critical requirements highlighted in the tracking issue are now explicitly covered with assertion blocks mirroring the intended behavior. 
- **Dependencies**: No new external testing crates or dependencies were introduced. Uses the existing `soroban_sdk::testutils` framework.