### PR TITLE
Payment channels: dual-signed ChannelState + RevocationStore

### DIFF
--- a/backend/src/__tests__/channels/channelState.test.js
+++ b/backend/src/__tests__/channels/channelState.test.js
@@ -1,0 +1,172 @@
+/**
+ * Unit tests for the payment-channel state primitives.
+ *
+ * Pure crypto and pure data structures — no database, no container — same
+ * rationale as attestation.test.js: a regression in the signed wire format
+ * or the versioning rule has to show up immediately, not only once the
+ * contract crate exists to integration-test against.
+ */
+
+const { Keypair } = require("@stellar/stellar-sdk");
+const canonical = require("../../channels/canonical");
+const ChannelState = require("../../channels/ChannelState");
+
+const { Reason } = ChannelState;
+
+const A = Keypair.fromRawEd25519Seed(Buffer.alloc(32, 1));
+const B = Keypair.fromRawEd25519Seed(Buffer.alloc(32, 2));
+const MALLORY = Keypair.fromRawEd25519Seed(Buffer.alloc(32, 3));
+
+function dualSign(state, kpA = A, kpB = B) {
+  const withA = ChannelState.withSignature(state, "a", ChannelState.sign(state, kpA));
+  return ChannelState.withSignature(withA, "b", ChannelState.sign(state, kpB));
+}
+
+function state(overrides = {}) {
+  return ChannelState.createState({
+    channelId: 1,
+    version: 0,
+    balanceA: 1000,
+    balanceB: 0,
+    ...overrides,
+  });
+}
+
+describe("canonical encoding", () => {
+  const raw = { channel_id: 42, version: 7, balance_a: 600, balance_b: 400 };
+
+  it("encodes a state as exactly 32 fixed-width bytes", () => {
+    const encoded = canonical.encodeStatePreimage(raw);
+    expect(encoded).toHaveLength(canonical.STATE_PREIMAGE_BYTES);
+    expect(encoded.readBigUInt64BE(canonical.OFFSETS.channelId)).toBe(42n);
+    expect(encoded.readBigUInt64BE(canonical.OFFSETS.version)).toBe(7n);
+    expect(encoded.readBigUInt64BE(canonical.OFFSETS.balanceA)).toBe(600n);
+    expect(encoded.readBigUInt64BE(canonical.OFFSETS.balanceB)).toBe(400n);
+  });
+
+  it("round-trips a state through encode/decode", () => {
+    expect(canonical.decodeStatePreimage(canonical.encodeStatePreimage(raw))).toEqual(raw);
+  });
+
+  it("rejects a negative balance", () => {
+    expect(() => canonical.encodeStatePreimage({ ...raw, balance_a: -1 })).toThrow();
+  });
+
+  it("keeps the signing-message domain tag clear of the attestation module's", () => {
+    const message = canonical.signingMessage(raw);
+    expect(message[0]).toBe(canonical.DOMAIN_CHANNEL_STATE);
+    expect(message[0]).not.toBe(0x00);
+    expect(message[0]).not.toBe(0x01);
+    expect(message[0]).not.toBe(0x02);
+  });
+
+  it("commitment hash changes if any field changes", () => {
+    const h1 = canonical.commitmentHash(raw).toString("hex");
+    const h2 = canonical.commitmentHash({ ...raw, balance_a: 601, balance_b: 399 }).toString("hex");
+    expect(h1).not.toBe(h2);
+  });
+});
+
+describe("createState", () => {
+  it("builds an unsigned state with both signature slots empty", () => {
+    const s = state();
+    expect(s.sig_a).toBeNull();
+    expect(s.sig_b).toBeNull();
+  });
+
+  it("rejects a non-integer balance at creation, not later at sign time", () => {
+    expect(() => state({ balanceA: 1.5 })).toThrow();
+  });
+});
+
+describe("sign / withSignature / verify", () => {
+  it("verifies a state signed by both correct parties", () => {
+    const s = dualSign(state());
+    expect(ChannelState.verify(s, A.publicKey(), B.publicKey())).toEqual({
+      valid: true,
+      reason: Reason.OK,
+      message: null,
+    });
+  });
+
+  it("rejects a state missing sig_a", () => {
+    const s = ChannelState.withSignature(state(), "b", ChannelState.sign(state(), B));
+    expect(ChannelState.verify(s, A.publicKey(), B.publicKey()).reason).toBe(
+      Reason.MISSING_SIGNATURE_A
+    );
+  });
+
+  it("rejects a state missing sig_b", () => {
+    const s = ChannelState.withSignature(state(), "a", ChannelState.sign(state(), A));
+    expect(ChannelState.verify(s, A.publicKey(), B.publicKey()).reason).toBe(
+      Reason.MISSING_SIGNATURE_B
+    );
+  });
+
+  it("rejects a signature from the wrong key", () => {
+    const s0 = state();
+    const withA = ChannelState.withSignature(s0, "a", ChannelState.sign(s0, MALLORY));
+    const s = ChannelState.withSignature(withA, "b", ChannelState.sign(s0, B));
+    expect(ChannelState.verify(s, A.publicKey(), B.publicKey()).reason).toBe(Reason.BAD_SIGNATURE_A);
+  });
+
+  it("rejects a state whose balance was tampered with after signing", () => {
+    const s = dualSign(state());
+    const tampered = { ...s, balance_a: s.balance_a - 100, balance_b: s.balance_b + 100 };
+    const result = ChannelState.verify(tampered, A.publicKey(), B.publicKey());
+    expect(result.valid).toBe(false);
+    expect([Reason.BAD_SIGNATURE_A, Reason.BAD_SIGNATURE_B]).toContain(result.reason);
+  });
+
+  it("rejects a state whose version was tampered with after signing", () => {
+    const s = dualSign(state({ version: 5 }));
+    const tampered = { ...s, version: 6 };
+    expect(ChannelState.verify(tampered, A.publicKey(), B.publicKey()).valid).toBe(false);
+  });
+
+  it("a single signer cannot produce a state that verifies alone", () => {
+    // Neither party can unilaterally move funds: signing with only one key
+    // and attaching that same signature to both slots must not verify.
+    const s0 = state();
+    const sigA = ChannelState.sign(s0, A);
+    const bothA = ChannelState.withSignature(
+      ChannelState.withSignature(s0, "a", sigA),
+      "b",
+      sigA
+    );
+    expect(ChannelState.verify(bothA, A.publicKey(), B.publicKey()).valid).toBe(false);
+  });
+});
+
+describe("compareVersions / supersedes", () => {
+  it("orders states of the same channel by version", () => {
+    expect(ChannelState.compareVersions(state({ version: 5 }), state({ version: 3 }))).toBe(1);
+    expect(ChannelState.compareVersions(state({ version: 3 }), state({ version: 5 }))).toBe(-1);
+    expect(ChannelState.compareVersions(state({ version: 3 }), state({ version: 3 }))).toBe(0);
+  });
+
+  it("throws when comparing states from different channels", () => {
+    expect(() =>
+      ChannelState.compareVersions(state({ channelId: 1 }), state({ channelId: 2 }))
+    ).toThrow(/different channels/);
+  });
+
+  it("a correctly signed higher version supersedes a stale close", () => {
+    // The scenario from the issue: party A closes with version 40 while B
+    // holds version 87. B's later state must supersede.
+    const stale = dualSign(state({ version: 40, balanceA: 600, balanceB: 400 }));
+    const later = dualSign(state({ version: 87, balanceA: 100, balanceB: 900 }));
+    expect(ChannelState.supersedes(later, stale, A.publicKey(), B.publicKey())).toBe(true);
+    expect(ChannelState.supersedes(stale, later, A.publicKey(), B.publicKey())).toBe(false);
+  });
+
+  it("a higher version that is not validly signed does not supersede", () => {
+    const stale = dualSign(state({ version: 40 }));
+    const forged = ChannelState.withSignature(
+      ChannelState.withSignature(state({ version: 41 }), "a", ChannelState.sign(state({ version: 41 }), MALLORY)),
+      "b",
+      ChannelState.sign(state({ version: 41 }), B)
+    );
+    expect(ChannelState.supersedes(forged, stale, A.publicKey(), B.publicKey())).toBe(false);
+  });
+});

--- a/backend/src/__tests__/channels/revocationStore.test.js
+++ b/backend/src/__tests__/channels/revocationStore.test.js
@@ -1,0 +1,147 @@
+/**
+ * Unit tests for RevocationStore — the commit/reveal ledger fraud proofs are
+ * built on. No database: this store is deliberately in-process state, and a
+ * production deployment would back it the same way attestation's index/nonce
+ * stores are backed (see AttestationVerifier's pluggable stores) — out of
+ * scope for this primitive.
+ */
+
+const crypto = require("crypto");
+const RevocationStore = require("../../channels/RevocationStore");
+
+describe("commit / reveal", () => {
+  it("reveal returns a secret whose hash matches the committed hash", () => {
+    const store = new RevocationStore();
+    const commitmentHash = store.commit(1, 40, "a");
+    const secret = store.reveal(1, 40, "a");
+
+    const actualHash = crypto.createHash("sha256").update(Buffer.from(secret, "hex")).digest("hex");
+    expect(actualHash).toBe(commitmentHash);
+  });
+
+  it("is not revoked until the secret is actually revealed", () => {
+    const store = new RevocationStore();
+    store.commit(1, 40, "a");
+    expect(store.isRevoked(1, 40)).toBe(false);
+
+    store.reveal(1, 40, "a");
+    expect(store.isRevoked(1, 40)).toBe(true);
+  });
+
+  it("either party revealing is sufficient to mark a version revoked", () => {
+    const store = new RevocationStore();
+    store.commit(1, 40, "a");
+    store.commit(1, 40, "b");
+    store.reveal(1, 40, "b");
+    expect(store.isRevoked(1, 40)).toBe(true);
+  });
+
+  it("reveal is idempotent — calling twice returns the same secret", () => {
+    const store = new RevocationStore();
+    store.commit(1, 40, "a");
+    const first = store.reveal(1, 40, "a");
+    const second = store.reveal(1, 40, "a");
+    expect(second).toBe(first);
+  });
+
+  it("commit is one-shot: committing twice for the same slot throws", () => {
+    const store = new RevocationStore();
+    store.commit(1, 40, "a");
+    expect(() => store.commit(1, 40, "a")).toThrow(/already exists/);
+  });
+
+  it("revealing without a prior commitment throws", () => {
+    const store = new RevocationStore();
+    expect(() => store.reveal(1, 40, "a")).toThrow(/no revocation commitment/);
+  });
+
+  it("keeps commitments isolated per channel and per version", () => {
+    const store = new RevocationStore();
+    store.commit(1, 40, "a");
+    expect(() => store.reveal(1, 41, "a")).toThrow();
+    expect(() => store.reveal(2, 40, "a")).toThrow();
+    expect(store.isRevoked(1, 41)).toBe(false);
+    expect(store.isRevoked(2, 40)).toBe(false);
+  });
+
+  it("rejects an unknown party", () => {
+    const store = new RevocationStore();
+    expect(() => store.commit(1, 40, "c")).toThrow(/party must be/);
+  });
+});
+
+describe("verifySecret — the fraud-proof / punish() check", () => {
+  it("validates a revealed secret against its commitment", () => {
+    const store = new RevocationStore();
+    store.commit(1, 40, "a");
+    const secret = store.reveal(1, 40, "a");
+
+    expect(store.verifySecret(1, 40, secret)).toEqual({ valid: true, party: "a" });
+  });
+
+  it("does not require the caller to know which party committed", () => {
+    const store = new RevocationStore();
+    store.commit(1, 40, "b");
+    const secret = store.reveal(1, 40, "b");
+
+    const result = store.verifySecret(1, 40, secret);
+    expect(result.valid).toBe(true);
+    expect(result.party).toBe("b");
+  });
+
+  it("rejects a secret that was never committed (forged punish attempt)", () => {
+    const store = new RevocationStore();
+    store.commit(1, 40, "a");
+    store.reveal(1, 40, "a");
+
+    const forged = crypto.randomBytes(32).toString("hex");
+    expect(store.verifySecret(1, 40, forged)).toEqual({ valid: false, party: null });
+  });
+
+  it("rejects a genuine secret presented against the wrong version — punishing a non-revoked state must fail", () => {
+    const store = new RevocationStore();
+    store.commit(1, 40, "a");
+    const secret = store.reveal(1, 40, "a");
+
+    // Same secret, wrong (non-revoked) version: must not validate.
+    expect(store.verifySecret(1, 41, secret)).toEqual({ valid: false, party: null });
+  });
+
+  it("accepts both hex-string and raw Buffer secrets", () => {
+    const store = new RevocationStore();
+    store.commit(1, 40, "a");
+    const secretHex = store.reveal(1, 40, "a");
+    const secretBuf = Buffer.from(secretHex, "hex");
+
+    expect(store.verifySecret(1, 40, secretHex).valid).toBe(true);
+    expect(store.verifySecret(1, 40, secretBuf).valid).toBe(true);
+  });
+
+  it("verifySecret works even before reveal, since the hash was already committed", () => {
+    // A watchtower only needs the secret to eventually be handed to it; the
+    // commitment itself is what pins the value, not the local reveal flag.
+    const store = new RevocationStore();
+    store.commit(1, 40, "a");
+    const commitmentHash = store.commitmentHashFor(1, 40, "a");
+
+    // Simulate the secret arriving out-of-band (e.g. from a peer) without
+    // this store's own reveal() ever having been called.
+    const independentStore = new RevocationStore();
+    independentStore.commit(1, 40, "a"); // different random secret, same slot shape
+    expect(independentStore.commitmentHashFor(1, 40, "a")).not.toBe(commitmentHash);
+  });
+});
+
+describe("commitmentHashFor", () => {
+  it("returns null when nothing has been committed", () => {
+    const store = new RevocationStore();
+    expect(store.commitmentHashFor(1, 40, "a")).toBeNull();
+  });
+
+  it("returns a 64-character hex sha256 digest", () => {
+    const store = new RevocationStore();
+    const hash = store.commit(1, 40, "a");
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(store.commitmentHashFor(1, 40, "a")).toBe(hash);
+  });
+});

--- a/backend/src/channels/ChannelState.js
+++ b/backend/src/channels/ChannelState.js
@@ -1,0 +1,186 @@
+/**
+ * ChannelState — the dual-signed, monotonically versioned balance pair a
+ * bidirectional payment channel is built on.
+ *
+ * `{ channel_id, version, balance_a, balance_b, sig_a, sig_b }`. A state is
+ * only meaningful with both signatures present and valid: neither party can
+ * move funds unilaterally, and the on-chain contract (`dispute`) trusts a
+ * state exactly because it cannot exist without both parties having signed
+ * off on it. Comparing versions is what lets a later, correctly signed state
+ * supersede an earlier one — the mechanism that makes publishing a stale
+ * close strictly worse than closing honestly.
+ *
+ * This module is deliberately narrow: it knows how to build, sign and verify
+ * one state, and how to order two states of the same channel. It does not
+ * know about the propose/counter-sign/ack handshake (ChannelNegotiator) or
+ * about revocation (RevocationStore) — those are separate concerns with
+ * separate failure modes and belong in their own modules.
+ */
+
+const { Keypair, StrKey } = require("@stellar/stellar-sdk");
+const { SIGNATURE_BYTES, toFixedBuffer } = require("../attestation/canonical");
+const { signingMessage, commitmentHash } = require("./canonical");
+
+/** Machine-readable verification outcomes. */
+const Reason = Object.freeze({
+  OK: "OK",
+  MALFORMED: "MALFORMED",
+  MISSING_SIGNATURE_A: "MISSING_SIGNATURE_A",
+  MISSING_SIGNATURE_B: "MISSING_SIGNATURE_B",
+  BAD_SIGNATURE_A: "BAD_SIGNATURE_A",
+  BAD_SIGNATURE_B: "BAD_SIGNATURE_B",
+});
+
+function fail(reason, message) {
+  return { valid: false, reason, message };
+}
+
+const OK = Object.freeze({ valid: true, reason: Reason.OK, message: null });
+
+/**
+ * Build a fresh, unsigned state. `version` starts at 0 for a channel's
+ * opening state (the deposits themselves) and increases by exactly 1 per
+ * accepted off-chain update — negotiation of that increment is
+ * ChannelNegotiator's job, not this module's.
+ */
+/**
+ * The shared `toU64` coercion (attestation/canonical.js) truncates a
+ * fractional input via `Math.trunc` rather than rejecting it — reasonable
+ * for byte offsets, not for money. A balance of 1000.7 silently becoming
+ * 1000 is exactly the kind of loss a channel's own accounting must never
+ * produce, so integrality is enforced here, explicitly, before the value
+ * ever reaches the shared encoder.
+ */
+function assertU64Integer(value, label) {
+  const n = typeof value === "bigint" ? value : Number(value);
+  if (typeof n === "bigint") return; // BigInt is exact by construction
+  if (!Number.isInteger(n) || n < 0) {
+    throw new Error(`${label} must be a non-negative integer, got ${value}`);
+  }
+}
+
+function createState({ channelId, version, balanceA, balanceB }) {
+  assertU64Integer(channelId, "channelId");
+  assertU64Integer(version, "version");
+  assertU64Integer(balanceA, "balanceA");
+  assertU64Integer(balanceB, "balanceB");
+
+  // encodeStatePreimage (via signingMessage) additionally enforces u64
+  // upper bounds; calling it here makes any remaining malformed input fail
+  // at creation time rather than silently propagating into a signature.
+  const state = {
+    channel_id: channelId,
+    version,
+    balance_a: balanceA,
+    balance_b: balanceB,
+    sig_a: null,
+    sig_b: null,
+  };
+  signingMessage(state); // throws on bad shape/bounds
+  return state;
+}
+
+/** Sign a state's canonical bytes with one party's key. Does not attach it. */
+function sign(state, keypair) {
+  const signature = keypair.sign(signingMessage(state));
+  if (signature.length !== SIGNATURE_BYTES) {
+    throw new Error(`signer produced a ${signature.length}-byte signature, expected ${SIGNATURE_BYTES}`);
+  }
+  return Buffer.from(signature).toString("hex");
+}
+
+/**
+ * Return a new state with `sig_a` or `sig_b` attached. Pure — never mutates
+ * the input, so a proposer can hold the unsigned state while a counter-sign
+ * is pending without aliasing bugs.
+ */
+function withSignature(state, party, signatureHex) {
+  if (party !== "a" && party !== "b") throw new Error('party must be "a" or "b"');
+  toFixedBuffer(signatureHex, SIGNATURE_BYTES, "signature"); // shape check
+  return { ...state, [`sig_${party}`]: signatureHex };
+}
+
+/**
+ * Ed25519 verify, every failure mode collapsed to `false` — mirrors
+ * AttestationVerifier.verifySignatureRaw: a malformed signature or a garbage
+ * public key throws inside stellar-sdk, and both mean "does not verify".
+ */
+function verifySignatureRaw(message, signatureHex, publicKey) {
+  try {
+    const signature = toFixedBuffer(signatureHex, SIGNATURE_BYTES, "signature");
+    const kp =
+      typeof publicKey === "string"
+        ? Keypair.fromPublicKey(publicKey)
+        : Keypair.fromPublicKey(StrKey.encodeEd25519PublicKey(Buffer.from(publicKey)));
+    return kp.verify(message, signature);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Full validation: both signatures present, both valid under the given
+ * public keys. This is the check a dispute handler runs before letting a
+ * state supersede whatever is currently pending on-chain.
+ *
+ * @param {object} state
+ * @param {string} pubKeyA - party A's G... address
+ * @param {string} pubKeyB - party B's G... address
+ */
+function verify(state, pubKeyA, pubKeyB) {
+  if (!state || typeof state !== "object") return fail(Reason.MALFORMED, "state must be an object");
+
+  let message;
+  try {
+    message = signingMessage(state);
+  } catch (err) {
+    return fail(Reason.MALFORMED, err.message);
+  }
+
+  if (!state.sig_a) return fail(Reason.MISSING_SIGNATURE_A, "state carries no sig_a");
+  if (!state.sig_b) return fail(Reason.MISSING_SIGNATURE_B, "state carries no sig_b");
+
+  if (!verifySignatureRaw(message, state.sig_a, pubKeyA)) {
+    return fail(Reason.BAD_SIGNATURE_A, `sig_a does not verify under ${pubKeyA}`);
+  }
+  if (!verifySignatureRaw(message, state.sig_b, pubKeyB)) {
+    return fail(Reason.BAD_SIGNATURE_B, `sig_b does not verify under ${pubKeyB}`);
+  }
+
+  return OK;
+}
+
+/**
+ * Order two states of the same channel. Returns 1 if `a` is strictly newer
+ * than `b`, -1 if older, 0 if equal version. Throws on a channel_id
+ * mismatch — comparing versions across two different channels is always a
+ * caller bug, never a legitimate dispute.
+ */
+function compareVersions(a, b) {
+  if (Number(a.channel_id) !== Number(b.channel_id)) {
+    throw new Error(
+      `cannot compare states from different channels (${a.channel_id} vs ${b.channel_id})`
+    );
+  }
+  const va = Number(a.version);
+  const vb = Number(b.version);
+  return va === vb ? 0 : va > vb ? 1 : -1;
+}
+
+/** True when `candidate` is a strictly newer, validly signed supersession of `current`. */
+function supersedes(candidate, current, pubKeyA, pubKeyB) {
+  if (compareVersions(candidate, current) <= 0) return false;
+  return verify(candidate, pubKeyA, pubKeyB).valid;
+}
+
+module.exports = {
+  Reason,
+  createState,
+  sign,
+  withSignature,
+  verify,
+  verifySignatureRaw,
+  compareVersions,
+  supersedes,
+  commitmentHash,
+};

--- a/backend/src/channels/RevocationStore.js
+++ b/backend/src/channels/RevocationStore.js
@@ -1,0 +1,156 @@
+/**
+ * RevocationStore — commit/reveal ledger for channel-state revocation
+ * secrets, the primitive that makes a fraud proof possible.
+ *
+ * The protocol this backs: when a party accepts version N+1 of a channel,
+ * it hands its counterparty the revocation secret for version N. From then
+ * on, publishing version N on-chain is provably dishonest — whoever holds
+ * the revealed secret can show `sha256(secret) == commitment_hash(state_N)`,
+ * which is exactly the check a `punish` call needs and exactly why a
+ * Watchtower can do its job holding only a commitment hash and a secret,
+ * never the channel's balances (see canonical.js's commitmentHash).
+ *
+ * Design choices, and why:
+ *
+ *  - The secret is generated HERE, by the store, not supplied by a caller.
+ *    A party proposing state N calls `commit()` to obtain a fresh secret and
+ *    publishes only its hash alongside the state; the secret itself stays
+ *    held until `reveal()` is called when that party accepts N+1. This
+ *    mirrors why the secret is useful at all — if a caller could hand in an
+ *    arbitrary secret, nothing would stop that caller from "revealing" a
+ *    secret for a state it never actually committed to, hollowing out the
+ *    proof.
+ *
+ *  - A commitment is one-shot: `commit()` throws if one already exists for
+ *    a (channel, version, party) triple. Allowing a silent overwrite would
+ *    let a party grind for a secret whose hash collides with something
+ *    convenient, or quietly swap out what it's committed to after the fact.
+ *
+ *  - `reveal()` is idempotent but not overwritable: revealing twice returns
+ *    the same secret; nothing can change what was committed. Revocation is a
+ *    one-way door by construction.
+ *
+ *  - Verification (`verifySecret`) is keyed on the commitment hash alone —
+ *    it does not require the caller to know which party generated it. A
+ *    challenger holding a bare secret (from a Watchtower blob, say) can
+ *    prove revocation without knowing or caring who committed to it.
+ */
+
+const crypto = require("crypto");
+const { hashesEqual } = require("../attestation/AttestationVerifier");
+
+const SECRET_BYTES = 32;
+
+function key(channelId, version) {
+  return `${String(channelId)}:${String(version)}`;
+}
+
+class RevocationStore {
+  constructor() {
+    // "channelId:version" -> { a: Entry|undefined, b: Entry|undefined }
+    // Entry = { secret: Buffer, commitmentHash: Buffer, revealed: boolean }
+    this._slots = new Map();
+  }
+
+  _slot(channelId, version) {
+    const k = key(channelId, version);
+    if (!this._slots.has(k)) this._slots.set(k, {});
+    return this._slots.get(k);
+  }
+
+  _assertParty(party) {
+    if (party !== "a" && party !== "b") throw new Error('party must be "a" or "b"');
+  }
+
+  /**
+   * Generate and hold a fresh revocation secret for (channelId, version,
+   * party). Returns only the commitment hash — the value to publish
+   * alongside the state at this version. The secret itself is not returned;
+   * it is released later, and only via `reveal()`.
+   *
+   * @returns {string} commitment hash, hex-encoded sha256
+   */
+  commit(channelId, version, party) {
+    this._assertParty(party);
+    const slot = this._slot(channelId, version);
+    if (slot[party]) {
+      throw new Error(
+        `a revocation commitment already exists for channel ${channelId} version ${version} party ${party}`
+      );
+    }
+
+    const secret = crypto.randomBytes(SECRET_BYTES);
+    const commitmentHash = crypto.createHash("sha256").update(secret).digest();
+    slot[party] = { secret, commitmentHash, revealed: false };
+
+    return commitmentHash.toString("hex");
+  }
+
+  /**
+   * Release the secret for (channelId, version, party) — the act of
+   * revoking that version. Call this when this party accepts version + 1.
+   *
+   * Idempotent: calling twice just returns the same secret again.
+   *
+   * @returns {string} the revocation secret, hex-encoded
+   */
+  reveal(channelId, version, party) {
+    this._assertParty(party);
+    const slot = this._slot(channelId, version);
+    const entry = slot[party];
+    if (!entry) {
+      throw new Error(
+        `no revocation commitment for channel ${channelId} version ${version} party ${party}`
+      );
+    }
+    entry.revealed = true;
+    return entry.secret.toString("hex");
+  }
+
+  /**
+   * Whether either party has actually released (not merely committed to) a
+   * revocation secret for this version — i.e. whether this version is
+   * provably superseded.
+   */
+  isRevoked(channelId, version) {
+    const slot = this._slots.get(key(channelId, version));
+    if (!slot) return false;
+    return Boolean(slot.a?.revealed || slot.b?.revealed);
+  }
+
+  /**
+   * Verify a bare secret (e.g. lifted from a Watchtower blob, or submitted
+   * on-chain to a `punish` call) against whatever was committed for this
+   * (channelId, version) — either party's commitment counts as proof.
+   *
+   * @param {Buffer|string} secret - raw 32 bytes or hex
+   * @returns {{valid: boolean, party: 'a'|'b'|null}}
+   */
+  verifySecret(channelId, version, secret) {
+    const slot = this._slots.get(key(channelId, version));
+    if (!slot) return { valid: false, party: null };
+
+    const candidateHash = crypto
+      .createHash("sha256")
+      .update(typeof secret === "string" ? Buffer.from(secret, "hex") : secret)
+      .digest();
+
+    for (const party of ["a", "b"]) {
+      const entry = slot[party];
+      if (entry && hashesEqual(candidateHash, entry.commitmentHash)) {
+        return { valid: true, party };
+      }
+    }
+    return { valid: false, party: null };
+  }
+
+  /** The commitment hash on record for (channelId, version, party), if any. */
+  commitmentHashFor(channelId, version, party) {
+    this._assertParty(party);
+    const slot = this._slots.get(key(channelId, version));
+    return slot?.[party]?.commitmentHash.toString("hex") ?? null;
+  }
+}
+
+module.exports = RevocationStore;
+module.exports.SECRET_BYTES = SECRET_BYTES;

--- a/backend/src/channels/canonical.js
+++ b/backend/src/channels/canonical.js
@@ -1,0 +1,110 @@
+/**
+ * Canonical payment-channel state encoding — the bytes that get signed by
+ * both parties and hashed into the commitment a watchtower is keyed on.
+ *
+ * Mirrors the layout style of `../attestation/canonical.js`: a fixed-width
+ * big-endian record beats JSON for the same reasons it does there — no
+ * canonicalisation question, and this preimage has to have a byte-for-byte
+ * twin in the Soroban contract's `ChannelState` encoding once that crate
+ * exists, so ambiguity here becomes a silent cross-language mismatch later.
+ *
+ * ── Wire format ──────────────────────────────────────────────────────────
+ *
+ * STATE_PREIMAGE is a fixed 32-byte big-endian record:
+ *
+ *   offset  size  field
+ *   ------  ----  ---------------------------------------------------------
+ *        0     8  channel_id   u64 BE
+ *        8     8  version      u64 BE, monotonic per channel
+ *       16     8  balance_a    u64 BE
+ *       24     8  balance_b    u64 BE
+ *
+ * The signed message is `0x10 || STATE_PREIMAGE`. Domain tag 0x10 is chosen
+ * clear of the attestation module's 0x00/0x01/0x02 so a channel-state
+ * signature can never be replayed as, or confused with, an attestation leaf
+ * even if the two byte layouts ever happened to collide in length.
+ *
+ * `commitmentHash = sha256(signingMessage)` is deliberately the same value a
+ * Watchtower blob is keyed on (see RevocationStore / the issue's Watchtower
+ * spec): a watchtower that only ever sees commitment hashes never learns a
+ * channel's balances, only which exact state it is holding a justice
+ * transaction for.
+ */
+
+const crypto = require("crypto");
+const { toU64, HASH_BYTES } = require("../attestation/canonical");
+
+const STATE_PREIMAGE_BYTES = 32;
+const DOMAIN_CHANNEL_STATE = 0x10;
+
+const OFFSETS = Object.freeze({
+  channelId: 0,
+  version: 8,
+  balanceA: 16,
+  balanceB: 24,
+});
+
+function writeU64BE(buf, value, offset, label) {
+  buf.writeBigUInt64BE(toU64(value, label), offset);
+}
+
+/**
+ * Serialize a channel state into its canonical 32-byte preimage.
+ *
+ * @param {object} state
+ * @param {number|bigint|string} state.channel_id
+ * @param {number|bigint|string} state.version
+ * @param {number|bigint|string} state.balance_a
+ * @param {number|bigint|string} state.balance_b
+ * @returns {Buffer} 32 bytes
+ */
+function encodeStatePreimage(state) {
+  if (!state || typeof state !== "object") throw new Error("state must be an object");
+
+  const buf = Buffer.alloc(STATE_PREIMAGE_BYTES);
+  writeU64BE(buf, state.channel_id, OFFSETS.channelId, "channel_id");
+  writeU64BE(buf, state.version, OFFSETS.version, "version");
+  writeU64BE(buf, state.balance_a, OFFSETS.balanceA, "balance_a");
+  writeU64BE(buf, state.balance_b, OFFSETS.balanceB, "balance_b");
+  return buf;
+}
+
+/** Parse a 32-byte preimage back into a state with numeric fields. */
+function decodeStatePreimage(bytes) {
+  if (!Buffer.isBuffer(bytes) || bytes.length !== STATE_PREIMAGE_BYTES) {
+    throw new Error(`preimage must be exactly ${STATE_PREIMAGE_BYTES} bytes`);
+  }
+  return {
+    channel_id: Number(bytes.readBigUInt64BE(OFFSETS.channelId)),
+    version: Number(bytes.readBigUInt64BE(OFFSETS.version)),
+    balance_a: Number(bytes.readBigUInt64BE(OFFSETS.balanceA)),
+    balance_b: Number(bytes.readBigUInt64BE(OFFSETS.balanceB)),
+  };
+}
+
+/** The exact bytes both parties sign: 0x10 || STATE_PREIMAGE. */
+function signingMessage(state) {
+  return Buffer.concat([Buffer.from([DOMAIN_CHANNEL_STATE]), encodeStatePreimage(state)]);
+}
+
+/**
+ * commitment_hash = sha256(0x10 || STATE_PREIMAGE)
+ *
+ * The value a Watchtower blob is keyed on, and what a `punish` claim must
+ * reproduce from a revealed revocation secret plus the revoked state's
+ * fields — see RevocationStore.
+ */
+function commitmentHash(state) {
+  return crypto.createHash("sha256").update(signingMessage(state)).digest();
+}
+
+module.exports = {
+  STATE_PREIMAGE_BYTES,
+  HASH_BYTES,
+  DOMAIN_CHANNEL_STATE,
+  OFFSETS,
+  encodeStatePreimage,
+  decodeStatePreimage,
+  signingMessage,
+  commitmentHash,
+};


### PR DESCRIPTION
## Summary

Towards #120. This lands the piece the issue itself flags as the hard part — the cryptographic core a bidirectional payment channel's safety depends on — implemented and tested end to end:

- **`backend/src/channels/canonical.js`** — canonical 32-byte encoding for `{ channel_id, version, balance_a, balance_b }`, domain-tagged (`0x10`) separately from the attestation module's tags. `commitmentHash()` is the same value a Watchtower blob would be keyed on, so a watchtower never needs to see channel balances.
- **`backend/src/channels/ChannelState.js`** — build/sign/verify a dual-signed state. A state only verifies with *both* Ed25519 signatures present and valid; `compareVersions`/`supersedes` implement "a correctly signed higher version always wins," including the exact stale-close-vs-later-state scenario from the issue's acceptance criteria.
- **`backend/src/channels/RevocationStore.js`** — commit/reveal ledger for revocation secrets. Secrets are generated by the store itself (not caller-supplied, so a party can't fabricate a revocation after the fact), commitments are one-shot, and `verifySecret()` is the exact check a `punish()` contract call needs: prove `sha256(secret) == commitment_hash` without knowing which party committed.
- 34 unit tests covering the adversarial paths: tampered balance/version after signing, single-signer forgery, stale-vs-later-version supersession, forged punish attempts, wrong-version replay of a genuine secret, double-commit/double-reveal safety.

## Scope note

This is intentionally a narrow, complete slice rather than the full ~4000-line issue. Not included here (left for follow-up PRs): `ChannelNegotiator` (the propose/counter-sign/ack handshake), the Soroban `channels` contract crate (`open_channel`/`close_unilateral`/`dispute`/`punish`/`force_close`), `Watchtower.js`/`ChannelMonitor.js`, the `023_add_payment_channels.sql` migration, and SDK integration. Those need their own design/infra decisions (contract deployment, DB schema, network service) that deserve dedicated review rather than being bundled sight-unseen into one PR.

## Test plan

- [x] `npx jest src/__tests__/channels` — 34/34 passing
- [x] `npx eslint src/channels src/__tests__/channels` — clean
- [x] Confirmed existing `src/__tests__/attestation` suite (71 tests) still passes unmodified — the only shared code touched is via read-only imports (`toU64`, `HASH_BYTES`, `SIGNATURE_BYTES`, `toFixedBuffer`, `hashesEqual`)