### PR TITLE
Implement bidirectional payment channels with unilateral exit and watchtower fraud proofs

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,9 +12,15 @@ MARKETPLACE_CONTRACT_ID=
 MICROPAYMENTS_CONTRACT_ID=
 AGENT_REGISTRY_CONTRACT_ID=
 AUDIT_ANCHOR_CONTRACT_ID=
+CHANNELS_CONTRACT_ID=
 
 # Server signing key (never commit the real secret)
 SERVER_SECRET_KEY=S...
+
+# 32-byte hex key this node's Watchtower uses to encrypt justice packages at
+# rest (see backend/src/channels/Watchtower.js). Generate with:
+#   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+WATCHTOWER_MASTER_KEY=
 
 # CORS allowed origins (comma-separated)
 CORS_ORIGINS=http://localhost:3000

--- a/backend/src/__tests__/channelMonitor.test.js
+++ b/backend/src/__tests__/channelMonitor.test.js
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for ChannelMonitor's per-event handler.
+ *
+ * `processUnilateralClose` takes its RPC calls and Watchtower as injected
+ * dependencies, so this suite never touches the network or a real
+ * Watchtower's encryption — it only has to prove the dispatch logic is
+ * right: skip when there's nothing to do, submit `punish` with the right
+ * arguments when the Watchtower actually holds a matching justice package.
+ */
+
+const { Keypair } = require("@stellar/stellar-sdk");
+const { processUnilateralClose } = require("../protocol/ChannelMonitor");
+
+function fakeKeypair(publicKey) {
+  return { publicKey: () => publicKey };
+}
+
+describe("processUnilateralClose", () => {
+  // Address.fromString inside processUnilateralClose needs a real,
+  // checksum-valid Stellar address — an arbitrary fake string would throw
+  // before invokeContract is ever reached.
+  const CHALLENGER = Keypair.fromRawEd25519Seed(Buffer.alloc(32, 4)).publicKey();
+
+  it("skips when the channels contract is not configured", async () => {
+    const result = await processUnilateralClose(
+      { watchtower: { findJustice: jest.fn() }, signerKeypair: fakeKeypair("G..."), contractId: "" },
+      1
+    );
+    expect(result).toEqual({ action: "skipped", reason: "channels contract not configured" });
+  });
+
+  it("skips when the channel has no pending close", async () => {
+    const viewContract = jest.fn().mockResolvedValue(null);
+    const result = await processUnilateralClose(
+      {
+        contractId: "C_CHANNELS",
+        viewContract,
+        watchtower: { findJustice: jest.fn() },
+        signerKeypair: fakeKeypair("GSIGNER"),
+      },
+      1
+    );
+    expect(result).toEqual({ action: "skipped", reason: "channel is not currently closing" });
+  });
+
+  it("skips when the watchtower holds no justice package for this state", async () => {
+    const pending = {
+      version: 40,
+      balance_a: 600,
+      balance_b: 400,
+      revocation_commit_a: Buffer.alloc(32, 1),
+      revocation_commit_b: Buffer.alloc(32, 2),
+    };
+    const viewContract = jest.fn().mockResolvedValue(pending);
+    const findJustice = jest.fn().mockReturnValue(null);
+
+    const result = await processUnilateralClose(
+      {
+        contractId: "C_CHANNELS",
+        viewContract,
+        watchtower: { findJustice },
+        signerKeypair: fakeKeypair("GSIGNER"),
+      },
+      1
+    );
+
+    expect(result).toEqual({ action: "skipped", reason: "no justice package for this state" });
+    expect(findJustice).toHaveBeenCalledWith({
+      channel_id: 1,
+      version: 40,
+      balance_a: 600,
+      balance_b: 400,
+      revocation_commit_a: "01".repeat(32),
+      revocation_commit_b: "02".repeat(32),
+    });
+  });
+
+  it("submits punish with the challenger and secret from the watchtower's claim", async () => {
+    const pending = {
+      version: 40,
+      balance_a: 600,
+      balance_b: 400,
+      revocation_commit_a: Buffer.alloc(32, 1),
+      revocation_commit_b: Buffer.alloc(32, 2),
+    };
+    const justice = {
+      party: "a",
+      revocationSecret: "aa".repeat(32),
+      challenger: CHALLENGER,
+    };
+    const viewContract = jest.fn().mockResolvedValue(pending);
+    const findJustice = jest.fn().mockReturnValue(justice);
+    const invokeContract = jest.fn().mockResolvedValue(1000);
+
+    const result = await processUnilateralClose(
+      {
+        contractId: "C_CHANNELS",
+        viewContract,
+        invokeContract,
+        watchtower: { findJustice },
+        signerKeypair: fakeKeypair("GSIGNER"),
+      },
+      42
+    );
+
+    expect(result).toEqual({ action: "punished", payout: 1000 });
+    expect(invokeContract).toHaveBeenCalledTimes(1);
+    const [contractId, method] = invokeContract.mock.calls[0];
+    expect(contractId).toBe("C_CHANNELS");
+    expect(method).toBe("punish");
+  });
+});

--- a/backend/src/__tests__/channels/channelNegotiator.test.js
+++ b/backend/src/__tests__/channels/channelNegotiator.test.js
@@ -1,0 +1,228 @@
+/**
+ * Unit tests for ChannelNegotiator — the propose/counter-sign/ack/complete
+ * handshake. Two independent negotiator instances (and two independent
+ * RevocationStores) stand in for two separate agent processes exchanging
+ * plain-object messages, which is the only channel they'd have over a real
+ * network too.
+ */
+
+const { Keypair } = require("@stellar/stellar-sdk");
+const ChannelNegotiator = require("../../channels/ChannelNegotiator");
+const RevocationStore = require("../../channels/RevocationStore");
+const ChannelState = require("../../channels/ChannelState");
+
+const KEY_A = Keypair.fromRawEd25519Seed(Buffer.alloc(32, 1));
+const KEY_B = Keypair.fromRawEd25519Seed(Buffer.alloc(32, 2));
+const CHANNEL_ID = 7;
+
+function makePair() {
+  const storeA = new RevocationStore();
+  const storeB = new RevocationStore();
+
+  const a = new ChannelNegotiator({
+    channelId: CHANNEL_ID,
+    party: "a",
+    keypair: KEY_A,
+    counterpartyPublicKey: KEY_B.publicKey(),
+    revocationStore: storeA,
+  });
+  const b = new ChannelNegotiator({
+    channelId: CHANNEL_ID,
+    party: "b",
+    keypair: KEY_B,
+    counterpartyPublicKey: KEY_A.publicKey(),
+    revocationStore: storeB,
+  });
+  return { a, b, storeA, storeB };
+}
+
+/** Run one full round: A proposes, B countersigns, A acks, B completes, A finalizes. */
+function runRound(a, b, { version, balanceA, balanceB }) {
+  const proposal = a.propose({ version, balanceA, balanceB });
+  const counterSignature = b.counterSign(proposal);
+  const ack = a.ack(counterSignature);
+  const completion = b.complete(ack);
+  a.finalize(completion);
+  return { proposal, counterSignature, ack, completion };
+}
+
+describe("full happy-path negotiation", () => {
+  it("both sides converge on the same fully-signed state", () => {
+    const { a, b } = makePair();
+    runRound(a, b, { version: 1, balanceA: 900, balanceB: 100 });
+
+    expect(a.currentState).toEqual(b.currentState);
+    expect(
+      ChannelState.verify(a.currentState, KEY_A.publicKey(), KEY_B.publicKey()).valid
+    ).toBe(true);
+  });
+
+  it("the first negotiation on a channel reveals nothing — there is no previous version", () => {
+    const { a, b } = makePair();
+    const { ack, completion } = runRound(a, b, { version: 1, balanceA: 900, balanceB: 100 });
+
+    expect(ack.revealedSecret).toBeNull();
+    expect(completion.revealedSecret).toBeNull();
+  });
+
+  it("a second round reveals and mutually verifies the first version's secrets", () => {
+    const { a, b, storeA, storeB } = makePair();
+    runRound(a, b, { version: 1, balanceA: 900, balanceB: 100 });
+    runRound(a, b, { version: 2, balanceA: 800, balanceB: 200 });
+
+    // Both parties' local stores now agree version 1 is revoked — each
+    // learned the *other* party's secret for it via the handshake, not by
+    // generating it themselves.
+    expect(storeA.isRevoked(CHANNEL_ID, 1)).toBe(true);
+    expect(storeB.isRevoked(CHANNEL_ID, 1)).toBe(true);
+  });
+
+  it("many sequential rounds settle at the final balance with each prior version revoked", () => {
+    const { a, b, storeA } = makePair();
+    let balanceA = 1_000_000;
+    let balanceB = 0;
+
+    for (let version = 1; version <= 25; version++) {
+      balanceA -= 100;
+      balanceB += 100;
+      runRound(a, b, { version, balanceA, balanceB });
+    }
+
+    expect(a.currentState.balance_a).toBe(1_000_000 - 2500);
+    expect(a.currentState.balance_b).toBe(2500);
+    expect(a.currentState.version).toBe(25);
+    // Every version before the last is revoked; the current one is not.
+    for (let v = 1; v < 25; v++) {
+      expect(storeA.isRevoked(CHANNEL_ID, v)).toBe(true);
+    }
+    expect(storeA.isRevoked(CHANNEL_ID, 25)).toBe(false);
+  });
+});
+
+describe("safety against a counterparty who abandons the exchange", () => {
+  it("abandonment after propose() leaves the proposer's old state untouched", () => {
+    const { a, b, storeA } = makePair();
+    runRound(a, b, { version: 1, balanceA: 900, balanceB: 100 });
+    const before = a.currentState;
+
+    a.propose({ version: 2, balanceA: 800, balanceB: 200 });
+    // B never responds.
+
+    expect(a.currentState).toEqual(before);
+    expect(storeA.isRevoked(CHANNEL_ID, 1)).toBe(false);
+    expect(ChannelState.verify(a.currentState, KEY_A.publicKey(), KEY_B.publicKey()).valid).toBe(
+      true
+    );
+  });
+
+  it("abandonment after counterSign() leaves both sides' old states untouched", () => {
+    const { a, b, storeA, storeB } = makePair();
+    runRound(a, b, { version: 1, balanceA: 900, balanceB: 100 });
+    const beforeA = a.currentState;
+    const beforeB = b.currentState;
+
+    const proposal = a.propose({ version: 2, balanceA: 800, balanceB: 200 });
+    b.counterSign(proposal);
+    // The counter-signature never reaches A.
+
+    expect(a.currentState).toEqual(beforeA);
+    expect(b.currentState).toEqual(beforeB);
+    expect(storeA.isRevoked(CHANNEL_ID, 1)).toBe(false);
+    expect(storeB.isRevoked(CHANNEL_ID, 1)).toBe(false);
+  });
+
+  it("abandonment after ack() still leaves the proposer holding a valid new state, and the counterparty's old state safe", () => {
+    // The one case where a secret does get revealed before the handshake
+    // fully closes out: A has already verified the complete dual-signed
+    // state by the time it reveals anything, so A is never left worse off
+    // even if B vanishes right here.
+    const { a, b, storeA, storeB } = makePair();
+    runRound(a, b, { version: 1, balanceA: 900, balanceB: 100 });
+    const bBefore = b.currentState;
+
+    const proposal = a.propose({ version: 2, balanceA: 800, balanceB: 200 });
+    const counterSignature = b.counterSign(proposal);
+    const ack = a.ack(counterSignature);
+    // The ack never reaches B.
+
+    // A already has a fully valid, fully signed version-2 state to close
+    // with — abandonment cost it nothing.
+    expect(a.currentState.version).toBe(2);
+    expect(ChannelState.verify(a.currentState, KEY_A.publicKey(), KEY_B.publicKey()).valid).toBe(
+      true
+    );
+    // A safely revoked its own superseded state, having already verified the successor.
+    expect(storeA.isRevoked(CHANNEL_ID, 1)).toBe(true);
+
+    // B never called complete(), so B's view of version 1 is untouched and
+    // still fully valid — B lost nothing either.
+    expect(b.currentState).toEqual(bBefore);
+    expect(storeB.isRevoked(CHANNEL_ID, 1)).toBe(false);
+    expect(ChannelState.verify(b.currentState, KEY_A.publicKey(), KEY_B.publicKey()).valid).toBe(
+      true
+    );
+
+    void ack; // the message that would have completed the handshake, unused here
+  });
+});
+
+describe("validation", () => {
+  it("rejects countersigning your own proposal", () => {
+    const { a } = makePair();
+    const proposal = a.propose({ version: 1, balanceA: 900, balanceB: 100 });
+    expect(() => a.counterSign(proposal)).toThrow(/own proposal/);
+  });
+
+  it("rejects a proposal that does not advance the version", () => {
+    const { a, b } = makePair();
+    runRound(a, b, { version: 5, balanceA: 900, balanceB: 100 });
+    expect(() => a.propose({ version: 5, balanceA: 800, balanceB: 200 })).toThrow(
+      /does not exceed/
+    );
+    expect(() => a.propose({ version: 4, balanceA: 800, balanceB: 200 })).toThrow(
+      /does not exceed/
+    );
+  });
+
+  it("counterSign rejects a proposal that does not advance the version", () => {
+    const { a, b } = makePair();
+    runRound(a, b, { version: 5, balanceA: 900, balanceB: 100 });
+
+    const staleProposal = {
+      channelId: CHANNEL_ID,
+      version: 5,
+      balanceA: 850,
+      balanceB: 150,
+      proposerParty: "a",
+      proposerCommitmentHash: "00".repeat(32),
+    };
+    expect(() => b.counterSign(staleProposal)).toThrow(/does not exceed/);
+  });
+
+  it("ack rejects a forged counter-signature", () => {
+    const { a, b } = makePair();
+    const proposal = a.propose({ version: 1, balanceA: 900, balanceB: 100 });
+    const counterSignature = b.counterSign(proposal);
+    counterSignature.signature = ChannelState.sign(
+      ChannelState.createState({
+        channelId: CHANNEL_ID,
+        version: 1,
+        balanceA: 1,
+        balanceB: 1,
+        revocationCommitA: "00".repeat(32),
+        revocationCommitB: "00".repeat(32),
+      }),
+      Keypair.fromRawEd25519Seed(Buffer.alloc(32, 9)) // impostor key
+    );
+
+    expect(() => a.ack(counterSignature)).toThrow(/does not verify/);
+  });
+
+  it("rejects starting a new proposal while one is already in flight", () => {
+    const { a } = makePair();
+    a.propose({ version: 1, balanceA: 900, balanceB: 100 });
+    expect(() => a.propose({ version: 2, balanceA: 800, balanceB: 200 })).toThrow(
+      /already in flight/
+    );
+  });
+});

--- a/backend/src/__tests__/channels/channelState.test.js
+++ b/backend/src/__tests__/channels/channelState.test.js
@@ -7,6 +7,7 @@
  * contract crate exists to integration-test against.
  */
 
+const crypto = require("crypto");
 const { Keypair } = require("@stellar/stellar-sdk");
 const canonical = require("../../channels/canonical");
 const ChannelState = require("../../channels/ChannelState");
@@ -16,6 +17,10 @@ const { Reason } = ChannelState;
 const A = Keypair.fromRawEd25519Seed(Buffer.alloc(32, 1));
 const B = Keypair.fromRawEd25519Seed(Buffer.alloc(32, 2));
 const MALLORY = Keypair.fromRawEd25519Seed(Buffer.alloc(32, 3));
+
+function commit(seed) {
+  return crypto.createHash("sha256").update(Buffer.from([seed])).digest("hex");
+}
 
 function dualSign(state, kpA = A, kpB = B) {
   const withA = ChannelState.withSignature(state, "a", ChannelState.sign(state, kpA));
@@ -28,20 +33,39 @@ function state(overrides = {}) {
     version: 0,
     balanceA: 1000,
     balanceB: 0,
+    revocationCommitA: commit(0xa0),
+    revocationCommitB: commit(0xb0),
     ...overrides,
   });
 }
 
 describe("canonical encoding", () => {
-  const raw = { channel_id: 42, version: 7, balance_a: 600, balance_b: 400 };
+  const raw = {
+    channel_id: 42,
+    version: 7,
+    balance_a: 600,
+    balance_b: 400,
+    revocation_commit_a: commit(0x01),
+    revocation_commit_b: commit(0x02),
+  };
 
-  it("encodes a state as exactly 32 fixed-width bytes", () => {
+  it("encodes a state as exactly 96 fixed-width bytes", () => {
     const encoded = canonical.encodeStatePreimage(raw);
     expect(encoded).toHaveLength(canonical.STATE_PREIMAGE_BYTES);
     expect(encoded.readBigUInt64BE(canonical.OFFSETS.channelId)).toBe(42n);
     expect(encoded.readBigUInt64BE(canonical.OFFSETS.version)).toBe(7n);
     expect(encoded.readBigUInt64BE(canonical.OFFSETS.balanceA)).toBe(600n);
     expect(encoded.readBigUInt64BE(canonical.OFFSETS.balanceB)).toBe(400n);
+    expect(
+      encoded
+        .subarray(canonical.OFFSETS.revocationCommitA, canonical.OFFSETS.revocationCommitA + 32)
+        .toString("hex")
+    ).toBe(raw.revocation_commit_a);
+    expect(
+      encoded
+        .subarray(canonical.OFFSETS.revocationCommitB, canonical.OFFSETS.revocationCommitB + 32)
+        .toString("hex")
+    ).toBe(raw.revocation_commit_b);
   });
 
   it("round-trips a state through encode/decode", () => {
@@ -52,6 +76,12 @@ describe("canonical encoding", () => {
     expect(() => canonical.encodeStatePreimage({ ...raw, balance_a: -1 })).toThrow();
   });
 
+  it("rejects a revocation commitment of the wrong width", () => {
+    expect(() =>
+      canonical.encodeStatePreimage({ ...raw, revocation_commit_a: "ab".repeat(16) })
+    ).toThrow(/64 hex characters/);
+  });
+
   it("keeps the signing-message domain tag clear of the attestation module's", () => {
     const message = canonical.signingMessage(raw);
     expect(message[0]).toBe(canonical.DOMAIN_CHANNEL_STATE);
@@ -60,10 +90,22 @@ describe("canonical encoding", () => {
     expect(message[0]).not.toBe(0x02);
   });
 
-  it("commitment hash changes if any field changes", () => {
+  it("commitment hash changes if any balance field changes", () => {
     const h1 = canonical.commitmentHash(raw).toString("hex");
     const h2 = canonical.commitmentHash({ ...raw, balance_a: 601, balance_b: 399 }).toString("hex");
     expect(h1).not.toBe(h2);
+  });
+
+  it("commitment hash changes if either revocation commitment changes", () => {
+    const h1 = canonical.commitmentHash(raw).toString("hex");
+    const h2 = canonical
+      .commitmentHash({ ...raw, revocation_commit_a: commit(0x99) })
+      .toString("hex");
+    const h3 = canonical
+      .commitmentHash({ ...raw, revocation_commit_b: commit(0x99) })
+      .toString("hex");
+    expect(h1).not.toBe(h2);
+    expect(h1).not.toBe(h3);
   });
 });
 
@@ -74,8 +116,18 @@ describe("createState", () => {
     expect(s.sig_b).toBeNull();
   });
 
+  it("carries both revocation commitments unchanged", () => {
+    const s = state({ revocationCommitA: commit(0x11), revocationCommitB: commit(0x22) });
+    expect(s.revocation_commit_a).toBe(commit(0x11));
+    expect(s.revocation_commit_b).toBe(commit(0x22));
+  });
+
   it("rejects a non-integer balance at creation, not later at sign time", () => {
     expect(() => state({ balanceA: 1.5 })).toThrow();
+  });
+
+  it("rejects a malformed revocation commitment at creation", () => {
+    expect(() => state({ revocationCommitA: "not-hex" })).toThrow();
   });
 });
 
@@ -90,14 +142,16 @@ describe("sign / withSignature / verify", () => {
   });
 
   it("rejects a state missing sig_a", () => {
-    const s = ChannelState.withSignature(state(), "b", ChannelState.sign(state(), B));
+    const s0 = state();
+    const s = ChannelState.withSignature(s0, "b", ChannelState.sign(s0, B));
     expect(ChannelState.verify(s, A.publicKey(), B.publicKey()).reason).toBe(
       Reason.MISSING_SIGNATURE_A
     );
   });
 
   it("rejects a state missing sig_b", () => {
-    const s = ChannelState.withSignature(state(), "a", ChannelState.sign(state(), A));
+    const s0 = state();
+    const s = ChannelState.withSignature(s0, "a", ChannelState.sign(s0, A));
     expect(ChannelState.verify(s, A.publicKey(), B.publicKey()).reason).toBe(
       Reason.MISSING_SIGNATURE_B
     );
@@ -121,6 +175,15 @@ describe("sign / withSignature / verify", () => {
   it("rejects a state whose version was tampered with after signing", () => {
     const s = dualSign(state({ version: 5 }));
     const tampered = { ...s, version: 6 };
+    expect(ChannelState.verify(tampered, A.publicKey(), B.publicKey()).valid).toBe(false);
+  });
+
+  it("rejects a state whose revocation commitment was swapped after signing", () => {
+    // The whole point of signing the commitments is that nobody — including
+    // one of the two channel parties — can rebind a version to a different
+    // revocation secret after the fact.
+    const s = dualSign(state());
+    const tampered = { ...s, revocation_commit_a: commit(0xff) };
     expect(ChannelState.verify(tampered, A.publicKey(), B.publicKey()).valid).toBe(false);
   });
 
@@ -155,17 +218,26 @@ describe("compareVersions / supersedes", () => {
     // The scenario from the issue: party A closes with version 40 while B
     // holds version 87. B's later state must supersede.
     const stale = dualSign(state({ version: 40, balanceA: 600, balanceB: 400 }));
-    const later = dualSign(state({ version: 87, balanceA: 100, balanceB: 900 }));
+    const later = dualSign(
+      state({
+        version: 87,
+        balanceA: 100,
+        balanceB: 900,
+        revocationCommitA: commit(0x87),
+        revocationCommitB: commit(0x88),
+      })
+    );
     expect(ChannelState.supersedes(later, stale, A.publicKey(), B.publicKey())).toBe(true);
     expect(ChannelState.supersedes(stale, later, A.publicKey(), B.publicKey())).toBe(false);
   });
 
   it("a higher version that is not validly signed does not supersede", () => {
     const stale = dualSign(state({ version: 40 }));
+    const higher = state({ version: 41 });
     const forged = ChannelState.withSignature(
-      ChannelState.withSignature(state({ version: 41 }), "a", ChannelState.sign(state({ version: 41 }), MALLORY)),
+      ChannelState.withSignature(higher, "a", ChannelState.sign(higher, MALLORY)),
       "b",
-      ChannelState.sign(state({ version: 41 }), B)
+      ChannelState.sign(higher, B)
     );
     expect(ChannelState.supersedes(forged, stale, A.publicKey(), B.publicKey())).toBe(false);
   });

--- a/backend/src/__tests__/channels/revocationStore.test.js
+++ b/backend/src/__tests__/channels/revocationStore.test.js
@@ -132,6 +132,62 @@ describe("verifySecret — the fraud-proof / punish() check", () => {
   });
 });
 
+describe("recordCommitment / recordRevealedSecret — the two-process case", () => {
+  // ChannelNegotiator runs one RevocationStore per party, in separate
+  // processes. A's store generates and owns the 'a' secret; it never sees
+  // B's raw secret until B's process reveals it over the wire, so it has to
+  // be able to record B's *commitment* up front and B's *secret* later,
+  // without ever generating either itself.
+
+  it("lets a store record a counterparty's commitment without generating a secret", () => {
+    const ownerStore = new RevocationStore();
+    const commitmentHash = ownerStore.commit(1, 40, "a");
+
+    const counterpartyStore = new RevocationStore();
+    counterpartyStore.recordCommitment(1, 40, "a", commitmentHash);
+
+    expect(counterpartyStore.commitmentHashFor(1, 40, "a")).toBe(commitmentHash);
+  });
+
+  it("recordCommitment is one-shot, same as commit()", () => {
+    const store = new RevocationStore();
+    store.recordCommitment(1, 40, "a", crypto.randomBytes(32).toString("hex"));
+    expect(() =>
+      store.recordCommitment(1, 40, "a", crypto.randomBytes(32).toString("hex"))
+    ).toThrow(/already exists/);
+  });
+
+  it("accepts and verifies a secret revealed by the counterparty", () => {
+    const ownerStore = new RevocationStore();
+    const commitmentHash = ownerStore.commit(1, 40, "a");
+    const secret = ownerStore.reveal(1, 40, "a");
+
+    const counterpartyStore = new RevocationStore();
+    counterpartyStore.recordCommitment(1, 40, "a", commitmentHash);
+    counterpartyStore.recordRevealedSecret(1, 40, "a", secret);
+
+    expect(counterpartyStore.isRevoked(1, 40)).toBe(true);
+    expect(counterpartyStore.verifySecret(1, 40, secret)).toEqual({ valid: true, party: "a" });
+  });
+
+  it("rejects a revealed secret that does not match the recorded commitment", () => {
+    const store = new RevocationStore();
+    store.recordCommitment(1, 40, "a", crypto.randomBytes(32).toString("hex"));
+
+    const wrongSecret = crypto.randomBytes(32).toString("hex");
+    expect(() => store.recordRevealedSecret(1, 40, "a", wrongSecret)).toThrow(
+      /does not match the recorded commitment/
+    );
+    expect(store.isRevoked(1, 40)).toBe(false);
+  });
+
+  it("reveal() refuses to act on a slot this store does not own", () => {
+    const store = new RevocationStore();
+    store.recordCommitment(1, 40, "a", crypto.randomBytes(32).toString("hex"));
+    expect(() => store.reveal(1, 40, "a")).toThrow(/recordRevealedSecret instead/);
+  });
+});
+
 describe("commitmentHashFor", () => {
   it("returns null when nothing has been committed", () => {
     const store = new RevocationStore();

--- a/backend/src/__tests__/channels/watchtower.test.js
+++ b/backend/src/__tests__/channels/watchtower.test.js
@@ -1,0 +1,181 @@
+/**
+ * Unit + integration tests for Watchtower and FraudProofBuilder.
+ *
+ * The integration test reproduces the exact scenario from the issue: B goes
+ * offline entirely, A publishes a revoked state, a watchtower punishes
+ * within the window, B recovers the full balance on return. It stops short
+ * of a live contract call (that's covered on the Rust side by
+ * `punishment_of_a_revoked_close_pays_the_challenger_everything` in
+ * contract/contracts/channels/src/test.rs) and instead asserts the exact
+ * check the contract performs — `sha256(secret) == revocation_commit_*` —
+ * so a regression in either the Watchtower's plumbing or the secret it hands
+ * back would be caught here before ever reaching the chain.
+ */
+
+const crypto = require("crypto");
+const { Keypair } = require("@stellar/stellar-sdk");
+const Watchtower = require("../../channels/Watchtower");
+const FraudProofBuilder = require("../../channels/FraudProofBuilder");
+const ChannelNegotiator = require("../../channels/ChannelNegotiator");
+const RevocationStore = require("../../channels/RevocationStore");
+const ChannelState = require("../../channels/ChannelState");
+
+const KEY_A = Keypair.fromRawEd25519Seed(Buffer.alloc(32, 5));
+const KEY_B = Keypair.fromRawEd25519Seed(Buffer.alloc(32, 6));
+const CHANNEL_ID = 900;
+const MASTER_KEY = crypto.randomBytes(32);
+
+function runRound(a, b, params) {
+  const proposal = a.propose(params);
+  const counterSignature = b.counterSign(proposal);
+  const ack = a.ack(counterSignature);
+  const completion = b.complete(ack);
+  a.finalize(completion);
+  return { ack, completion };
+}
+
+describe("Watchtower storage", () => {
+  it("round-trips a justice package through register/findJustice", () => {
+    const tower = new Watchtower({ masterKey: MASTER_KEY });
+    const state = ChannelState.createState({
+      channelId: 1,
+      version: 1,
+      balanceA: 900,
+      balanceB: 100,
+      revocationCommitA: crypto.randomBytes(32).toString("hex"),
+      revocationCommitB: crypto.randomBytes(32).toString("hex"),
+    });
+    const justice = {
+      party: "a",
+      revocationSecret: crypto.randomBytes(32).toString("hex"),
+      challenger: "GDUMMYADDRESS",
+    };
+
+    tower.register(state, justice);
+    expect(tower.findJustice(state)).toEqual(justice);
+  });
+
+  it("returns null for a state nothing was ever registered for", () => {
+    const tower = new Watchtower({ masterKey: MASTER_KEY });
+    const state = ChannelState.createState({
+      channelId: 1,
+      version: 1,
+      balanceA: 900,
+      balanceB: 100,
+      revocationCommitA: crypto.randomBytes(32).toString("hex"),
+      revocationCommitB: crypto.randomBytes(32).toString("hex"),
+    });
+    expect(tower.findJustice(state)).toBeNull();
+  });
+
+  it("a different watchtower (different master key) cannot decrypt another's blobs", () => {
+    const towerA = new Watchtower({ masterKey: MASTER_KEY });
+    const towerB = new Watchtower({ masterKey: crypto.randomBytes(32) });
+    const state = ChannelState.createState({
+      channelId: 1,
+      version: 1,
+      balanceA: 900,
+      balanceB: 100,
+      revocationCommitA: crypto.randomBytes(32).toString("hex"),
+      revocationCommitB: crypto.randomBytes(32).toString("hex"),
+    });
+    const hash = towerA.register(state, {
+      party: "a",
+      revocationSecret: crypto.randomBytes(32).toString("hex"),
+      challenger: "G...",
+    });
+
+    // towerB never received this registration at all — simulates the blob
+    // never having reached a different operator's storage.
+    expect(towerB.has(hash)).toBe(false);
+  });
+
+  it("rejects a master key of the wrong length", () => {
+    expect(() => new Watchtower({ masterKey: crypto.randomBytes(16) })).toThrow(/32 bytes/);
+  });
+});
+
+describe("FraudProofBuilder", () => {
+  it("returns null when nothing was revealed for that version", () => {
+    const store = new RevocationStore();
+    const builder = new FraudProofBuilder({ revocationStore: store });
+    expect(builder.build(1, 40)).toBeNull();
+  });
+
+  it("builds a claim from a revealed secret, without needing to know which party revealed it", () => {
+    const store = new RevocationStore();
+    store.commit(1, 40, "b");
+    const secret = store.reveal(1, 40, "b");
+
+    const builder = new FraudProofBuilder({ revocationStore: store });
+    expect(builder.build(1, 40)).toEqual({
+      channelId: 1,
+      version: 40,
+      party: "b",
+      revocationSecret: secret,
+    });
+  });
+});
+
+describe("end-to-end: offline party recovers full balance via a watchtower", () => {
+  it("B goes offline, A publishes a revoked state, the watchtower's claim satisfies the contract's punish check", () => {
+    const storeA = new RevocationStore();
+    const storeB = new RevocationStore();
+    const a = new ChannelNegotiator({
+      channelId: CHANNEL_ID,
+      party: "a",
+      keypair: KEY_A,
+      counterpartyPublicKey: KEY_B.publicKey(),
+      revocationStore: storeA,
+    });
+    const b = new ChannelNegotiator({
+      channelId: CHANNEL_ID,
+      party: "b",
+      keypair: KEY_B,
+      counterpartyPublicKey: KEY_A.publicKey(),
+      revocationStore: storeB,
+    });
+    const tower = new Watchtower({ masterKey: MASTER_KEY });
+
+    // Version 1: the channel's opening balances.
+    runRound(a, b, { version: 1, balanceA: 600, balanceB: 400 });
+    const staleState = a.currentState; // this is what A will later cheat with
+
+    // Version 2: B pays A honestly. As part of completing this round, B
+    // reveals its own secret for version 1 and — before going offline —
+    // registers a justice package with the watchtower keyed to exactly
+    // that revoked state.
+    const { completion } = runRound(a, b, { version: 2, balanceA: 500, balanceB: 500 });
+    tower.register(staleState, {
+      party: completion.revealedParty,
+      revocationSecret: completion.revealedSecret,
+      challenger: KEY_B.publicKey(),
+    });
+
+    // B now goes offline for good. A dishonestly publishes the stale
+    // version-1 state on-chain (simulated: this is exactly the object a
+    // real close_unilateral call would carry).
+    expect(staleState.version).toBe(1);
+
+    // The watchtower observes the close (ChannelMonitor's job in
+    // production) and looks up a justice package for exactly this state.
+    const justice = tower.findJustice(staleState);
+    expect(justice).not.toBeNull();
+    expect(justice.challenger).toBe(KEY_B.publicKey());
+
+    // This is exactly what contract/contracts/channels/src/lib.rs's punish()
+    // checks: sha256(secret) must equal one of the revoked state's own
+    // committed hashes.
+    const secretHash = crypto
+      .createHash("sha256")
+      .update(Buffer.from(justice.revocationSecret, "hex"))
+      .digest("hex");
+    const expectedField =
+      justice.party === "a" ? staleState.revocation_commit_a : staleState.revocation_commit_b;
+    expect(secretHash).toBe(expectedField);
+
+    // The payout the contract would make is the full original deposit
+    // (600 + 400 = 1000), not B's honest 500 — B recovers everything,
+    // exactly as the issue's acceptance criteria require.
+  });
+});

--- a/backend/src/__tests__/sdk/cortexAgentSDK.channels.test.js
+++ b/backend/src/__tests__/sdk/cortexAgentSDK.channels.test.js
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for CortexAgentSDK's payment-channel negotiation wiring.
+ *
+ * Covers only the network-free half: two SDK instances (standing in for two
+ * separate agents) driving ChannelNegotiator through the SDK's
+ * payInChannel / receiveChannel... / getChannelState methods. The on-chain calls
+ * (registerChannelKey, openChannel, closeChannel) need a live RPC endpoint
+ * and are exercised on the Rust side instead — see
+ * contract/contracts/channels/src/test.rs, which covers the exact same
+ * ChannelState wire format these methods build.
+ */
+
+const { Keypair } = require("@stellar/stellar-sdk");
+const CortexAgentSDK = require("../../sdk/CortexAgentSDK");
+const ChannelState = require("../../channels/ChannelState");
+
+const KEY_A = Keypair.fromRawEd25519Seed(Buffer.alloc(32, 21));
+const KEY_B = Keypair.fromRawEd25519Seed(Buffer.alloc(32, 22));
+const CHANNEL_ID = 55;
+
+function makeAgents() {
+  const a = new CortexAgentSDK({ backendUrl: "http://localhost:4000", buyerKeypair: KEY_A });
+  const b = new CortexAgentSDK({ backendUrl: "http://localhost:4000", buyerKeypair: KEY_B });
+  a.joinChannel(CHANNEL_ID, { party: "a", counterpartyPublicKey: KEY_B.publicKey() });
+  b.joinChannel(CHANNEL_ID, { party: "b", counterpartyPublicKey: KEY_A.publicKey() });
+  return { a, b };
+}
+
+/** Drive one full round through both agents' SDKs. */
+function runRound(a, b, { balanceA, balanceB }) {
+  const proposal = a.payInChannel(CHANNEL_ID, balanceA, balanceB);
+  const counterSignature = b.receiveChannelProposal(CHANNEL_ID, proposal);
+  const ack = a.receiveChannelCounterSignature(CHANNEL_ID, counterSignature);
+  const completion = b.receiveChannelAck(CHANNEL_ID, ack);
+  a.receiveChannelCompletion(CHANNEL_ID, completion);
+  return { ack, completion };
+}
+
+describe("CortexAgentSDK channel negotiation", () => {
+  it("both agents converge on the same fully-signed state after one round", () => {
+    const { a, b } = makeAgents();
+    runRound(a, b, { balanceA: 900, balanceB: 100 });
+
+    expect(a.getChannelState(CHANNEL_ID)).toEqual(b.getChannelState(CHANNEL_ID));
+    expect(
+      ChannelState.verify(a.getChannelState(CHANNEL_ID), KEY_A.publicKey(), KEY_B.publicKey()).valid
+    ).toBe(true);
+  });
+
+  it("payInChannel advances the version automatically", () => {
+    const { a, b } = makeAgents();
+    runRound(a, b, { balanceA: 900, balanceB: 100 });
+    runRound(a, b, { balanceA: 800, balanceB: 200 });
+
+    expect(a.getChannelState(CHANNEL_ID).version).toBe(2);
+    expect(a.getChannelState(CHANNEL_ID).balance_a).toBe(800);
+  });
+
+  it("a completed round hands back everything registerWatchtower needs", () => {
+    const { a, b } = makeAgents();
+    runRound(a, b, { balanceA: 900, balanceB: 100 }); // version 1, nothing revoked yet
+    const { completion } = runRound(a, b, { balanceA: 800, balanceB: 200 }); // revokes version 1
+
+    expect(completion.revokedState.version).toBe(1);
+    expect(completion.revealedSecret).toEqual(expect.any(String));
+    expect(["a", "b"]).toContain(completion.revealedParty);
+  });
+
+  it("methods that touch a channel this agent never joined throw a clear error", () => {
+    const a = new CortexAgentSDK({ backendUrl: "http://localhost:4000", buyerKeypair: KEY_A });
+    expect(() => a.payInChannel(999, 1, 1)).toThrow(/no local channel negotiator/);
+  });
+
+  it("payForCallViaChannel reports no channel available before joinChannel", () => {
+    const a = new CortexAgentSDK({ backendUrl: "http://localhost:4000", buyerKeypair: KEY_A });
+    expect(a.payForCallViaChannel(KEY_B.publicKey(), 10)).toEqual({ viaChannel: false });
+  });
+
+  it("payForCallViaChannel reports no channel available before any balance is negotiated", () => {
+    const { a } = makeAgents();
+    // joinChannel happened, but no round has run yet — currentState is null.
+    expect(a.payForCallViaChannel(KEY_B.publicKey(), 10)).toEqual({ viaChannel: false });
+  });
+
+  it("payForCallViaChannel deducts from the caller's own balance and proposes the next version", () => {
+    const { a, b } = makeAgents();
+    runRound(a, b, { balanceA: 1000, balanceB: 0 });
+
+    const result = a.payForCallViaChannel(KEY_B.publicKey(), 25);
+    expect(result.viaChannel).toBe(true);
+    expect(result.channelId).toBe(CHANNEL_ID);
+    expect(result.proposal.balanceA).toBe(975);
+    expect(result.proposal.balanceB).toBe(25);
+    expect(result.proposal.version).toBe(2);
+  });
+
+  it("payForCallViaChannel falls back to false when the caller's balance can't cover the price", () => {
+    const { a, b } = makeAgents();
+    runRound(a, b, { balanceA: 10, balanceB: 990 });
+
+    expect(a.payForCallViaChannel(KEY_B.publicKey(), 25)).toEqual({ viaChannel: false });
+  });
+
+  it("works symmetrically for the counterparty (party b) side of the channel", () => {
+    const { a, b } = makeAgents();
+    runRound(a, b, { balanceA: 400, balanceB: 600 });
+
+    const result = b.payForCallViaChannel(KEY_A.publicKey(), 50);
+    expect(result.viaChannel).toBe(true);
+    expect(result.proposal.balanceB).toBe(550);
+    expect(result.proposal.balanceA).toBe(450);
+  });
+
+  it("registerWatchtower rejects a call missing the revoked-state context", async () => {
+    const { a } = makeAgents();
+    await expect(a.registerWatchtower(CHANNEL_ID, "http://tower.example")).rejects.toThrow(
+      /needs the state that was just superseded/
+    );
+  });
+});

--- a/backend/src/channels/ChannelNegotiator.js
+++ b/backend/src/channels/ChannelNegotiator.js
@@ -1,0 +1,340 @@
+/**
+ * ChannelNegotiator — the off-chain update handshake: propose, counter-sign,
+ * ack, complete.
+ *
+ * One instance per party, per channel. Each side holds its own Ed25519
+ * keypair and its own RevocationStore — there is no shared process, no
+ * trusted intermediary, and each party's revocation secrets never leave
+ * that party's own machine until deliberately revealed.
+ *
+ * ── The five steps ─────────────────────────────────────────────────────────
+ *
+ *   1. propose()    — proposer picks a new version + balances, generates
+ *                      *its own* revocation commitment for that version,
+ *                      sends {version, balances, proposerCommit}.
+ *   2. counterSign() — counterparty generates its own commitment, builds the
+ *                      full (still one-sided) signed state, sends back its
+ *                      {commitmentHash, signature}.
+ *   3. ack()         — proposer combines both commitments + both intended
+ *                      signatures into the fully dual-signed state, verifies
+ *                      it, and *only then* reveals its own previous-version
+ *                      secret. Sends {state, revealedSecret}.
+ *   4. complete()    — counterparty verifies the final dual-signed state,
+ *                      records the proposer's revealed secret, and reveals
+ *                      its own previous-version secret in turn.
+ *   5. finalize()    — proposer records the counterparty's revealed secret
+ *                      from step 4. Both sides now hold the same current
+ *                      state, and both previous-version secrets are mutually
+ *                      known.
+ *
+ * ── Why this ordering is safe against a counterparty who abandons halfway ──
+ *
+ * The dangerous failure mode for any revocation scheme is ending up with
+ * your *old* state revoked while your *new* state never finished being
+ * signed — a counterparty who vanishes at exactly that point leaves you
+ * holding nothing valid at all, having handed them the means to punish you
+ * for whatever you try to close with instead.
+ *
+ * This protocol makes that impossible by construction: a party reveals its
+ * own previous-version secret (step 3 for the proposer, step 4 for the
+ * counterparty) *only after* it already holds a state that verifies under
+ * both signatures. If the counterparty disappears at any earlier point —
+ * after step 1, after step 2, even after step 3 if step 4 never arrives for
+ * the proposer's side of the story — the party that has not yet revealed
+ * still has its old, unrevoked, fully closable state sitting untouched. The
+ * worst an abandoned handshake costs either side is one unused RevocationStore
+ * commitment slot for a version that never became current — never money, and
+ * never a state the other side can deny having agreed to, because nothing
+ * before "current" ever changes.
+ */
+
+const ChannelState = require("./ChannelState");
+const { signingMessage } = require("./canonical");
+
+function otherParty(party) {
+  return party === "a" ? "b" : "a";
+}
+
+class ChannelNegotiator {
+  /**
+   * @param {object} config
+   * @param {number|string} config.channelId
+   * @param {'a'|'b'} config.party - which side this instance represents
+   * @param {import('@stellar/stellar-sdk').Keypair} config.keypair - this
+   *   party's signing key
+   * @param {string} config.counterpartyPublicKey - the other party's G...
+   *   address, used to verify their half of each new state
+   * @param {import('./RevocationStore')} config.revocationStore - this
+   *   party's own store; never shared with the counterparty's process
+   * @param {object} [config.initialState] - a fully dual-signed state to
+   *   start from (e.g. the version negotiated immediately after
+   *   open_channel); omit for a negotiator that will itself run the very
+   *   first negotiation
+   */
+  constructor({ channelId, party, keypair, counterpartyPublicKey, revocationStore, initialState = null }) {
+    if (party !== "a" && party !== "b") throw new Error('party must be "a" or "b"');
+    this.channelId = channelId;
+    this.party = party;
+    this.counterpartyParty = otherParty(party);
+    this.keypair = keypair;
+    this.counterpartyPublicKey = counterpartyPublicKey;
+    this.revocationStore = revocationStore;
+    this.currentState = initialState;
+    this._pending = null;
+  }
+
+  _myPublicKey() {
+    return this.keypair.publicKey();
+  }
+
+  _partyPublicKeys() {
+    return this.party === "a"
+      ? { a: this._myPublicKey(), b: this.counterpartyPublicKey }
+      : { a: this.counterpartyPublicKey, b: this._myPublicKey() };
+  }
+
+  /**
+   * Step 1. Propose a new version with new balances.
+   *
+   * @returns {object} the Proposal message to send to the counterparty
+   */
+  propose({ version, balanceA, balanceB }) {
+    if (this._pending) {
+      throw new Error("a negotiation is already in flight for this channel");
+    }
+    if (this.currentState && Number(version) <= Number(this.currentState.version)) {
+      throw new Error(
+        `version ${version} does not exceed the current version ${this.currentState.version}`
+      );
+    }
+
+    const commitmentHash = this.revocationStore.commit(this.channelId, version, this.party);
+    const proposal = {
+      channelId: this.channelId,
+      version,
+      balanceA,
+      balanceB,
+      proposerParty: this.party,
+      proposerCommitmentHash: commitmentHash,
+    };
+    this._pending = { role: "proposer", ...proposal };
+    return proposal;
+  }
+
+  /**
+   * Step 2. Countersign a received proposal.
+   *
+   * Generates this party's own commitment and produces this party's half of
+   * the signature. Deliberately does *not* reveal anything about this
+   * party's previous state yet — see the module doc.
+   *
+   * @returns {object} the CounterSignature message to send to the proposer
+   */
+  counterSign(proposal) {
+    if (String(proposal.channelId) !== String(this.channelId)) {
+      throw new Error("proposal is for a different channel");
+    }
+    if (proposal.proposerParty === this.party) {
+      throw new Error("cannot countersign your own proposal");
+    }
+    if (this.currentState && Number(proposal.version) <= Number(this.currentState.version)) {
+      throw new Error(
+        `proposed version ${proposal.version} does not exceed the current version ${this.currentState.version}`
+      );
+    }
+
+    this.revocationStore.recordCommitment(
+      this.channelId,
+      proposal.version,
+      proposal.proposerParty,
+      proposal.proposerCommitmentHash
+    );
+    const myCommitmentHash = this.revocationStore.commit(this.channelId, proposal.version, this.party);
+
+    const commits =
+      this.party === "a"
+        ? { revocationCommitA: myCommitmentHash, revocationCommitB: proposal.proposerCommitmentHash }
+        : { revocationCommitA: proposal.proposerCommitmentHash, revocationCommitB: myCommitmentHash };
+
+    const state = ChannelState.createState({
+      channelId: this.channelId,
+      version: proposal.version,
+      balanceA: proposal.balanceA,
+      balanceB: proposal.balanceB,
+      ...commits,
+    });
+    const signature = ChannelState.sign(state, this.keypair);
+
+    this._pending = { role: "counterparty", state, myCommitmentHash };
+    return {
+      channelId: this.channelId,
+      version: proposal.version,
+      party: this.party,
+      commitmentHash: myCommitmentHash,
+      signature,
+    };
+  }
+
+  /**
+   * Step 3 (proposer). Accept the counterparty's counter-signature, produce
+   * the final dual-signed state, and — only having verified it in full —
+   * reveal this party's own previous-version secret.
+   *
+   * @returns {object} the Ack message to send to the counterparty:
+   *   `{ state, revealedVersion, revealedSecret }`, where the last two are
+   *   `null` when there was no previous version to revoke (the very first
+   *   negotiation on this channel).
+   */
+  ack(counterSignature) {
+    if (!this._pending || this._pending.role !== "proposer") {
+      throw new Error("no proposal from this party is awaiting a counter-signature");
+    }
+    const pending = this._pending;
+    if (String(counterSignature.channelId) !== String(this.channelId)) {
+      throw new Error("counter-signature is for a different channel");
+    }
+    if (Number(counterSignature.version) !== Number(pending.version)) {
+      throw new Error("counter-signature version does not match the outstanding proposal");
+    }
+
+    // Learn the counterparty's commitment hash for this version — mirrors
+    // what counterSign() already does for the proposer's side. Without this,
+    // this store has no commitment on record to check a later revealed
+    // secret against, even though the state itself already carries it.
+    this.revocationStore.recordCommitment(
+      this.channelId,
+      pending.version,
+      this.counterpartyParty,
+      counterSignature.commitmentHash
+    );
+
+    const commits =
+      pending.proposerParty === "a"
+        ? { revocationCommitA: pending.proposerCommitmentHash, revocationCommitB: counterSignature.commitmentHash }
+        : { revocationCommitA: counterSignature.commitmentHash, revocationCommitB: pending.proposerCommitmentHash };
+
+    const unsigned = ChannelState.createState({
+      channelId: this.channelId,
+      version: pending.version,
+      balanceA: pending.balanceA,
+      balanceB: pending.balanceB,
+      ...commits,
+    });
+
+    if (
+      !ChannelState.verifySignatureRaw(
+        signingMessage(unsigned),
+        counterSignature.signature,
+        this.counterpartyPublicKey
+      )
+    ) {
+      throw new Error("counterparty's counter-signature does not verify");
+    }
+
+    const mySignature = ChannelState.sign(unsigned, this.keypair);
+    const withCounterparty = ChannelState.withSignature(
+      unsigned,
+      this.counterpartyParty,
+      counterSignature.signature
+    );
+    const state = ChannelState.withSignature(withCounterparty, this.party, mySignature);
+
+    const pubkeys = this._partyPublicKeys();
+    const verification = ChannelState.verify(state, pubkeys.a, pubkeys.b);
+    if (!verification.valid) {
+      throw new Error(`assembled state failed verification: ${verification.reason}`);
+    }
+
+    // Only now — with a fully verified successor in hand — is it safe to
+    // revoke the previous version.
+    const previous = this.currentState;
+    const revealedSecret = previous ? this.revocationStore.reveal(this.channelId, previous.version, this.party) : null;
+
+    this.currentState = state;
+    this._pending = null;
+
+    return {
+      channelId: this.channelId,
+      state,
+      revealedVersion: previous ? previous.version : null,
+      revealedParty: previous ? this.party : null,
+      revealedSecret,
+      // The full superseded state, not just its version — a caller wiring
+      // up Watchtower.register() needs this to compute the old state's
+      // commitment hash; it's otherwise gone once currentState moves on.
+      revokedState: previous,
+    };
+  }
+
+  /**
+   * Step 4 (counterparty). Verify the proposer's ack, record their revealed
+   * secret, and — only now — reveal this party's own previous-version
+   * secret in turn.
+   *
+   * @returns {object} the Completion message to send back to the proposer:
+   *   `{ revealedVersion, revealedSecret, revokedState }`, `null` fields on
+   *   the first negotiation, same as `ack()`.
+   */
+  complete(ack) {
+    if (!this._pending || this._pending.role !== "counterparty") {
+      throw new Error("no counter-signature from this party is awaiting an ack");
+    }
+    const pending = this._pending;
+    if (String(ack.channelId) !== String(this.channelId)) {
+      throw new Error("ack is for a different channel");
+    }
+
+    const pubkeys = this._partyPublicKeys();
+    const verification = ChannelState.verify(ack.state, pubkeys.a, pubkeys.b);
+    if (!verification.valid) {
+      throw new Error(`proposer's assembled state failed verification: ${verification.reason}`);
+    }
+    if (
+      Number(ack.state.channel_id) !== Number(this.channelId) ||
+      Number(ack.state.version) !== Number(pending.state.version)
+    ) {
+      throw new Error("ack state does not match the outstanding counter-signature");
+    }
+
+    if (ack.revealedSecret) {
+      this.revocationStore.recordRevealedSecret(
+        this.channelId,
+        ack.revealedVersion,
+        ack.revealedParty,
+        ack.revealedSecret
+      );
+    }
+
+    const previous = this.currentState;
+    const revealedSecret = previous ? this.revocationStore.reveal(this.channelId, previous.version, this.party) : null;
+
+    this.currentState = ack.state;
+    this._pending = null;
+
+    return {
+      channelId: this.channelId,
+      revealedVersion: previous ? previous.version : null,
+      revealedParty: previous ? this.party : null,
+      revealedSecret,
+      revokedState: previous,
+    };
+  }
+
+  /**
+   * Step 5 (proposer). Record the counterparty's revealed secret from
+   * `complete()`. Purely bookkeeping — both sides already hold the same
+   * `currentState` by this point.
+   */
+  finalize(completion) {
+    if (completion.revealedSecret) {
+      this.revocationStore.recordRevealedSecret(
+        this.channelId,
+        completion.revealedVersion,
+        completion.revealedParty,
+        completion.revealedSecret
+      );
+    }
+  }
+}
+
+module.exports = ChannelNegotiator;

--- a/backend/src/channels/ChannelState.js
+++ b/backend/src/channels/ChannelState.js
@@ -2,13 +2,19 @@
  * ChannelState — the dual-signed, monotonically versioned balance pair a
  * bidirectional payment channel is built on.
  *
- * `{ channel_id, version, balance_a, balance_b, sig_a, sig_b }`. A state is
- * only meaningful with both signatures present and valid: neither party can
- * move funds unilaterally, and the on-chain contract (`dispute`) trusts a
- * state exactly because it cannot exist without both parties having signed
- * off on it. Comparing versions is what lets a later, correctly signed state
- * supersede an earlier one — the mechanism that makes publishing a stale
- * close strictly worse than closing honestly.
+ * `{ channel_id, version, balance_a, balance_b, revocation_commit_a,
+ * revocation_commit_b, sig_a, sig_b }`. A state is only meaningful with both
+ * signatures present and valid: neither party can move funds unilaterally,
+ * and the on-chain contract (`dispute`) trusts a state exactly because it
+ * cannot exist without both parties having signed off on it. Comparing
+ * versions is what lets a later, correctly signed state supersede an
+ * earlier one — the mechanism that makes publishing a stale close strictly
+ * worse than closing honestly.
+ *
+ * The two `revocation_commit_*` fields are each party's RevocationStore
+ * commitment hash for *this* version — signed alongside the balances so a
+ * `punish` claim can prove a revealed secret revokes this exact version
+ * using nothing but the state itself (see canonical.js's header for why).
  *
  * This module is deliberately narrow: it knows how to build, sign and verify
  * one state, and how to order two states of the same channel. It does not
@@ -59,20 +65,30 @@ function assertU64Integer(value, label) {
   }
 }
 
-function createState({ channelId, version, balanceA, balanceB }) {
+function createState({
+  channelId,
+  version,
+  balanceA,
+  balanceB,
+  revocationCommitA,
+  revocationCommitB,
+}) {
   assertU64Integer(channelId, "channelId");
   assertU64Integer(version, "version");
   assertU64Integer(balanceA, "balanceA");
   assertU64Integer(balanceB, "balanceB");
 
   // encodeStatePreimage (via signingMessage) additionally enforces u64
-  // upper bounds; calling it here makes any remaining malformed input fail
-  // at creation time rather than silently propagating into a signature.
+  // upper bounds and the 32-byte shape of the commitment fields; calling it
+  // here makes any remaining malformed input fail at creation time rather
+  // than silently propagating into a signature.
   const state = {
     channel_id: channelId,
     version,
     balance_a: balanceA,
     balance_b: balanceB,
+    revocation_commit_a: revocationCommitA,
+    revocation_commit_b: revocationCommitB,
     sig_a: null,
     sig_b: null,
   };

--- a/backend/src/channels/FraudProofBuilder.js
+++ b/backend/src/channels/FraudProofBuilder.js
@@ -1,0 +1,43 @@
+/**
+ * FraudProofBuilder — given a revoked on-chain close attempt, assembles a
+ * punishment claim.
+ *
+ * The claim is deliberately minimal: the contract's `punish(challenger,
+ * channel_id, revocation_secret)` needs nothing but the bare secret — no
+ * balances, no the-other signed state — so that is all this builds. See
+ * `contract/contracts/channels/src/lib.rs`'s module doc for why `punish`
+ * only needs a secret where `dispute` needs a whole state: the secret proves
+ * revocation on its own, once the pending close's own
+ * `revocation_commit_a`/`_b` fields are known (they are always public,
+ * posted on-chain by `close_unilateral` itself).
+ */
+
+class FraudProofBuilder {
+  /**
+   * @param {import('./RevocationStore')} revocationStore
+   */
+  constructor({ revocationStore }) {
+    this.revocationStore = revocationStore;
+  }
+
+  /**
+   * @param {number|string} channelId
+   * @param {number|string} revokedVersion - the version an on-chain
+   *   `close_unilateral`/pending state is resting on
+   * @returns {{channelId, version, party: 'a'|'b', revocationSecret: string}|null}
+   *   a claim ready to pass as `punish`'s `revocation_secret`, or `null` if
+   *   this store holds no revealed secret for that version (nothing to
+   *   punish — the pending close may well be honest).
+   */
+  build(channelId, revokedVersion) {
+    for (const party of ["a", "b"]) {
+      const secret = this.revocationStore.revealedSecretFor(channelId, revokedVersion, party);
+      if (secret) {
+        return { channelId, version: revokedVersion, party, revocationSecret: secret };
+      }
+    }
+    return null;
+  }
+}
+
+module.exports = FraudProofBuilder;

--- a/backend/src/channels/RevocationStore.js
+++ b/backend/src/channels/RevocationStore.js
@@ -103,8 +103,62 @@ class RevocationStore {
         `no revocation commitment for channel ${channelId} version ${version} party ${party}`
       );
     }
+    if (!entry.secret) {
+      throw new Error(
+        `channel ${channelId} version ${version} party ${party} is a recorded (counterparty-owned) ` +
+          "commitment, not one this store generated — use recordRevealedSecret instead"
+      );
+    }
     entry.revealed = true;
     return entry.secret.toString("hex");
+  }
+
+  /**
+   * Record a counterparty's published commitment hash for a slot this store
+   * does not own — used by ChannelNegotiator on the receiving side of a
+   * propose/counter-sign exchange, where each party's Ed25519 secret lives
+   * only in that party's own process. Unlike commit(), this never generates
+   * a secret; it just remembers the hash so a later revealed secret can be
+   * checked against it.
+   *
+   * One-shot, same as commit(): a slot's commitment is fixed the first time
+   * either party learns of it.
+   */
+  recordCommitment(channelId, version, party, commitmentHashHex) {
+    this._assertParty(party);
+    const slot = this._slot(channelId, version);
+    if (slot[party]) {
+      throw new Error(
+        `a revocation commitment already exists for channel ${channelId} version ${version} party ${party}`
+      );
+    }
+    slot[party] = {
+      secret: null,
+      commitmentHash: Buffer.from(commitmentHashHex, "hex"),
+      revealed: false,
+    };
+    return commitmentHashHex;
+  }
+
+  /**
+   * Record a secret the counterparty revealed for a slot this store does
+   * not own. Verifies it against the previously recorded commitment before
+   * accepting it — a mismatch means the counterparty sent a secret that
+   * does not open what they committed to, which is a protocol violation,
+   * not something this store should silently trust.
+   */
+  recordRevealedSecret(channelId, version, party, secretHex) {
+    this._assertParty(party);
+    const { valid } = this.verifySecret(channelId, version, secretHex);
+    if (!valid) {
+      throw new Error(
+        `revealed secret does not match the recorded commitment for channel ${channelId} ` +
+          `version ${version} party ${party}`
+      );
+    }
+    const slot = this._slot(channelId, version);
+    slot[party].secret = Buffer.from(secretHex, "hex");
+    slot[party].revealed = true;
   }
 
   /**
@@ -142,6 +196,19 @@ class RevocationStore {
       }
     }
     return { valid: false, party: null };
+  }
+
+  /**
+   * The revealed secret for (channelId, version, party), hex-encoded, or
+   * `null` if that slot has not been revealed (or does not exist). This is
+   * the read accessor FraudProofBuilder uses to find a punishable secret
+   * without needing to know in advance which party revealed it.
+   */
+  revealedSecretFor(channelId, version, party) {
+    this._assertParty(party);
+    const slot = this._slots.get(key(channelId, version));
+    const entry = slot?.[party];
+    return entry?.revealed && entry.secret ? entry.secret.toString("hex") : null;
   }
 
   /** The commitment hash on record for (channelId, version, party), if any. */

--- a/backend/src/channels/Watchtower.js
+++ b/backend/src/channels/Watchtower.js
@@ -1,0 +1,119 @@
+/**
+ * Watchtower — holds encrypted justice packages and finds the right one
+ * when it observes a revoked close.
+ *
+ * ── What "without learning the channel balances" actually means here ───────
+ *
+ * A justice package is nothing but a bare 32-byte revocation secret plus
+ * who it belongs to — never a channel's balances, never even the state it
+ * revokes. A random 32 bytes carries no information about what a channel
+ * was worth, so a watchtower holding one learns nothing by design, not by
+ * promise. (The balances themselves are separately, unavoidably public: they
+ * get posted on-chain in the clear the moment a unilateral close happens —
+ * see `PendingClose` in the contract. No amount of client-side encryption
+ * changes that; it was never this module's job to hide it.)
+ *
+ * What this module *does* encrypt is the secret at rest, under a key derived
+ * from this watchtower's own master key. That is ordinary encryption-at-rest
+ * hygiene — it protects a client's secret from a storage-layer breach that
+ * doesn't also compromise the watchtower process itself — not a
+ * zero-knowledge scheme. A watchtower that *submits* `punish` transactions
+ * necessarily has to recover the plaintext secret to do that; nothing short
+ * of the watchtower never seeing the secret at all (defeating the point of
+ * registering with it) could change that.
+ *
+ * ── Lookup ───────────────────────────────────────────────────────────────
+ *
+ * Blobs are keyed by `commitmentHash(state)` (canonical.js) — the same value
+ * `close_unilateral` implicitly commits a party to the moment it posts a
+ * state on-chain. A client registers a package for a state as soon as it has
+ * one to register (see FraudProofBuilder's header for when that is);
+ * ChannelMonitor recomputes the same hash from whatever it observes on-chain
+ * and calls `findJustice` to see if this watchtower is holding anything for
+ * it.
+ */
+
+const crypto = require("crypto");
+const { commitmentHash } = require("./canonical");
+
+const MASTER_KEY_BYTES = 32;
+
+class Watchtower {
+  /**
+   * @param {Buffer|string} masterKey - 32 bytes (or 64 hex chars), this
+   *   watchtower operator's own key. Never derived from anything a client
+   *   supplies — a client-supplied key would let whoever controls the
+   *   client also read every other client's blobs stored under the same
+   *   watchtower process.
+   */
+  constructor({ masterKey }) {
+    const key = Buffer.isBuffer(masterKey) ? masterKey : Buffer.from(masterKey, "hex");
+    if (key.length !== MASTER_KEY_BYTES) {
+      throw new Error(`masterKey must be ${MASTER_KEY_BYTES} bytes`);
+    }
+    this.masterKey = key;
+    this._blobs = new Map(); // commitmentHashHex -> { iv, authTag, ciphertext }
+  }
+
+  _blobKeyFor(commitmentHashHex) {
+    return crypto.createHmac("sha256", this.masterKey).update(commitmentHashHex, "hex").digest();
+  }
+
+  /**
+   * Register a justice package for `state`. Typically called right after a
+   * ChannelNegotiator round reveals the secret for the state it just
+   * superseded (`ack()`/`complete()`'s `revokedState` + `revealedSecret`).
+   *
+   * @param {object} state - the ChannelState being protected against
+   * @param {object} justice
+   * @param {'a'|'b'} justice.party - whose revocation secret this is
+   * @param {string} justice.revocationSecret - hex
+   * @param {string} justice.challenger - the G... address `punish` should
+   *   pay — this party's own address, so a watchtower can submit on their
+   *   behalf without needing a fresh signature from them
+   * @returns {string} the commitment hash this package is stored under
+   */
+  register(state, justice) {
+    const hash = commitmentHash(state).toString("hex");
+    const key = this._blobKeyFor(hash);
+    const iv = crypto.randomBytes(12);
+    const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+    const plaintext = Buffer.from(JSON.stringify(justice), "utf8");
+    const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+
+    this._blobs.set(hash, { iv, authTag, ciphertext });
+    return hash;
+  }
+
+  has(commitmentHashHex) {
+    return this._blobs.has(commitmentHashHex);
+  }
+
+  /**
+   * Given a state actually observed on-chain (public: channel_id, version,
+   * balances, revocation commitments — from `get_pending_close` after a
+   * `UNILATERAL_CLOSE` event), check whether this watchtower holds a
+   * justice package for it, and if so, decrypt and return it.
+   *
+   * @returns {{party, revocationSecret, challenger}|null}
+   */
+  findJustice(state) {
+    const hash = commitmentHash(state).toString("hex");
+    return this.findJusticeByHash(hash);
+  }
+
+  /** Same as findJustice, keyed directly by a commitment hash already in hand. */
+  findJusticeByHash(commitmentHashHex) {
+    const blob = this._blobs.get(commitmentHashHex);
+    if (!blob) return null;
+
+    const key = this._blobKeyFor(commitmentHashHex);
+    const decipher = crypto.createDecipheriv("aes-256-gcm", key, blob.iv);
+    decipher.setAuthTag(blob.authTag);
+    const plaintext = Buffer.concat([decipher.update(blob.ciphertext), decipher.final()]);
+    return JSON.parse(plaintext.toString("utf8"));
+  }
+}
+
+module.exports = Watchtower;

--- a/backend/src/channels/canonical.js
+++ b/backend/src/channels/canonical.js
@@ -4,37 +4,52 @@
  *
  * Mirrors the layout style of `../attestation/canonical.js`: a fixed-width
  * big-endian record beats JSON for the same reasons it does there — no
- * canonicalisation question, and this preimage has to have a byte-for-byte
- * twin in the Soroban contract's `ChannelState` encoding once that crate
- * exists, so ambiguity here becomes a silent cross-language mismatch later.
+ * canonicalisation question, and this preimage has a byte-for-byte twin in
+ * the Soroban contract's `state.rs` (`contract/contracts/channels/src/state.rs`),
+ * so ambiguity here becomes a silent cross-language mismatch there.
  *
  * ── Wire format ──────────────────────────────────────────────────────────
  *
- * STATE_PREIMAGE is a fixed 32-byte big-endian record:
+ * STATE_PREIMAGE is a fixed 96-byte big-endian record:
  *
  *   offset  size  field
  *   ------  ----  ---------------------------------------------------------
- *        0     8  channel_id   u64 BE
- *        8     8  version      u64 BE, monotonic per channel
- *       16     8  balance_a    u64 BE
- *       24     8  balance_b    u64 BE
+ *        0     8  channel_id            u64 BE
+ *        8     8  version               u64 BE, monotonic per channel
+ *       16     8  balance_a             u64 BE
+ *       24     8  balance_b             u64 BE
+ *       32    32  revocation_commit_a   sha256(party A's revocation secret for this version)
+ *       64    32  revocation_commit_b   sha256(party B's revocation secret for this version)
  *
  * The signed message is `0x10 || STATE_PREIMAGE`. Domain tag 0x10 is chosen
  * clear of the attestation module's 0x00/0x01/0x02 so a channel-state
  * signature can never be replayed as, or confused with, an attestation leaf
  * even if the two byte layouts ever happened to collide in length.
  *
+ * ── Why the revocation commitments are part of the signed state ──────────
+ *
+ * `punish(challenger, channel_id, revocation_secret)` has to decide, from
+ * nothing but a bare 32-byte secret, whether some *earlier* version was
+ * revoked — the whole value of a watchtower is that it can do this without
+ * ever having seen the later state that superseded it (see RevocationStore's
+ * header for why: the watchtower must not learn channel balances). That is
+ * only checkable if the version being punished carries, as part of what both
+ * parties signed, the exact hash the secret must open. So each state commits
+ * to its own party-generated revocation secrets — RevocationStore.commit()
+ * produces the two hashes that go in these fields — and revealing either
+ * secret later (RevocationStore.reveal()) is what proves this version was
+ * superseded, per the protocol documented in RevocationStore.js.
+ *
  * `commitmentHash = sha256(signingMessage)` is deliberately the same value a
- * Watchtower blob is keyed on (see RevocationStore / the issue's Watchtower
- * spec): a watchtower that only ever sees commitment hashes never learns a
- * channel's balances, only which exact state it is holding a justice
- * transaction for.
+ * Watchtower blob is keyed on: a watchtower that only ever sees commitment
+ * hashes never learns a channel's balances, only which exact state it is
+ * holding a justice transaction for.
  */
 
 const crypto = require("crypto");
-const { toU64, HASH_BYTES } = require("../attestation/canonical");
+const { toU64, toFixedBuffer, HASH_BYTES } = require("../attestation/canonical");
 
-const STATE_PREIMAGE_BYTES = 32;
+const STATE_PREIMAGE_BYTES = 96;
 const DOMAIN_CHANNEL_STATE = 0x10;
 
 const OFFSETS = Object.freeze({
@@ -42,6 +57,8 @@ const OFFSETS = Object.freeze({
   version: 8,
   balanceA: 16,
   balanceB: 24,
+  revocationCommitA: 32,
+  revocationCommitB: 64,
 });
 
 function writeU64BE(buf, value, offset, label) {
@@ -49,14 +66,16 @@ function writeU64BE(buf, value, offset, label) {
 }
 
 /**
- * Serialize a channel state into its canonical 32-byte preimage.
+ * Serialize a channel state into its canonical 96-byte preimage.
  *
  * @param {object} state
  * @param {number|bigint|string} state.channel_id
  * @param {number|bigint|string} state.version
  * @param {number|bigint|string} state.balance_a
  * @param {number|bigint|string} state.balance_b
- * @returns {Buffer} 32 bytes
+ * @param {Buffer|string} state.revocation_commit_a - 32 bytes
+ * @param {Buffer|string} state.revocation_commit_b - 32 bytes
+ * @returns {Buffer} 96 bytes
  */
 function encodeStatePreimage(state) {
   if (!state || typeof state !== "object") throw new Error("state must be an object");
@@ -66,10 +85,18 @@ function encodeStatePreimage(state) {
   writeU64BE(buf, state.version, OFFSETS.version, "version");
   writeU64BE(buf, state.balance_a, OFFSETS.balanceA, "balance_a");
   writeU64BE(buf, state.balance_b, OFFSETS.balanceB, "balance_b");
+  toFixedBuffer(state.revocation_commit_a, HASH_BYTES, "revocation_commit_a").copy(
+    buf,
+    OFFSETS.revocationCommitA
+  );
+  toFixedBuffer(state.revocation_commit_b, HASH_BYTES, "revocation_commit_b").copy(
+    buf,
+    OFFSETS.revocationCommitB
+  );
   return buf;
 }
 
-/** Parse a 32-byte preimage back into a state with numeric fields. */
+/** Parse a 96-byte preimage back into a state with hex/numeric fields. */
 function decodeStatePreimage(bytes) {
   if (!Buffer.isBuffer(bytes) || bytes.length !== STATE_PREIMAGE_BYTES) {
     throw new Error(`preimage must be exactly ${STATE_PREIMAGE_BYTES} bytes`);
@@ -79,6 +106,12 @@ function decodeStatePreimage(bytes) {
     version: Number(bytes.readBigUInt64BE(OFFSETS.version)),
     balance_a: Number(bytes.readBigUInt64BE(OFFSETS.balanceA)),
     balance_b: Number(bytes.readBigUInt64BE(OFFSETS.balanceB)),
+    revocation_commit_a: bytes
+      .subarray(OFFSETS.revocationCommitA, OFFSETS.revocationCommitA + HASH_BYTES)
+      .toString("hex"),
+    revocation_commit_b: bytes
+      .subarray(OFFSETS.revocationCommitB, OFFSETS.revocationCommitB + HASH_BYTES)
+      .toString("hex"),
   };
 }
 
@@ -90,9 +123,10 @@ function signingMessage(state) {
 /**
  * commitment_hash = sha256(0x10 || STATE_PREIMAGE)
  *
- * The value a Watchtower blob is keyed on, and what a `punish` claim must
- * reproduce from a revealed revocation secret plus the revoked state's
- * fields — see RevocationStore.
+ * The value a Watchtower blob is keyed on. Distinct from the per-version
+ * revocation commitments carried *inside* the state (`revocation_commit_a/b`,
+ * which open a party's revocation secret) — this hash identifies the state
+ * as a whole, theirs identify the right to punish it.
  */
 function commitmentHash(state) {
   return crypto.createHash("sha256").update(signingMessage(state)).digest();

--- a/backend/src/config/stellar.js
+++ b/backend/src/config/stellar.js
@@ -44,6 +44,7 @@ const CONTRACT_IDS = {
   marketplace: process.env.MARKETPLACE_CONTRACT_ID || "",
   micropayments: process.env.MICROPAYMENTS_CONTRACT_ID || "",
   agentRegistry: process.env.AGENT_REGISTRY_CONTRACT_ID || "",
+  channels: process.env.CHANNELS_CONTRACT_ID || "",
 };
 
 module.exports = {

--- a/backend/src/db/migrations/026_add_payment_channels.sql
+++ b/backend/src/db/migrations/026_add_payment_channels.sql
@@ -1,0 +1,81 @@
+-- Bidirectional payment channels indexed from the channels contract, plus
+-- the durable backing a production node needs for RevocationStore and
+-- Watchtower — both ship as pure in-memory primitives (see
+-- backend/src/channels/RevocationStore.js and Watchtower.js) precisely so
+-- they can be given a Postgres-backed store here without changing their
+-- API, the same split AttestationVerifier's pluggable nonce/index stores
+-- already use.
+
+CREATE TABLE IF NOT EXISTS channels (
+    id               BIGINT      PRIMARY KEY,        -- on-chain channel_id
+    party_a          TEXT        NOT NULL,
+    party_b          TEXT        NOT NULL,
+    token            TEXT        NOT NULL,
+    deposit_a        BIGINT      NOT NULL CHECK (deposit_a >= 0),
+    deposit_b        BIGINT      NOT NULL CHECK (deposit_b >= 0),
+    status           TEXT        NOT NULL DEFAULT 'Open' CHECK (status IN (
+                         'Open', 'Closing', 'Closed'
+                     )),
+    closer           TEXT,
+    dispute_deadline BIGINT,
+    indexed_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Metering's "route through a channel when one exists" lookup: at most one
+-- open channel per (buyer, seller, token) triple. Older, closed channels
+-- between the same pair are left alone — this only constrains what counts
+-- as "the" currently usable channel.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_channels_open_pair
+    ON channels (party_a, party_b, token)
+    WHERE status = 'Open';
+
+CREATE INDEX IF NOT EXISTS idx_channels_party_a ON channels (party_a);
+CREATE INDEX IF NOT EXISTS idx_channels_party_b ON channels (party_b);
+CREATE INDEX IF NOT EXISTS idx_channels_status ON channels (status);
+
+-- Every off-chain state either party has fully countersigned, kept so a
+-- node can resume ChannelNegotiator's currentState after a restart without
+-- asking the counterparty to replay the whole history.
+CREATE TABLE IF NOT EXISTS channel_states (
+    channel_id           BIGINT      NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+    version              BIGINT      NOT NULL CHECK (version >= 0),
+    balance_a            BIGINT      NOT NULL CHECK (balance_a >= 0),
+    balance_b            BIGINT      NOT NULL CHECK (balance_b >= 0),
+    revocation_commit_a  TEXT        NOT NULL,
+    revocation_commit_b  TEXT        NOT NULL,
+    sig_a                TEXT        NOT NULL,
+    sig_b                TEXT        NOT NULL,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (channel_id, version)
+);
+
+-- Durable backing for RevocationStore: one row per (channel, version,
+-- party) commitment slot, whether generated locally (commit()) or recorded
+-- from the counterparty (recordCommitment()) — `secret` and `revealed`
+-- distinguish the two until a reveal actually happens.
+CREATE TABLE IF NOT EXISTS revocation_secrets (
+    channel_id       BIGINT      NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+    version          BIGINT      NOT NULL CHECK (version >= 0),
+    party            TEXT        NOT NULL CHECK (party IN ('a', 'b')),
+    commitment_hash  TEXT        NOT NULL,
+    secret           TEXT,
+    revealed         BOOLEAN     NOT NULL DEFAULT FALSE,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (channel_id, version, party)
+);
+
+-- Durable backing for Watchtower: the encrypted-at-rest justice packages a
+-- client has registered, keyed the same way the in-memory store is —
+-- by commitment_hash, so a node can rebuild its Watchtower Map on restart
+-- with no protocol change.
+CREATE TABLE IF NOT EXISTS watchtower_blobs (
+    commitment_hash  TEXT        PRIMARY KEY,
+    iv               TEXT        NOT NULL,
+    auth_tag         TEXT        NOT NULL,
+    ciphertext       TEXT        NOT NULL,
+    channel_id       BIGINT      REFERENCES channels(id) ON DELETE CASCADE,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_watchtower_blobs_channel ON watchtower_blobs (channel_id);

--- a/backend/src/protocol/ChannelMonitor.js
+++ b/backend/src/protocol/ChannelMonitor.js
@@ -1,0 +1,156 @@
+/**
+ * ChannelMonitor — watches for UNILATERAL_CLOSE events on the channels
+ * contract and dispatches to a Watchtower.
+ *
+ * "Channels this node backs" is not a separate registry: it is exactly
+ * whatever the configured Watchtower holds a justice package for.
+ * `processUnilateralClose` fetches the pending close's public fields,
+ * recomputes its commitment hash, and asks the Watchtower — a `null`
+ * answer means either this channel is fine or this node was never asked to
+ * back it, and both are the same "do nothing" outcome.
+ *
+ * Mirrors BatchSettler's shape: a pure per-event handler that is fully unit
+ * testable against injected `viewContract`/`invokeContract`/`watchtower`,
+ * wrapped by a thin start/stop polling daemon for production.
+ */
+
+const { Address, nativeToScVal, scValToNative } = require("@stellar/stellar-sdk");
+const { rpcServer, CONTRACT_IDS } = require("../config/stellar");
+const { viewContract, invokeContract } = require("../services/stellarService");
+const { logger } = require("../utils/logger");
+
+let intervalId = null;
+let lastLedger = 0;
+
+/**
+ * Decode a channels-contract event's topic tag the same way
+ * listeners/eventListener.js does for the marketplace/registry contracts.
+ */
+function decodeEventValue(scVal) {
+  try {
+    return scValToNative(scVal);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch a channel's currently pending close (public on-chain fields) and,
+ * if this node's Watchtower holds a justice package for exactly that state,
+ * submit `punish` on the honest party's behalf.
+ *
+ * @param {object} deps - injected for testability; production callers omit
+ *   this and get the real stellarService-backed versions.
+ * @param {Function} [deps.viewContract]
+ * @param {Function} [deps.invokeContract]
+ * @param {import('../channels/Watchtower')} deps.watchtower
+ * @param {import('@stellar/stellar-sdk').Keypair} deps.signerKeypair - this
+ *   node's own key, used only to *submit* the transaction; `punish`'s payout
+ *   goes to `justice.challenger`, never to this key
+ * @param {number|string} channelId
+ * @returns {Promise<{action: 'skipped'|'punished', reason?: string, payout?: *}>}
+ */
+async function processUnilateralClose(deps, channelId) {
+  const { watchtower, signerKeypair } = deps;
+  const view = deps.viewContract || viewContract;
+  const invoke = deps.invokeContract || invokeContract;
+  const contractId = deps.contractId || CONTRACT_IDS.channels;
+
+  if (!contractId) {
+    return { action: "skipped", reason: "channels contract not configured" };
+  }
+
+  const pending = await view(
+    contractId,
+    "get_pending_close",
+    [nativeToScVal(BigInt(channelId), { type: "u64" })],
+    signerKeypair.publicKey()
+  );
+  if (!pending) {
+    return { action: "skipped", reason: "channel is not currently closing" };
+  }
+
+  const state = {
+    channel_id: Number(channelId),
+    version: Number(pending.version),
+    balance_a: Number(pending.balance_a),
+    balance_b: Number(pending.balance_b),
+    revocation_commit_a: Buffer.from(pending.revocation_commit_a).toString("hex"),
+    revocation_commit_b: Buffer.from(pending.revocation_commit_b).toString("hex"),
+  };
+
+  const justice = watchtower.findJustice(state);
+  if (!justice) {
+    return { action: "skipped", reason: "no justice package for this state" };
+  }
+
+  logger.warn(
+    `[ChannelMonitor] revoked close detected on channel ${channelId} (version ${state.version}); submitting punish`
+  );
+
+  const payout = await invoke(
+    contractId,
+    "punish",
+    [
+      Address.fromString(justice.challenger).toScVal(),
+      nativeToScVal(BigInt(channelId), { type: "u64" }),
+      nativeToScVal(Buffer.from(justice.revocationSecret, "hex"), { type: "bytes" }),
+    ],
+    signerKeypair
+  );
+
+  logger.info(`[ChannelMonitor] punished channel ${channelId}; payout=${payout}`);
+  return { action: "punished", payout };
+}
+
+/**
+ * Poll for UNILATERAL_CLOSE events since the last processed ledger and
+ * dispatch each to processUnilateralClose.
+ */
+async function poll(deps) {
+  const contractId = deps.contractId || CONTRACT_IDS.channels;
+  if (!contractId) return;
+
+  try {
+    const response = await rpcServer.getEvents({
+      startLedger: lastLedger,
+      filters: [{ type: "contract", contractIds: [contractId] }],
+      limit: 100,
+    });
+
+    for (const event of response.events) {
+      const [topicTag] = Array.isArray(event.topic) ? event.topic.map(decodeEventValue) : [];
+      if (topicTag === "UNILATERAL_CLOSE") {
+        const decoded = decodeEventValue(event.value);
+        const channelId = Array.isArray(decoded) ? decoded[0] : decoded?.channel_id;
+        if (channelId !== undefined && channelId !== null) {
+          await processUnilateralClose(deps, channelId).catch((err) =>
+            logger.error(`[ChannelMonitor] error handling channel ${channelId}:`, err.message)
+          );
+        }
+      }
+      if (event.ledger > lastLedger) lastLedger = event.ledger;
+    }
+  } catch (err) {
+    logger.warn("[ChannelMonitor] poll error:", err.message);
+  }
+}
+
+function start(deps, intervalMs = 15_000) {
+  if (intervalId) return;
+  intervalId = setInterval(() => poll(deps), intervalMs);
+}
+
+function stop() {
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+}
+
+module.exports = {
+  processUnilateralClose,
+  poll,
+  start,
+  stop,
+};

--- a/backend/src/repositories/channelRepository.js
+++ b/backend/src/repositories/channelRepository.js
@@ -1,0 +1,121 @@
+/**
+ * Channel repository — all SQL touching the `channels` table lives here.
+ *
+ * `findOpenChannel` is the hook metering routing decisions go through:
+ * "route through a channel when one exists for (buyer, seller), falling
+ * back to the existing stream path when it does not" is exactly a call to
+ * this function before falling back to the stream lookup already used by
+ * MeteringEngine.
+ */
+
+const { run, toMs } = require("./repoUtils");
+
+const COLUMNS = `
+  id, party_a, party_b, token, deposit_a, deposit_b, status,
+  closer, dispute_deadline, indexed_at, updated_at
+`;
+
+function mapChannel(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    partyA: row.party_a,
+    partyB: row.party_b,
+    token: row.token,
+    depositA: row.deposit_a,
+    depositB: row.deposit_b,
+    status: row.status,
+    closer: row.closer,
+    disputeDeadline: row.dispute_deadline,
+    indexedAt: toMs(row.indexed_at),
+    updatedAt: toMs(row.updated_at),
+  };
+}
+
+/**
+ * Upsert a channel by its on-chain id — the indexer's entry point whenever
+ * it observes `OPENED`, `UNILATERAL_CLOSE`, `DISPUTED`, `COOP_CLS`,
+ * `PUNISHED`, or `FRC_CLS` on the channels contract.
+ */
+async function upsert(channel, client) {
+  const {
+    id,
+    partyA,
+    partyB,
+    token,
+    depositA,
+    depositB,
+    status = "Open",
+    closer = null,
+    disputeDeadline = null,
+  } = channel;
+
+  const { rows } = await run(
+    `INSERT INTO channels
+       (id, party_a, party_b, token, deposit_a, deposit_b, status, closer, dispute_deadline)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+     ON CONFLICT (id) DO UPDATE SET
+       status           = EXCLUDED.status,
+       closer           = EXCLUDED.closer,
+       dispute_deadline = EXCLUDED.dispute_deadline,
+       updated_at       = now()
+     RETURNING ${COLUMNS}`,
+    [id, partyA, partyB, token, depositA, depositB, status, closer, disputeDeadline],
+    client
+  );
+  return mapChannel(rows[0]);
+}
+
+/**
+ * The channel a buyer would use to pay a seller right now, if any — an
+ * open channel between the two addresses for this token. Direction-agnostic:
+ * `party_a`/`party_b` on-chain doesn't imply buyer/seller, so this checks
+ * both orderings.
+ */
+async function findOpenChannel(buyer, seller, token, client) {
+  const { rows } = await run(
+    `SELECT ${COLUMNS} FROM channels
+     WHERE status = 'Open'
+       AND token = $3
+       AND ((party_a = $1 AND party_b = $2) OR (party_a = $2 AND party_b = $1))
+     ORDER BY id DESC
+     LIMIT 1`,
+    [buyer, seller, token],
+    client,
+    "read"
+  );
+  return mapChannel(rows[0]);
+}
+
+async function findById(id, client) {
+  const { rows } = await run(
+    `SELECT ${COLUMNS} FROM channels WHERE id = $1`,
+    [id],
+    client,
+    "read"
+  );
+  return mapChannel(rows[0]);
+}
+
+async function updateStatus(id, status, { closer = undefined, disputeDeadline = undefined } = {}, client) {
+  const { rows } = await run(
+    `UPDATE channels SET
+       status           = $2,
+       closer           = COALESCE($3, closer),
+       dispute_deadline = COALESCE($4, dispute_deadline),
+       updated_at       = now()
+     WHERE id = $1
+     RETURNING ${COLUMNS}`,
+    [id, status, closer ?? null, disputeDeadline ?? null],
+    client
+  );
+  return mapChannel(rows[0]);
+}
+
+module.exports = {
+  upsert,
+  findOpenChannel,
+  findById,
+  updateStatus,
+  _mapChannel: mapChannel,
+};

--- a/backend/src/sdk/CortexAgentSDK.js
+++ b/backend/src/sdk/CortexAgentSDK.js
@@ -3,6 +3,7 @@ const {
   TransactionBuilder,
   BASE_FEE,
   Address,
+  StrKey,
   nativeToScVal,
   rpc,
   scValToNative,
@@ -13,6 +14,8 @@ const AttestationBuilder = require("../attestation/AttestationBuilder");
 const AttestationVerifier = require("../attestation/AttestationVerifier");
 const MerkleBatchBuilder = require("../attestation/MerkleBatchBuilder");
 const { toFixedBuffer } = require("../attestation/canonical");
+const ChannelNegotiator = require("../channels/ChannelNegotiator");
+const RevocationStore = require("../channels/RevocationStore");
 
 class CortexAgentSDK {
   /**
@@ -41,6 +44,7 @@ class CortexAgentSDK {
     this.horizonUrl = config.horizonUrl || "https://horizon-testnet.stellar.org";
     this.networkPassphrase = config.networkPassphrase || "Test SDF Network ; September 2015";
     this.micropaymentsContractId = config.micropaymentsContractId;
+    this.channelsContractId = config.channelsContractId;
     this.tokenAddress = config.tokenAddress || "CDLZFC3SYJYDZT7K6AOFHG23NFR7EDLI226OJZ5U3XEE2FEUA7HJTZUA";
 
     this.rpcServer = new SorobanRpc.Server(this.rpcUrl);
@@ -51,6 +55,16 @@ class CortexAgentSDK {
       : null;
 
     this._attestationVerifier = new AttestationVerifier();
+
+    // channelId -> ChannelNegotiator. One RevocationStore is shared across
+    // every channel this agent is party to — RevocationStore already keys
+    // everything by channelId internally, so there is no cross-channel
+    // leakage in sharing it.
+    this._channelNegotiators = new Map();
+    this._channelRevocationStore = new RevocationStore();
+    // counterparty G-address -> channelId, so payForCallViaChannel can find
+    // an existing channel without the caller having to track ids itself.
+    this._channelByCounterparty = new Map();
   }
 
   /**
@@ -444,6 +458,305 @@ class CortexAgentSDK {
         },
       }
     );
+  }
+
+  // ── Payment Channels ───────────────────────────────────────────────────
+
+  _requireChannelsContract() {
+    if (!this.channelsContractId) {
+      throw new Error("channelsContractId is not configured on SDK client");
+    }
+    return this.channelsContractId;
+  }
+
+  /** Sign with each keypair in order, submit, and poll for the result. */
+  async _submitTx(tx, signers) {
+    const prepared = await this.rpcServer.prepareTransaction(tx);
+    for (const kp of signers) prepared.sign(kp);
+
+    const submit = await this.rpcServer.sendTransaction(prepared);
+    if (submit.status === "ERROR") {
+      throw new Error(`Tx send failed: ${JSON.stringify(submit.errorResult)}`);
+    }
+
+    let status = await this.rpcServer.getTransaction(submit.hash);
+    let retries = 0;
+    while (status.status === "NOT_FOUND" && retries < 10) {
+      await new Promise((r) => setTimeout(r, 2000));
+      status = await this.rpcServer.getTransaction(submit.hash);
+      retries++;
+    }
+    if (status.status !== "SUCCESS") {
+      throw new Error(`Transaction failed with status: ${status.status}`);
+    }
+    return status.returnValue ? scValToNative(status.returnValue) : null;
+  }
+
+  _channelStateToScVal(state) {
+    return nativeToScVal(
+      {
+        channel_id: BigInt(state.channel_id),
+        version: BigInt(state.version),
+        balance_a: BigInt(state.balance_a),
+        balance_b: BigInt(state.balance_b),
+        revocation_commit_a: toFixedBuffer(state.revocation_commit_a, 32, "revocation_commit_a"),
+        revocation_commit_b: toFixedBuffer(state.revocation_commit_b, 32, "revocation_commit_b"),
+        sig_a: toFixedBuffer(state.sig_a, 64, "sig_a"),
+        sig_b: toFixedBuffer(state.sig_b, 64, "sig_b"),
+      },
+      {
+        type: {
+          channel_id: ["symbol", "u64"],
+          version: ["symbol", "u64"],
+          balance_a: ["symbol", "u64"],
+          balance_b: ["symbol", "u64"],
+          revocation_commit_a: ["symbol", "bytes"],
+          revocation_commit_b: ["symbol", "bytes"],
+          sig_a: ["symbol", "bytes"],
+          sig_b: ["symbol", "bytes"],
+        },
+      }
+    );
+  }
+
+  /**
+   * Register this agent's Ed25519 key for off-chain channel-state signing.
+   * Reuses the Stellar account keypair already held — Stellar keys are
+   * Ed25519 already, so there is nothing separate to generate or manage.
+   * Must be called once before this agent can be a party to any channel.
+   */
+  async registerChannelKey() {
+    const contractId = this._requireChannelsContract();
+    const pubkey = this.buyerKeypair.publicKey();
+    const account = await this.rpcServer.getAccount(pubkey);
+
+    const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: this.networkPassphrase })
+      .addOperation(
+        new Contract(contractId).call(
+          "register_channel_key",
+          Address.fromString(pubkey).toScVal(),
+          nativeToScVal(StrKey.decodeEd25519PublicKey(pubkey), { type: "bytes" })
+        )
+      )
+      .setTimeout(30)
+      .build();
+
+    return this._submitTx(tx, [this.buyerKeypair]);
+  }
+
+  /**
+   * Open a channel with `counterpartyPubkey`. Both parties fund the
+   * channel in the same transaction (see the contract's `open_channel`),
+   * so both must authorize it. Pass `counterpartyKeypair` when this
+   * process controls both sides (tests, demos, one operator running both
+   * agents); otherwise this returns an unsigned-by-them XDR for the
+   * counterparty to co-sign and submit out-of-band.
+   *
+   * @param {string} counterpartyPubkey
+   * @param {number} myDepositXlm
+   * @param {number} counterpartyDepositXlm
+   * @param {object} [opts]
+   * @param {Keypair} [opts.counterpartyKeypair]
+   */
+  async openChannel(counterpartyPubkey, myDepositXlm, counterpartyDepositXlm, { counterpartyKeypair } = {}) {
+    const contractId = this._requireChannelsContract();
+    const myPubkey = this.buyerKeypair.publicKey();
+    const account = await this.rpcServer.getAccount(myPubkey);
+
+    const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: this.networkPassphrase })
+      .addOperation(
+        new Contract(contractId).call(
+          "open_channel",
+          Address.fromString(myPubkey).toScVal(),
+          Address.fromString(counterpartyPubkey).toScVal(),
+          Address.fromString(this.tokenAddress).toScVal(),
+          nativeToScVal(BigInt(Math.floor(myDepositXlm * 10_000_000)), { type: "i128" }),
+          nativeToScVal(BigInt(Math.floor(counterpartyDepositXlm * 10_000_000)), { type: "i128" })
+        )
+      )
+      .setTimeout(30)
+      .build();
+
+    if (!counterpartyKeypair) {
+      const prepared = await this.rpcServer.prepareTransaction(tx);
+      prepared.sign(this.buyerKeypair);
+      return { xdr: prepared.toXDR(), needsCounterpartySignature: true };
+    }
+
+    const channelId = Number(await this._submitTx(tx, [this.buyerKeypair, counterpartyKeypair]));
+    this.joinChannel(channelId, { party: "a", counterpartyPublicKey: counterpartyPubkey });
+    return { channelId };
+  }
+
+  /**
+   * Register a locally-tracked negotiator for a channel this agent is
+   * party to. The opener gets this for free from `openChannel`; the
+   * counterparty calls it explicitly on learning the new channel_id (from
+   * the OPENED event, or told directly by the opener).
+   */
+  joinChannel(channelId, { party, counterpartyPublicKey, initialState = null }) {
+    const negotiator = new ChannelNegotiator({
+      channelId,
+      party,
+      keypair: this.buyerKeypair,
+      counterpartyPublicKey,
+      revocationStore: this._channelRevocationStore,
+      initialState,
+    });
+    this._channelNegotiators.set(String(channelId), negotiator);
+    this._channelByCounterparty.set(counterpartyPublicKey, channelId);
+    return negotiator;
+  }
+
+  /**
+   * Route one call's payment through an existing open channel with
+   * `counterpartyPubkey` when this agent has joined one, instead of the
+   * ordinary stream-metered path. This is the client-side half of "route
+   * metering through a channel when one exists, falling back to the
+   * stream path when it does not": the decision has to be made here,
+   * locally, because a channel payment is a peer-to-peer balance update
+   * (payInChannel), not something the backend brokers the way stream
+   * metering is.
+   *
+   * @param {string} counterpartyPubkey
+   * @param {number} pricePerCall
+   * @returns {{viaChannel: false}|{viaChannel: true, channelId, proposal}}
+   *   `viaChannel: false` means no usable channel was found (never joined
+   *   one, or this agent's balance can't cover pricePerCall) — the caller
+   *   should fall back to openStream()/call() as usual. Otherwise
+   *   `proposal` is the message this agent must still send the
+   *   counterparty (who runs it through receiveChannelProposal) to
+   *   actually move the balance.
+   */
+  payForCallViaChannel(counterpartyPubkey, pricePerCall) {
+    const channelId = this._channelByCounterparty.get(counterpartyPubkey);
+    if (channelId === undefined) return { viaChannel: false };
+
+    const negotiator = this._negotiatorFor(channelId);
+    const state = negotiator.currentState;
+    if (!state) return { viaChannel: false };
+
+    const mine = negotiator.party === "a" ? Number(state.balance_a) : Number(state.balance_b);
+    const theirs = negotiator.party === "a" ? Number(state.balance_b) : Number(state.balance_a);
+    if (mine < pricePerCall) return { viaChannel: false };
+
+    const nextMine = mine - pricePerCall;
+    const nextTheirs = theirs + pricePerCall;
+    const [balanceA, balanceB] =
+      negotiator.party === "a" ? [nextMine, nextTheirs] : [nextTheirs, nextMine];
+
+    return { viaChannel: true, channelId, proposal: this.payInChannel(channelId, balanceA, balanceB) };
+  }
+
+  _negotiatorFor(channelId) {
+    const negotiator = this._channelNegotiators.get(String(channelId));
+    if (!negotiator) {
+      throw new Error(`no local channel negotiator for channel ${channelId}; call joinChannel first`);
+    }
+    return negotiator;
+  }
+
+  /**
+   * Propose the channel's next off-chain balances — the whole point of a
+   * channel: this touches no ledger. Returns the Proposal message to send
+   * to the counterparty over whatever transport they share.
+   */
+  payInChannel(channelId, balanceA, balanceB) {
+    const negotiator = this._negotiatorFor(channelId);
+    const nextVersion = negotiator.currentState ? Number(negotiator.currentState.version) + 1 : 1;
+    return negotiator.propose({ version: nextVersion, balanceA, balanceB });
+  }
+
+  /** Counterparty side: respond to a received Proposal with a CounterSignature. */
+  receiveChannelProposal(channelId, proposal) {
+    return this._negotiatorFor(channelId).counterSign(proposal);
+  }
+
+  /** Proposer side: accept a CounterSignature, producing an Ack. */
+  receiveChannelCounterSignature(channelId, counterSignature) {
+    return this._negotiatorFor(channelId).ack(counterSignature);
+  }
+
+  /** Counterparty side: accept an Ack, producing a Completion. */
+  receiveChannelAck(channelId, ack) {
+    return this._negotiatorFor(channelId).complete(ack);
+  }
+
+  /** Proposer side: accept a Completion, finishing the round. */
+  receiveChannelCompletion(channelId, completion) {
+    this._negotiatorFor(channelId).finalize(completion);
+  }
+
+  /** This agent's current fully-signed off-chain state for a channel, if any. */
+  getChannelState(channelId) {
+    return this._negotiatorFor(channelId).currentState;
+  }
+
+  /**
+   * Close a channel. Cooperative (the default) settles instantly at the
+   * current agreed state and needs no counterparty signature on this
+   * call — the state's own dual signature already carries their consent.
+   * Unilateral instead starts the dispute window, for when the
+   * counterparty cannot be reached to cooperatively close.
+   */
+  async closeChannel(channelId, { cooperative = true } = {}) {
+    const contractId = this._requireChannelsContract();
+    const state = this._negotiatorFor(channelId).currentState;
+    if (!state) {
+      throw new Error(`channel ${channelId} has no locally agreed state to close with`);
+    }
+
+    const myPubkey = this.buyerKeypair.publicKey();
+    const account = await this.rpcServer.getAccount(myPubkey);
+    const method = cooperative ? "close_cooperative" : "close_unilateral";
+    const args = cooperative
+      ? [nativeToScVal(BigInt(channelId), { type: "u64" }), this._channelStateToScVal(state)]
+      : [
+          Address.fromString(myPubkey).toScVal(),
+          nativeToScVal(BigInt(channelId), { type: "u64" }),
+          this._channelStateToScVal(state),
+        ];
+
+    const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: this.networkPassphrase })
+      .addOperation(new Contract(contractId).call(method, ...args))
+      .setTimeout(30)
+      .build();
+
+    return this._submitTx(tx, [this.buyerKeypair]);
+  }
+
+  /**
+   * Register this channel's most recently superseded state with a remote
+   * watchtower service (POSTs to `${endpoint}/register`), so it can submit
+   * `punish` on this agent's behalf if the counterparty ever republishes
+   * that state. Call this right after a payInChannel round completes
+   * (once this agent has revealed a secret) and before going offline —
+   * pass the `revokedState`/`revealedParty`/`revealedSecret` fields from
+   * whichever of `receiveChannelAck`/`receiveChannelCompletion` just ran.
+   */
+  async registerWatchtower(channelId, endpoint, { revokedState, revealedParty, revealedSecret } = {}) {
+    if (!revokedState || !revealedSecret) {
+      throw new Error(
+        "registerWatchtower needs the state that was just superseded plus the secret revealed " +
+          "for it — pass revokedState/revealedParty/revealedSecret from the round that just completed"
+      );
+    }
+
+    const res = await fetch(`${endpoint.replace(/\/$/, "")}/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        channelId,
+        state: revokedState,
+        party: revealedParty,
+        revocationSecret: revealedSecret,
+        challenger: this.buyerKeypair.publicKey(),
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(`watchtower registration failed: HTTP ${res.status}`);
+    }
+    return res.json();
   }
 
   async closeStream(streamId) {

--- a/contract/Cargo.lock
+++ b/contract/Cargo.lock
@@ -247,6 +247,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "channels"
+version = "0.1.0"
+dependencies = [
+ "ed25519-dalek",
+ "soroban-sdk",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/contract/Cargo.toml
+++ b/contract/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "contracts/agent_registry",
   "contracts/audit_anchor",
   "contracts/sig_check",
+  "contracts/channels",
 ]
 
 [workspace.dependencies]

--- a/contract/README.md
+++ b/contract/README.md
@@ -36,13 +36,14 @@
 
 ## Overview
 
-Cortex Protocol deploys three Soroban smart contracts to Stellar testnet:
+Cortex Protocol deploys these Soroban smart contracts to Stellar testnet:
 
 | Contract | Purpose |
 |----------|---------|
 | **Marketplace** | Lists, purchases, and manages intelligence assets |
 | **Micropayments** | Streaming payments (per-second / per-call billing) |
 | **Agent Registry** | On-chain identity and reputation for autonomous agents |
+| **Channels** | Bidirectional payment channels: unbounded off-chain updates, on-chain only to open/close/dispute |
 
 The deployment pipeline proceeds in four stages:
 
@@ -60,7 +61,8 @@ cortex-protocols/
 │   ├── contracts/
 │   │   ├── marketplace/       # Soroban marketplace contract (Rust)
 │   │   ├── micropayments/     # Payment streaming contract (Rust)
-│   │   └── agent_registry/    # Agent identity contract (Rust)
+│   │   ├── agent_registry/    # Agent identity contract (Rust)
+│   │   └── channels/          # Bidirectional payment channels (Rust)
 │   ├── scripts/
 │   │   ├── deploy.sh          # Deploy + re-deploy detection
 │   │   ├── init.sh            # Post-deploy initialisation
@@ -465,6 +467,45 @@ Marketplace events use the action and actor as topics. Version publication emits
 | `get_reputation(agent_id)` | Current reputation (0–10000 bp) | none |
 
 **Capabilities:** TextGeneration, CodeGeneration, Reasoning, VisionUnderstanding, AudioProcessing, DataAnalysis, WebResearch, ActionExecution
+
+---
+
+### Channels Contract
+
+Bidirectional payment channels: two parties exchange signed balance updates
+entirely off-chain (see `backend/src/channels/`), touching this contract only
+to open, to close cooperatively, or to adjudicate a dispute.
+
+| Function | Description | Auth |
+|----------|-------------|------|
+| `register_channel_key(party, public_key)` | Bind the Ed25519 key `party` signs off-chain states with | party |
+| `open_channel(a, b, token, deposit_a, deposit_b)` | Escrow both deposits → returns channel_id | a and b |
+| `close_cooperative(channel_id, state)` | Instant settlement from a dual-signed state, no window | none — the state's own signatures are the authorization |
+| `close_unilateral(closer, channel_id, state)` | Start the dispute window on a dual-signed state | closer |
+| `dispute(challenger, channel_id, later_state)` | Supersede the pending close with a strictly higher, validly signed version; does not extend the window | none |
+| `punish(challenger, channel_id, revocation_secret)` | Prove the pending state was revoked; pays the entire channel balance to `challenger` | none — the revealed secret is the proof |
+| `force_close(channel_id)` | Settle the pending state once the dispute window has elapsed | none |
+| `get_channel(channel_id)` | Read a channel's deposits and status | none |
+| `get_pending_close(channel_id)` | Read the state a unilateral close is currently resting on | none |
+| `state_commitment_hash(state)` | The hash a Watchtower blob for `state` is keyed on | none |
+
+**`ChannelState`:** `{ channel_id, version, balance_a, balance_b, revocation_commit_a, revocation_commit_b, sig_a, sig_b }` — see
+`contract/contracts/channels/src/state.rs` for the exact byte-for-byte wire
+format shared with `backend/src/channels/canonical.js`. The two
+`revocation_commit_*` fields are each party's RevocationStore commitment
+hash for that version, signed alongside the balances — this is what lets
+`punish` prove a bare revealed secret revokes an exact version without
+needing the state that superseded it.
+
+**Why `dispute` and `punish` are separate:** `dispute` needs the challenger to
+actually hold a later signed state, and corrects the outcome to what was
+honestly agreed — nothing more. `punish` needs only a revealed revocation
+secret and pays the *entire* channel balance as a deterrent; this is the
+path a Watchtower uses to act for an offline party without ever learning
+that party's balances.
+
+**Dispute window:** `DISPUTE_WINDOW_SECS` = 86,400 (24h), matching
+`CHALLENGE_WINDOW_SECS` in the micropayments contract.
 
 ---
 

--- a/contract/contracts/channels/Cargo.toml
+++ b/contract/contracts/channels/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "channels"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+soroban-sdk = { workspace = true, features = ["alloc"] }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+# Tests need to *produce* Ed25519 signatures (and deliberately bad ones); the
+# contract itself only verifies, so this stays out of the wasm build.
+ed25519-dalek = { workspace = true }

--- a/contract/contracts/channels/src/errors.rs
+++ b/contract/contracts/channels/src/errors.rs
@@ -1,0 +1,56 @@
+use soroban_sdk::contracterror;
+
+/// Errors returned by the Channels contract.
+///
+/// Error codes are stable and should not be changed once the contract
+/// is deployed, as clients may rely on their numeric values.
+#[contracterror]
+#[derive(Clone, Debug, Copy, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ChannelsError {
+    /// Caller has not registered an Ed25519 key for off-chain state signing.
+    ChannelKeyNotRegistered = 1,
+
+    /// Deposits must be positive.
+    InvalidDeposit = 2,
+
+    /// The two channel parties must be different addresses.
+    SelfChannel = 3,
+
+    /// Channel does not exist.
+    ChannelNotFound = 4,
+
+    /// Caller is not a party to this channel.
+    NotAParty = 5,
+
+    /// Channel is not in the `Open` state.
+    ChannelNotOpen = 6,
+
+    /// Channel is not in the `Closing` state.
+    ChannelNotClosing = 7,
+
+    /// The state's `channel_id` does not match the channel being acted on.
+    ChannelIdMismatch = 8,
+
+    /// The submitted state does not carry both valid signatures.
+    InvalidStateSignature = 9,
+
+    /// Balances in the submitted state do not sum to the channel's total
+    /// deposit — funds would be created or destroyed.
+    BalanceConservationViolated = 10,
+
+    /// A dispute's state version must be strictly greater than the version
+    /// currently pending on-chain.
+    VersionNotHigher = 11,
+
+    /// The dispute window has not yet elapsed.
+    DisputeWindowOpen = 12,
+
+    /// The revealed secret does not open either party's revocation
+    /// commitment for the pending state.
+    InvalidRevocationSecret = 13,
+
+    /// `punish`'s caller must be the channel party who did not initiate the
+    /// disputed unilateral close.
+    NotTheHonestParty = 14,
+}

--- a/contract/contracts/channels/src/lib.rs
+++ b/contract/contracts/channels/src/lib.rs
@@ -1,0 +1,549 @@
+#![no_std]
+
+//! Bidirectional payment channels for Intelligence Rail.
+//!
+//! Two parties exchange signed balance updates entirely off-chain (see
+//! `backend/src/channels/ChannelState.js` / `ChannelNegotiator.js`); this
+//! contract is touched only to open, to close cooperatively, or to
+//! adjudicate a dispute. The hard part is not the happy path — it is
+//! guaranteeing that a party who goes offline cannot be robbed by a
+//! counterparty publishing a stale, more favourable state.
+//!
+//! ## The dispute lifecycle
+//!
+//! ```text
+//! Open --close_unilateral--> Closing --(dispute window elapses)--> Closed
+//!                                |
+//!                                | dispute (higher version supersedes)
+//!                                v
+//!                             Closing (same window, corrected state)
+//!                                |
+//!                                | punish (revoked state proven)
+//!                                v
+//!                             Closed (challenger takes everything)
+//! ```
+//!
+//! `close_cooperative` can short-circuit straight to `Closed` from either
+//! `Open` or `Closing` — both parties agreeing always trumps a pending
+//! dispute, since fresh dual signatures are strictly stronger evidence of
+//! intent than anything already on-chain.
+//!
+//! ## Why `dispute` and `punish` are different entrypoints
+//!
+//! `dispute` requires the challenger to actually hold the later signed
+//! state — it corrects the outcome to what was honestly agreed, nothing
+//! more. `punish` requires only a revealed revocation secret — proof that
+//! *some* later state existed, without needing its contents — and pays the
+//! challenger the entire channel balance as a deterrent. This second, harsher
+//! path is what lets a Watchtower (`backend/src/channels/Watchtower.js`) act
+//! for an offline party while never learning that party's balances: it holds
+//! an encrypted justice transaction keyed by `commitment_hash`, and a secret,
+//! and nothing else. See `state.rs` for exactly what is signed and hashed.
+
+use soroban_sdk::{
+    contract, contractimpl, contracttype, symbol_short, token, Address, Bytes, BytesN, Env, Symbol,
+};
+
+mod errors;
+mod state;
+
+pub use errors::ChannelsError;
+pub use state::ChannelState;
+use state::{commitment_hash as state_commitment_hash, verify_dual_signature};
+
+/// How long a unilateral close can be disputed before it finalizes, in
+/// seconds. Mirrors `CHALLENGE_WINDOW_SECS`'s reasoning in micropayments:
+/// long enough for an offline party (or their watchtower) to notice and
+/// react, short enough that a stale close is not a viable griefing vector.
+pub const DISPUTE_WINDOW_SECS: u64 = 86_400;
+
+const NEXT_ID: Symbol = symbol_short!("CH_NEXT");
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ChannelStatus {
+    Open,
+    Closing,
+    Closed,
+}
+
+/// A channel's durable, rarely-changing record: who, what token, how much
+/// was deposited, and its current lifecycle status. The high-frequency
+/// off-chain balance updates never touch this — see `PendingClose` for the
+/// only balance state the chain ever needs to hold, and only while disputed.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Channel {
+    pub id: u64,
+    pub party_a: Address,
+    pub party_b: Address,
+    pub token: Address,
+    pub deposit_a: i128,
+    pub deposit_b: i128,
+    pub status: ChannelStatus,
+}
+
+/// The state a unilateral close is currently resting on, live only while
+/// `status == Closing`. Replaced wholesale by `dispute`, consumed by
+/// `force_close` or `punish`.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct PendingClose {
+    pub closer: Address,
+    pub dispute_deadline: u64,
+    pub version: u64,
+    pub balance_a: u64,
+    pub balance_b: u64,
+    pub revocation_commit_a: BytesN<32>,
+    pub revocation_commit_b: BytesN<32>,
+}
+
+#[contracttype]
+pub enum ChannelKey {
+    Channel(u64),
+    PendingClose(u64),
+    /// Address -> the Ed25519 key its off-chain channel states are signed
+    /// with. Registered once per address, reused across every channel that
+    /// address opens — mirrors `AttKey::SellerKey` in micropayments.
+    ChannelPubKey(Address),
+}
+
+// ── Storage helpers ──────────────────────────────────────────────────────────
+
+fn load_channel(env: &Env, channel_id: u64) -> Result<Channel, ChannelsError> {
+    env.storage()
+        .persistent()
+        .get(&ChannelKey::Channel(channel_id))
+        .ok_or(ChannelsError::ChannelNotFound)
+}
+
+fn save_channel(env: &Env, channel: &Channel) {
+    env.storage()
+        .persistent()
+        .set(&ChannelKey::Channel(channel.id), channel);
+}
+
+fn load_pending(env: &Env, channel_id: u64) -> PendingClose {
+    env.storage()
+        .persistent()
+        .get(&ChannelKey::PendingClose(channel_id))
+        .expect("channel is Closing but has no pending close on record")
+}
+
+fn save_pending(env: &Env, channel_id: u64, pending: &PendingClose) {
+    env.storage()
+        .persistent()
+        .set(&ChannelKey::PendingClose(channel_id), pending);
+}
+
+fn registered_key(env: &Env, party: &Address) -> BytesN<32> {
+    env.storage()
+        .persistent()
+        .get(&ChannelKey::ChannelPubKey(party.clone()))
+        .expect("channel party has no registered key; open_channel should have required this")
+}
+
+fn require_party(channel: &Channel, who: &Address) -> Result<(), ChannelsError> {
+    if who == &channel.party_a || who == &channel.party_b {
+        Ok(())
+    } else {
+        Err(ChannelsError::NotAParty)
+    }
+}
+
+/// Balances in a state must sum to exactly what the channel holds — nothing
+/// created, nothing destroyed. Checked on every state the chain accepts
+/// (unilateral close, dispute, cooperative close), not just at the end,
+/// since a bad split off-chain should be rejected outright rather than
+/// allowed to open a dispute window over impossible funds math.
+fn require_conserved(
+    channel: &Channel,
+    balance_a: u64,
+    balance_b: u64,
+) -> Result<(), ChannelsError> {
+    let total = channel.deposit_a + channel.deposit_b;
+    if (balance_a as i128) + (balance_b as i128) == total {
+        Ok(())
+    } else {
+        Err(ChannelsError::BalanceConservationViolated)
+    }
+}
+
+fn pay(env: &Env, token: &Address, to: &Address, amount: i128) {
+    if amount > 0 {
+        token::Client::new(env, token).transfer(&env.current_contract_address(), to, &amount);
+    }
+}
+
+#[contract]
+pub struct ChannelsContract;
+
+#[contractimpl]
+impl ChannelsContract {
+    // ── Configuration ────────────────────────────────────────────────────
+
+    /// Register the Ed25519 key this address signs off-chain channel states
+    /// with. `require_auth` means only the address itself can bind a key to
+    /// itself — the same reasoning as micropayments'
+    /// `register_attestation_key`. Must be called before that address can be
+    /// a party to `open_channel`.
+    pub fn register_channel_key(env: Env, party: Address, public_key: BytesN<32>) {
+        party.require_auth();
+        env.storage()
+            .persistent()
+            .set(&ChannelKey::ChannelPubKey(party.clone()), &public_key);
+
+        env.events().publish(
+            (Symbol::new(&env, "CHANNEL_KEY_REGISTERED"), party),
+            public_key,
+        );
+    }
+
+    pub fn get_channel_key(env: Env, party: Address) -> Option<BytesN<32>> {
+        env.storage()
+            .persistent()
+            .get(&ChannelKey::ChannelPubKey(party))
+    }
+
+    // ── Lifecycle ────────────────────────────────────────────────────────
+
+    /// Open a channel, pulling each party's deposit into escrow.
+    ///
+    /// Both parties must authorize the same call — atomic bilateral
+    /// funding, no window where only one side's money is locked. Both must
+    /// also already have a registered channel key, since every subsequent
+    /// state update is only meaningful once the chain knows how to verify
+    /// their signatures.
+    pub fn open_channel(
+        env: Env,
+        a: Address,
+        b: Address,
+        token: Address,
+        deposit_a: i128,
+        deposit_b: i128,
+    ) -> Result<u64, ChannelsError> {
+        // Checked before either require_auth call: requiring the same
+        // address's authorization twice in one invocation traps at the host
+        // level rather than composing, so a==b has to be rejected first.
+        if a == b {
+            return Err(ChannelsError::SelfChannel);
+        }
+        a.require_auth();
+        b.require_auth();
+
+        if deposit_a < 0 || deposit_b < 0 || deposit_a + deposit_b <= 0 {
+            return Err(ChannelsError::InvalidDeposit);
+        }
+        if env
+            .storage()
+            .persistent()
+            .get::<_, BytesN<32>>(&ChannelKey::ChannelPubKey(a.clone()))
+            .is_none()
+            || env
+                .storage()
+                .persistent()
+                .get::<_, BytesN<32>>(&ChannelKey::ChannelPubKey(b.clone()))
+                .is_none()
+        {
+            return Err(ChannelsError::ChannelKeyNotRegistered);
+        }
+
+        let token_client = token::Client::new(&env, &token);
+        if deposit_a > 0 {
+            token_client.transfer(&a, &env.current_contract_address(), &deposit_a);
+        }
+        if deposit_b > 0 {
+            token_client.transfer(&b, &env.current_contract_address(), &deposit_b);
+        }
+
+        let channel_id = env.storage().instance().get(&NEXT_ID).unwrap_or(0u64) + 1;
+        env.storage().instance().set(&NEXT_ID, &channel_id);
+
+        let channel = Channel {
+            id: channel_id,
+            party_a: a.clone(),
+            party_b: b.clone(),
+            token,
+            deposit_a,
+            deposit_b,
+            status: ChannelStatus::Open,
+        };
+        save_channel(&env, &channel);
+
+        env.events().publish(
+            (symbol_short!("OPENED"), a),
+            (channel_id, b, deposit_a, deposit_b),
+        );
+
+        Ok(channel_id)
+    }
+
+    /// Close instantly with both signatures present. No dispute window: two
+    /// fresh, mutually consistent signatures are the strongest evidence of
+    /// intent the protocol has, so there is nothing left to wait out.
+    ///
+    /// Callable by anyone — the recipients and amounts are fully determined
+    /// by `state`'s own dual signature, so the submitter has no discretion
+    /// to abuse. This lets either party, or a disinterested relayer, submit
+    /// a cooperative close on both parties' behalf.
+    pub fn close_cooperative(
+        env: Env,
+        channel_id: u64,
+        state: ChannelState,
+    ) -> Result<(), ChannelsError> {
+        let mut channel = load_channel(&env, channel_id)?;
+        if channel.status == ChannelStatus::Closed {
+            return Err(ChannelsError::ChannelNotOpen);
+        }
+        if state.channel_id != channel_id {
+            return Err(ChannelsError::ChannelIdMismatch);
+        }
+
+        let pubkey_a = registered_key(&env, &channel.party_a);
+        let pubkey_b = registered_key(&env, &channel.party_b);
+        verify_dual_signature(&env, &state, &pubkey_a, &pubkey_b);
+        require_conserved(&channel, state.balance_a, state.balance_b)?;
+
+        pay(
+            &env,
+            &channel.token,
+            &channel.party_a,
+            state.balance_a as i128,
+        );
+        pay(
+            &env,
+            &channel.token,
+            &channel.party_b,
+            state.balance_b as i128,
+        );
+
+        channel.status = ChannelStatus::Closed;
+        save_channel(&env, &channel);
+        env.storage()
+            .persistent()
+            .remove(&ChannelKey::PendingClose(channel_id));
+
+        env.events().publish(
+            (symbol_short!("COOP_CLS"), channel.party_a.clone()),
+            (channel_id, state.balance_a, state.balance_b),
+        );
+
+        Ok(())
+    }
+
+    /// Start a unilateral close: `closer` submits a state and a dispute
+    /// window begins. Anyone who holds a validly higher-versioned state has
+    /// until `dispute_deadline` to supersede it via `dispute`, or to prove
+    /// it was revoked via `punish`.
+    pub fn close_unilateral(
+        env: Env,
+        closer: Address,
+        channel_id: u64,
+        state: ChannelState,
+    ) -> Result<u64, ChannelsError> {
+        closer.require_auth();
+
+        let mut channel = load_channel(&env, channel_id)?;
+        require_party(&channel, &closer)?;
+        if channel.status != ChannelStatus::Open {
+            return Err(ChannelsError::ChannelNotOpen);
+        }
+        if state.channel_id != channel_id {
+            return Err(ChannelsError::ChannelIdMismatch);
+        }
+
+        let pubkey_a = registered_key(&env, &channel.party_a);
+        let pubkey_b = registered_key(&env, &channel.party_b);
+        verify_dual_signature(&env, &state, &pubkey_a, &pubkey_b);
+        require_conserved(&channel, state.balance_a, state.balance_b)?;
+
+        let dispute_deadline = env.ledger().timestamp() + DISPUTE_WINDOW_SECS;
+        let pending = PendingClose {
+            closer: closer.clone(),
+            dispute_deadline,
+            version: state.version,
+            balance_a: state.balance_a,
+            balance_b: state.balance_b,
+            revocation_commit_a: state.revocation_commit_a.clone(),
+            revocation_commit_b: state.revocation_commit_b.clone(),
+        };
+        save_pending(&env, channel_id, &pending);
+
+        channel.status = ChannelStatus::Closing;
+        save_channel(&env, &channel);
+
+        // The exact event ChannelMonitor.js watches for to dispatch to a
+        // Watchtower — see that module for the offline-party recovery path.
+        env.events().publish(
+            (Symbol::new(&env, "UNILATERAL_CLOSE"), closer),
+            (channel_id, state.version, dispute_deadline),
+        );
+
+        Ok(dispute_deadline)
+    }
+
+    /// Supersede the pending close with a correctly signed, strictly higher
+    /// version. Restarts nothing — the original `dispute_deadline` stands —
+    /// so a dispute cannot be used to buy the closer more time.
+    pub fn dispute(
+        env: Env,
+        challenger: Address,
+        channel_id: u64,
+        later_state: ChannelState,
+    ) -> Result<(), ChannelsError> {
+        let channel = load_channel(&env, channel_id)?;
+        require_party(&channel, &challenger)?;
+        if channel.status != ChannelStatus::Closing {
+            return Err(ChannelsError::ChannelNotClosing);
+        }
+        if later_state.channel_id != channel_id {
+            return Err(ChannelsError::ChannelIdMismatch);
+        }
+
+        let pubkey_a = registered_key(&env, &channel.party_a);
+        let pubkey_b = registered_key(&env, &channel.party_b);
+        verify_dual_signature(&env, &later_state, &pubkey_a, &pubkey_b);
+        require_conserved(&channel, later_state.balance_a, later_state.balance_b)?;
+
+        let mut pending = load_pending(&env, channel_id);
+        if later_state.version <= pending.version {
+            return Err(ChannelsError::VersionNotHigher);
+        }
+
+        pending.version = later_state.version;
+        pending.balance_a = later_state.balance_a;
+        pending.balance_b = later_state.balance_b;
+        pending.revocation_commit_a = later_state.revocation_commit_a.clone();
+        pending.revocation_commit_b = later_state.revocation_commit_b.clone();
+        // dispute_deadline is deliberately left untouched.
+        save_pending(&env, channel_id, &pending);
+
+        env.events().publish(
+            (symbol_short!("DISPUTED"), challenger),
+            (channel_id, pending.version),
+        );
+
+        Ok(())
+    }
+
+    /// Prove the pending close rests on a version both parties already
+    /// moved past, using nothing but a revealed revocation secret. Pays the
+    /// entire channel balance to `challenger` as a deterrent — strictly
+    /// worse for the closer than closing honestly ever could be.
+    ///
+    /// `challenger` must be the channel's *other* party — the one who did
+    /// not initiate the disputed close — so an onlooker who merely observes
+    /// a leaked secret cannot name themselves as the payout recipient. A
+    /// Watchtower calls this with the honest party's address, not its own.
+    pub fn punish(
+        env: Env,
+        challenger: Address,
+        channel_id: u64,
+        revocation_secret: BytesN<32>,
+    ) -> Result<i128, ChannelsError> {
+        let mut channel = load_channel(&env, channel_id)?;
+        if channel.status != ChannelStatus::Closing {
+            return Err(ChannelsError::ChannelNotClosing);
+        }
+
+        let pending = load_pending(&env, channel_id);
+        require_party(&channel, &challenger)?;
+        if challenger == pending.closer {
+            return Err(ChannelsError::NotTheHonestParty);
+        }
+
+        let secret_bytes = Bytes::from_array(&env, &revocation_secret.to_array());
+        let secret_hash: BytesN<32> = env.crypto().sha256(&secret_bytes).into();
+        if secret_hash != pending.revocation_commit_a && secret_hash != pending.revocation_commit_b
+        {
+            return Err(ChannelsError::InvalidRevocationSecret);
+        }
+
+        let payout = channel.deposit_a + channel.deposit_b;
+        pay(&env, &channel.token, &challenger, payout);
+
+        channel.status = ChannelStatus::Closed;
+        save_channel(&env, &channel);
+        env.storage()
+            .persistent()
+            .remove(&ChannelKey::PendingClose(channel_id));
+
+        env.events().publish(
+            (symbol_short!("PUNISHED"), challenger),
+            (channel_id, payout),
+        );
+
+        Ok(payout)
+    }
+
+    /// Finalize a unilateral close once its dispute window has elapsed
+    /// uncontested. Callable by anyone — the payout is fully determined by
+    /// the pending state, so there is no discretion to abuse, and requiring
+    /// a specific caller would only create a liveness risk if that party
+    /// were unreachable.
+    pub fn force_close(env: Env, channel_id: u64) -> Result<(), ChannelsError> {
+        let mut channel = load_channel(&env, channel_id)?;
+        if channel.status != ChannelStatus::Closing {
+            return Err(ChannelsError::ChannelNotClosing);
+        }
+
+        let pending = load_pending(&env, channel_id);
+        if env.ledger().timestamp() < pending.dispute_deadline {
+            return Err(ChannelsError::DisputeWindowOpen);
+        }
+
+        pay(
+            &env,
+            &channel.token,
+            &channel.party_a,
+            pending.balance_a as i128,
+        );
+        pay(
+            &env,
+            &channel.token,
+            &channel.party_b,
+            pending.balance_b as i128,
+        );
+
+        channel.status = ChannelStatus::Closed;
+        save_channel(&env, &channel);
+        env.storage()
+            .persistent()
+            .remove(&ChannelKey::PendingClose(channel_id));
+
+        env.events().publish(
+            (symbol_short!("FRC_CLS"), channel_id),
+            (pending.balance_a, pending.balance_b),
+        );
+
+        Ok(())
+    }
+
+    // ── Views ────────────────────────────────────────────────────────────
+
+    pub fn get_channel(env: Env, channel_id: u64) -> Option<Channel> {
+        env.storage()
+            .persistent()
+            .get(&ChannelKey::Channel(channel_id))
+    }
+
+    pub fn get_pending_close(env: Env, channel_id: u64) -> Option<PendingClose> {
+        env.storage()
+            .persistent()
+            .get(&ChannelKey::PendingClose(channel_id))
+    }
+
+    pub fn channel_count(env: Env) -> u64 {
+        env.storage().instance().get(&NEXT_ID).unwrap_or(0u64)
+    }
+
+    /// The commitment hash a Watchtower blob for `state` would be keyed on —
+    /// exposed so an off-chain service can confirm it derives the same value
+    /// the contract would.
+    pub fn state_commitment_hash(env: Env, state: ChannelState) -> BytesN<32> {
+        state_commitment_hash(&env, &state)
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/contract/contracts/channels/src/state.rs
+++ b/contract/contracts/channels/src/state.rs
@@ -1,0 +1,92 @@
+//! Canonical channel-state encoding — signing, hashing, and the struct both
+//! off-chain parties sign.
+//!
+//! Byte-for-byte identical to `backend/src/channels/canonical.js`; that file
+//! carries the full field table and the rationale for embedding the two
+//! revocation commitments in the signed bytes rather than registering them
+//! separately. In brief, the preimage is 96 fixed-width big-endian bytes:
+//!
+//! ```text
+//! offset  size  field
+//! ------  ----  -------------------------------------------------------
+//!      0     8  channel_id            u64 BE
+//!      8     8  version               u64 BE
+//!     16     8  balance_a             u64 BE
+//!     24     8  balance_b             u64 BE
+//!     32    32  revocation_commit_a   sha256(party A's secret for this version)
+//!     64    32  revocation_commit_b   sha256(party B's secret for this version)
+//! ```
+//!
+//! and the signed message is `0x10 || PREIMAGE` (domain tag 0x10, kept clear
+//! of the attestation module's 0x00/0x01/0x02 so the two signature schemes
+//! can never be confused with each other).
+
+use soroban_sdk::{contracttype, Bytes, BytesN, Env};
+
+/// Domain tag. Keep in lockstep with `backend/src/channels/canonical.js`.
+pub const DOMAIN_CHANNEL_STATE: u8 = 0x10;
+
+/// A dual-signed, monotonically versioned balance pair.
+///
+/// Only meaningful with both `sig_a` and `sig_b` present and verifying —
+/// neither party can move funds unilaterally, which is what lets `dispute`
+/// trust any state that merely verifies: it cannot exist without both
+/// parties having signed off on it.
+///
+/// `revocation_commit_a`/`_b` are each party's RevocationStore commitment
+/// hash for *this* version (see the module doc). Signing them alongside the
+/// balances is what lets `punish` prove a bare revealed secret revokes this
+/// exact version using only what `close_unilateral` already put in storage.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ChannelState {
+    pub channel_id: u64,
+    pub version: u64,
+    pub balance_a: u64,
+    pub balance_b: u64,
+    pub revocation_commit_a: BytesN<32>,
+    pub revocation_commit_b: BytesN<32>,
+    pub sig_a: BytesN<64>,
+    pub sig_b: BytesN<64>,
+}
+
+/// `0x10 || PREIMAGE` — the exact bytes both parties Ed25519-sign, and the
+/// commitment-hash preimage. Deliberately excludes `sig_a`/`sig_b`.
+pub(crate) fn signing_message(env: &Env, state: &ChannelState) -> Bytes {
+    let mut msg = Bytes::new(env);
+    msg.extend_from_array(&[DOMAIN_CHANNEL_STATE]);
+    msg.extend_from_array(&state.channel_id.to_be_bytes());
+    msg.extend_from_array(&state.version.to_be_bytes());
+    msg.extend_from_array(&state.balance_a.to_be_bytes());
+    msg.extend_from_array(&state.balance_b.to_be_bytes());
+    msg.extend_from_array(&state.revocation_commit_a.to_array());
+    msg.extend_from_array(&state.revocation_commit_b.to_array());
+    msg
+}
+
+/// `commitment_hash = sha256(signing_message)` — the value a Watchtower blob
+/// is keyed on, letting it hold a justice transaction without ever learning
+/// the channel's balances.
+pub(crate) fn commitment_hash(env: &Env, state: &ChannelState) -> BytesN<32> {
+    env.crypto().sha256(&signing_message(env, state)).into()
+}
+
+/// Verify both signatures over `state`, strict: panics (via
+/// `ed25519_verify`) on the first bad one. This is the "must be good or the
+/// whole call fails" mode — used everywhere a state is *accepted* (open,
+/// close, dispute). Nothing here ever needs the catchable/boolean mode: a
+/// `punish` claim never re-checks Ed25519 at all, it only compares a sha256
+/// of a revealed secret against a commitment already bound into a state that
+/// was strictly verified when it was first accepted.
+pub(crate) fn verify_dual_signature(
+    env: &Env,
+    state: &ChannelState,
+    pubkey_a: &BytesN<32>,
+    pubkey_b: &BytesN<32>,
+) {
+    let message = signing_message(env, state);
+    env.crypto()
+        .ed25519_verify(pubkey_a, &message, &state.sig_a);
+    env.crypto()
+        .ed25519_verify(pubkey_b, &message, &state.sig_b);
+}

--- a/contract/contracts/channels/src/test.rs
+++ b/contract/contracts/channels/src/test.rs
@@ -1,0 +1,697 @@
+//! Tests for the bidirectional payment channel contract.
+//!
+//! Built around the same adversarial shape as attestation_test.rs: every
+//! happy path must survive, and every dishonest attempt — a stale close, a
+//! forged signature, a revoked state republished, a race between two
+//! unilateral closes — must lose exactly the right amount of money.
+
+extern crate alloc;
+
+use super::*;
+use crate::state::signing_message;
+use alloc::vec::Vec as StdVec;
+use ed25519_dalek::{Signer, SigningKey};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger, LedgerInfo},
+    token, Address, Bytes, BytesN, Env,
+};
+
+// ── Harness ──────────────────────────────────────────────────────────────────
+
+struct Fixture {
+    env: Env,
+    client: ChannelsContractClient<'static>,
+    party_a: Address,
+    party_b: Address,
+    key_a: SigningKey,
+    key_b: SigningKey,
+    token: Address,
+    channel_id: u64,
+}
+
+fn to_vec(bytes: &Bytes) -> StdVec<u8> {
+    bytes.iter().collect()
+}
+
+fn signing_key(seed: u8) -> SigningKey {
+    SigningKey::from_bytes(&[seed; 32])
+}
+
+fn public_key(env: &Env, key: &SigningKey) -> BytesN<32> {
+    BytesN::from_array(env, &key.verifying_key().to_bytes())
+}
+
+fn sign(env: &Env, key: &SigningKey, message: &Bytes) -> BytesN<64> {
+    BytesN::from_array(env, &key.sign(&to_vec(message)).to_bytes())
+}
+
+fn secret_of(seed: u8) -> [u8; 32] {
+    [seed; 32]
+}
+
+fn commitment_of(env: &Env, secret: &[u8; 32]) -> BytesN<32> {
+    env.crypto().sha256(&Bytes::from_array(env, secret)).into()
+}
+
+/// Build a fully dual-signed state, plus the two raw revocation secrets it
+/// commits to (so a test can later reveal one to `punish`).
+#[allow(clippy::too_many_arguments)]
+fn make_state(
+    fx: &Fixture,
+    version: u64,
+    balance_a: u64,
+    balance_b: u64,
+    seed_a: u8,
+    seed_b: u8,
+) -> (ChannelState, [u8; 32], [u8; 32]) {
+    let secret_a = secret_of(seed_a);
+    let secret_b = secret_of(seed_b);
+
+    let mut state = ChannelState {
+        channel_id: fx.channel_id,
+        version,
+        balance_a,
+        balance_b,
+        revocation_commit_a: commitment_of(&fx.env, &secret_a),
+        revocation_commit_b: commitment_of(&fx.env, &secret_b),
+        sig_a: BytesN::from_array(&fx.env, &[0u8; 64]),
+        sig_b: BytesN::from_array(&fx.env, &[0u8; 64]),
+    };
+    let message = signing_message(&fx.env, &state);
+    state.sig_a = sign(&fx.env, &fx.key_a, &message);
+    state.sig_b = sign(&fx.env, &fx.key_b, &message);
+    (state, secret_a, secret_b)
+}
+
+fn token_balance(env: &Env, token: &Address, who: &Address) -> i128 {
+    token::Client::new(env, token).balance(who)
+}
+
+fn advance_to(env: &Env, timestamp: u64) {
+    env.ledger().set(LedgerInfo {
+        timestamp,
+        protocol_version: 22,
+        sequence_number: 10,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_temp_entry_ttl: 16,
+        min_persistent_entry_ttl: 100_000,
+        max_entry_ttl: 6_312_000,
+    });
+}
+
+fn setup(deposit_a: i128, deposit_b: i128) -> Fixture {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(ChannelsContract, ());
+    let client = ChannelsContractClient::new(&env, &contract_id);
+
+    let party_a = Address::generate(&env);
+    let party_b = Address::generate(&env);
+    let key_a = signing_key(11);
+    let key_b = signing_key(22);
+    client.register_channel_key(&party_a, &public_key(&env, &key_a));
+    client.register_channel_key(&party_b, &public_key(&env, &key_b));
+
+    let token_admin = Address::generate(&env);
+    let token_contract = env.register_stellar_asset_contract_v2(token_admin);
+    let token = token_contract.address();
+    token::StellarAssetClient::new(&env, &token).mint(&party_a, &1_000_000_000);
+    token::StellarAssetClient::new(&env, &token).mint(&party_b, &1_000_000_000);
+
+    let channel_id = client.open_channel(&party_a, &party_b, &token, &deposit_a, &deposit_b);
+
+    Fixture {
+        env,
+        client,
+        party_a,
+        party_b,
+        key_a,
+        key_b,
+        token,
+        channel_id,
+    }
+}
+
+// ── Opening ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn opening_a_channel_escrows_both_deposits() {
+    let fx = setup(600, 400);
+    let contract_id = fx.client.address.clone();
+
+    assert_eq!(token_balance(&fx.env, &fx.token, &contract_id), 1000);
+    let channel = fx.client.get_channel(&fx.channel_id).unwrap();
+    assert_eq!(channel.deposit_a, 600);
+    assert_eq!(channel.deposit_b, 400);
+    assert_eq!(channel.status, ChannelStatus::Open);
+}
+
+#[test]
+fn opening_requires_both_parties_to_have_registered_a_key() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(ChannelsContract, ());
+    let client = ChannelsContractClient::new(&env, &contract_id);
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    client.register_channel_key(&a, &public_key(&env, &signing_key(1)));
+    // b never registers.
+
+    let token_admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    token::StellarAssetClient::new(&env, &token).mint(&a, &1000);
+    token::StellarAssetClient::new(&env, &token).mint(&b, &1000);
+
+    let result = client.try_open_channel(&a, &b, &token, &600, &400);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        ChannelsError::ChannelKeyNotRegistered
+    );
+}
+
+#[test]
+fn opening_a_channel_with_yourself_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(ChannelsContract, ());
+    let client = ChannelsContractClient::new(&env, &contract_id);
+
+    let a = Address::generate(&env);
+    client.register_channel_key(&a, &public_key(&env, &signing_key(1)));
+    let token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+    token::StellarAssetClient::new(&env, &token).mint(&a, &1000);
+
+    let result = client.try_open_channel(&a, &a, &token, &600, &400);
+    assert_eq!(result.unwrap_err().unwrap(), ChannelsError::SelfChannel);
+}
+
+#[test]
+fn opening_with_no_deposit_on_either_side_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(ChannelsContract, ());
+    let client = ChannelsContractClient::new(&env, &contract_id);
+
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    client.register_channel_key(&a, &public_key(&env, &signing_key(1)));
+    client.register_channel_key(&b, &public_key(&env, &signing_key(2)));
+    let token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+
+    let result = client.try_open_channel(&a, &b, &token, &0, &0);
+    assert_eq!(result.unwrap_err().unwrap(), ChannelsError::InvalidDeposit);
+}
+
+// ── Cooperative close ────────────────────────────────────────────────────────
+
+#[test]
+fn cooperative_close_pays_both_parties_and_needs_no_window() {
+    let fx = setup(600, 400);
+    let (state, _, _) = make_state(&fx, 1, 550, 450, 1, 2);
+
+    fx.client.close_cooperative(&fx.channel_id, &state);
+
+    assert_eq!(
+        token_balance(&fx.env, &fx.token, &fx.party_a),
+        1_000_000_000 - 600 + 550
+    );
+    assert_eq!(
+        token_balance(&fx.env, &fx.token, &fx.party_b),
+        1_000_000_000 - 400 + 450
+    );
+    assert_eq!(
+        fx.client.get_channel(&fx.channel_id).unwrap().status,
+        ChannelStatus::Closed
+    );
+}
+
+#[test]
+fn cooperative_close_rejects_balances_that_do_not_conserve_the_deposit() {
+    let fx = setup(600, 400);
+    let (state, _, _) = make_state(&fx, 1, 550, 500, 1, 2); // sums to 1050, not 1000
+
+    let result = fx.client.try_close_cooperative(&fx.channel_id, &state);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        ChannelsError::BalanceConservationViolated
+    );
+}
+
+#[test]
+#[should_panic]
+fn cooperative_close_rejects_a_single_signer_state() {
+    let fx = setup(600, 400);
+    let (mut state, _, _) = make_state(&fx, 1, 550, 450, 1, 2);
+    // Corrupt sig_b to something that never verifies under party_b's key.
+    state.sig_b = BytesN::from_array(&fx.env, &[0xAB; 64]);
+
+    fx.client.close_cooperative(&fx.channel_id, &state);
+}
+
+#[test]
+fn cooperative_close_overrides_a_pending_unilateral_close() {
+    let fx = setup(600, 400);
+    let (stale, _, _) = make_state(&fx, 5, 600, 400, 1, 2);
+    fx.client
+        .close_unilateral(&fx.party_a, &fx.channel_id, &stale);
+
+    let (agreed, _, _) = make_state(&fx, 6, 500, 500, 3, 4);
+    fx.client.close_cooperative(&fx.channel_id, &agreed);
+
+    assert_eq!(
+        fx.client.get_channel(&fx.channel_id).unwrap().status,
+        ChannelStatus::Closed
+    );
+    assert_eq!(
+        token_balance(&fx.env, &fx.token, &fx.party_a),
+        1_000_000_000 - 600 + 500
+    );
+}
+
+// ── Unilateral close, uncontested ───────────────────────────────────────────
+
+#[test]
+fn a_stream_of_off_chain_updates_settles_at_the_final_balance_with_one_close() {
+    // The acceptance criterion: unbounded off-chain updates, one on-chain
+    // close. We don't literally submit 10,000 updates to the contract (only
+    // the final one is ever posted) — that IS the point being tested.
+    let fx = setup(1_000_000, 0);
+    let mut version = 0u64;
+    let mut balance_a = 1_000_000u64;
+    let mut balance_b = 0u64;
+
+    for _ in 0..500 {
+        version += 1;
+        balance_a -= 100;
+        balance_b += 100;
+    }
+
+    let (final_state, _, _) = make_state(&fx, version, balance_a, balance_b, 7, 8);
+    fx.client.close_cooperative(&fx.channel_id, &final_state);
+
+    assert_eq!(
+        token_balance(&fx.env, &fx.token, &fx.party_b),
+        1_000_000_000 + 50_000
+    );
+    assert_eq!(
+        token_balance(&fx.env, &fx.token, &fx.party_a),
+        1_000_000_000 - 1_000_000 + 950_000
+    );
+}
+
+#[test]
+fn unilateral_close_starts_a_dispute_window_and_force_close_pays_the_pending_state() {
+    let fx = setup(600, 400);
+    let (state, _, _) = make_state(&fx, 3, 550, 450, 1, 2);
+    fx.client
+        .close_unilateral(&fx.party_a, &fx.channel_id, &state);
+
+    assert_eq!(
+        fx.client.get_channel(&fx.channel_id).unwrap().status,
+        ChannelStatus::Closing
+    );
+
+    advance_to(&fx.env, DISPUTE_WINDOW_SECS + 1);
+    fx.client.force_close(&fx.channel_id);
+
+    assert_eq!(
+        token_balance(&fx.env, &fx.token, &fx.party_a),
+        1_000_000_000 - 600 + 550
+    );
+    assert_eq!(
+        token_balance(&fx.env, &fx.token, &fx.party_b),
+        1_000_000_000 - 400 + 450
+    );
+    assert_eq!(
+        fx.client.get_channel(&fx.channel_id).unwrap().status,
+        ChannelStatus::Closed
+    );
+}
+
+#[test]
+fn force_close_before_the_window_elapses_is_rejected() {
+    let fx = setup(600, 400);
+    let (state, _, _) = make_state(&fx, 3, 550, 450, 1, 2);
+    fx.client
+        .close_unilateral(&fx.party_a, &fx.channel_id, &state);
+
+    let result = fx.client.try_force_close(&fx.channel_id);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        ChannelsError::DisputeWindowOpen
+    );
+}
+
+#[test]
+fn only_a_channel_party_may_start_a_unilateral_close() {
+    let fx = setup(600, 400);
+    let (state, _, _) = make_state(&fx, 1, 600, 400, 1, 2);
+    let stranger = Address::generate(&fx.env);
+
+    let result = fx
+        .client
+        .try_close_unilateral(&stranger, &fx.channel_id, &state);
+    assert_eq!(result.unwrap_err().unwrap(), ChannelsError::NotAParty);
+}
+
+#[test]
+#[should_panic]
+fn a_forged_closing_state_cannot_start_the_dispute_window() {
+    let fx = setup(600, 400);
+    let (mut state, _, _) = make_state(&fx, 1, 600, 400, 1, 2);
+    let impostor = signing_key(99);
+    state.sig_a = sign(&fx.env, &impostor, &signing_message(&fx.env, &state));
+
+    fx.client
+        .close_unilateral(&fx.party_a, &fx.channel_id, &state);
+}
+
+// ── Dispute: a stale close superseded by a higher version ──────────────────
+
+#[test]
+fn a_stale_close_is_superseded_by_a_higher_version() {
+    // The exact scenario from the issue: party A closes with version 40
+    // while B holds version 87.
+    let fx = setup(600, 400);
+    let (stale, _, _) = make_state(&fx, 40, 600, 400, 1, 2);
+    fx.client
+        .close_unilateral(&fx.party_a, &fx.channel_id, &stale);
+
+    let (later, _, _) = make_state(&fx, 87, 100, 900, 3, 4);
+    fx.client.dispute(&fx.party_b, &fx.channel_id, &later);
+
+    let pending = fx.client.get_pending_close(&fx.channel_id).unwrap();
+    assert_eq!(pending.version, 87);
+    assert_eq!(pending.balance_a, 100);
+    assert_eq!(pending.balance_b, 900);
+
+    advance_to(&fx.env, DISPUTE_WINDOW_SECS + 1);
+    fx.client.force_close(&fx.channel_id);
+    assert_eq!(
+        token_balance(&fx.env, &fx.token, &fx.party_a),
+        1_000_000_000 - 600 + 100
+    );
+    assert_eq!(
+        token_balance(&fx.env, &fx.token, &fx.party_b),
+        1_000_000_000 - 400 + 900
+    );
+}
+
+#[test]
+fn dispute_does_not_restart_the_window() {
+    let fx = setup(600, 400);
+    let (stale, _, _) = make_state(&fx, 1, 600, 400, 1, 2);
+    fx.client
+        .close_unilateral(&fx.party_a, &fx.channel_id, &stale);
+    let original_deadline = fx
+        .client
+        .get_pending_close(&fx.channel_id)
+        .unwrap()
+        .dispute_deadline;
+
+    advance_to(&fx.env, 100);
+    let (later, _, _) = make_state(&fx, 2, 500, 500, 3, 4);
+    fx.client.dispute(&fx.party_b, &fx.channel_id, &later);
+
+    assert_eq!(
+        fx.client
+            .get_pending_close(&fx.channel_id)
+            .unwrap()
+            .dispute_deadline,
+        original_deadline
+    );
+}
+
+#[test]
+fn a_dispute_after_the_window_would_have_expired_still_lands_if_nobody_force_closed() {
+    // "Dispute after window expiry" from the issue's test list: the window
+    // is a minimum wait for force_close, not a hard deadline on correcting
+    // the record — as long as the channel has not yet finalized, a later
+    // signed state can still supersede.
+    let fx = setup(600, 400);
+    let (stale, _, _) = make_state(&fx, 1, 600, 400, 1, 2);
+    fx.client
+        .close_unilateral(&fx.party_a, &fx.channel_id, &stale);
+
+    advance_to(&fx.env, DISPUTE_WINDOW_SECS + 1_000);
+    let (later, _, _) = make_state(&fx, 2, 500, 500, 3, 4);
+    fx.client.dispute(&fx.party_b, &fx.channel_id, &later);
+
+    assert_eq!(
+        fx.client.get_pending_close(&fx.channel_id).unwrap().version,
+        2
+    );
+}
+
+#[test]
+fn a_lower_or_equal_version_cannot_supersede() {
+    let fx = setup(600, 400);
+    let (current, _, _) = make_state(&fx, 10, 600, 400, 1, 2);
+    fx.client
+        .close_unilateral(&fx.party_a, &fx.channel_id, &current);
+
+    let (same_version, _, _) = make_state(&fx, 10, 300, 700, 3, 4);
+    let result = fx
+        .client
+        .try_dispute(&fx.party_b, &fx.channel_id, &same_version);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        ChannelsError::VersionNotHigher
+    );
+}
+
+// ── Simultaneous close race ─────────────────────────────────────────────────
+
+#[test]
+fn a_second_unilateral_close_cannot_reopen_the_race_only_dispute_can() {
+    // Both parties "closing at once" resolves deterministically: whoever's
+    // close_unilateral lands first opens the window; the other party's only
+    // recourse from then on is `dispute`, and the higher version always
+    // wins regardless of closing order.
+    let fx = setup(600, 400);
+    let (a_close, _, _) = make_state(&fx, 40, 600, 400, 1, 2);
+    fx.client
+        .close_unilateral(&fx.party_a, &fx.channel_id, &a_close);
+
+    let (b_close, _, _) = make_state(&fx, 87, 50, 950, 5, 6);
+    let result = fx
+        .client
+        .try_close_unilateral(&fx.party_b, &fx.channel_id, &b_close);
+    assert_eq!(result.unwrap_err().unwrap(), ChannelsError::ChannelNotOpen);
+
+    // B's higher version still wins, via dispute instead.
+    fx.client.dispute(&fx.party_b, &fx.channel_id, &b_close);
+    assert_eq!(
+        fx.client.get_pending_close(&fx.channel_id).unwrap().version,
+        87
+    );
+}
+
+// ── Punishment ───────────────────────────────────────────────────────────────
+
+#[test]
+fn punishment_of_a_revoked_close_pays_the_challenger_everything() {
+    let fx = setup(600, 400);
+    // Version 1 is signed, and both parties' revocation secrets for it are
+    // generated — then the channel moves on to version 2. Revealing either
+    // secret now proves version 1 was revoked.
+    let (v1, secret_a_v1, _secret_b_v1) = make_state(&fx, 1, 600, 400, 111, 112);
+    let (_v2, _, _) = make_state(&fx, 2, 500, 500, 113, 114);
+
+    // Party A dishonestly closes with the revoked version 1.
+    fx.client.close_unilateral(&fx.party_a, &fx.channel_id, &v1);
+
+    let secret = BytesN::from_array(&fx.env, &secret_a_v1);
+    let payout = fx.client.punish(&fx.party_b, &fx.channel_id, &secret);
+
+    assert_eq!(
+        payout, 1000,
+        "the entire deposit, not just party B's honest share"
+    );
+    assert_eq!(
+        token_balance(&fx.env, &fx.token, &fx.party_b),
+        1_000_000_000 - 400 + 1000
+    );
+    assert_eq!(
+        fx.client.get_channel(&fx.channel_id).unwrap().status,
+        ChannelStatus::Closed
+    );
+}
+
+#[test]
+fn either_partys_revealed_secret_is_sufficient_to_punish() {
+    let fx = setup(600, 400);
+    let (v1, _secret_a, secret_b) = make_state(&fx, 1, 600, 400, 121, 122);
+    fx.client.close_unilateral(&fx.party_a, &fx.channel_id, &v1);
+
+    let secret = BytesN::from_array(&fx.env, &secret_b);
+    let payout = fx.client.punish(&fx.party_b, &fx.channel_id, &secret);
+    assert_eq!(payout, 1000);
+}
+
+#[test]
+fn punishment_against_a_non_revoked_state_fails() {
+    let fx = setup(600, 400);
+    let (v1, _, _) = make_state(&fx, 1, 600, 400, 1, 2);
+    fx.client.close_unilateral(&fx.party_a, &fx.channel_id, &v1);
+
+    // A secret that was never committed to by this (or any) version.
+    let unrelated_secret = BytesN::from_array(&fx.env, &secret_of(0xFF));
+    let result = fx
+        .client
+        .try_punish(&fx.party_b, &fx.channel_id, &unrelated_secret);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        ChannelsError::InvalidRevocationSecret
+    );
+}
+
+#[test]
+fn the_closer_cannot_punish_themselves() {
+    let fx = setup(600, 400);
+    let (v1, secret_a, _) = make_state(&fx, 1, 600, 400, 1, 2);
+    fx.client.close_unilateral(&fx.party_a, &fx.channel_id, &v1);
+
+    let secret = BytesN::from_array(&fx.env, &secret_a);
+    let result = fx.client.try_punish(&fx.party_a, &fx.channel_id, &secret);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        ChannelsError::NotTheHonestParty
+    );
+}
+
+#[test]
+fn punishment_is_unavailable_once_the_channel_is_open_or_already_closed() {
+    let fx = setup(600, 400);
+    let secret = BytesN::from_array(&fx.env, &secret_of(1));
+
+    let while_open = fx.client.try_punish(&fx.party_b, &fx.channel_id, &secret);
+    assert_eq!(
+        while_open.unwrap_err().unwrap(),
+        ChannelsError::ChannelNotClosing
+    );
+
+    let (v1, secret_a, _) = make_state(&fx, 1, 600, 400, 1, 2);
+    fx.client.close_unilateral(&fx.party_a, &fx.channel_id, &v1);
+    fx.client.punish(
+        &fx.party_b,
+        &fx.channel_id,
+        &BytesN::from_array(&fx.env, &secret_a),
+    );
+
+    let while_closed = fx.client.try_punish(&fx.party_b, &fx.channel_id, &secret);
+    assert!(while_closed.is_err());
+}
+
+// ── Deposit accounting across every path ────────────────────────────────────
+
+#[test]
+fn deposit_accounting_holds_across_cooperative_unilateral_and_punished_paths() {
+    for path in ["cooperative", "uncontested_unilateral", "punished"] {
+        let fx = setup(700, 300);
+        let contract_id = fx.client.address.clone();
+        let start_a = token_balance(&fx.env, &fx.token, &fx.party_a);
+        let start_b = token_balance(&fx.env, &fx.token, &fx.party_b);
+
+        match path {
+            "cooperative" => {
+                let (state, _, _) = make_state(&fx, 1, 250, 750, 1, 2);
+                fx.client.close_cooperative(&fx.channel_id, &state);
+                assert_eq!(
+                    token_balance(&fx.env, &fx.token, &fx.party_a),
+                    start_a + 250
+                );
+                assert_eq!(
+                    token_balance(&fx.env, &fx.token, &fx.party_b),
+                    start_b + 750
+                );
+            }
+            "uncontested_unilateral" => {
+                let (state, _, _) = make_state(&fx, 1, 250, 750, 1, 2);
+                fx.client
+                    .close_unilateral(&fx.party_a, &fx.channel_id, &state);
+                advance_to(&fx.env, DISPUTE_WINDOW_SECS + 1);
+                fx.client.force_close(&fx.channel_id);
+                assert_eq!(
+                    token_balance(&fx.env, &fx.token, &fx.party_a),
+                    start_a + 250
+                );
+                assert_eq!(
+                    token_balance(&fx.env, &fx.token, &fx.party_b),
+                    start_b + 750
+                );
+            }
+            "punished" => {
+                let (v1, secret_a, _) = make_state(&fx, 1, 700, 300, 1, 2);
+                fx.client.close_unilateral(&fx.party_a, &fx.channel_id, &v1);
+                fx.client.punish(
+                    &fx.party_b,
+                    &fx.channel_id,
+                    &BytesN::from_array(&fx.env, &secret_a),
+                );
+                assert_eq!(
+                    token_balance(&fx.env, &fx.token, &fx.party_b),
+                    start_b + 1000
+                );
+            }
+            _ => unreachable!(),
+        }
+
+        // Never a stroop created or destroyed: the contract holds nothing
+        // once a channel is closed.
+        assert_eq!(token_balance(&fx.env, &fx.token, &contract_id), 0);
+    }
+}
+
+// ── Cross-language wire compatibility ────────────────────────────────────────
+
+/// Pinned vectors shared with `backend/src/__tests__/channels/channelState.test.js`.
+///
+/// Produced by `backend/src/channels/canonical.js` for
+/// `{ channel_id: 42, version: 7, balance_a: 600, balance_b: 400,
+///    revocation_commit_a: sha256([0x01]), revocation_commit_b: sha256([0x02]) }`.
+/// A one-byte disagreement here means the contract and the Node encoder
+/// silently stop agreeing on what a channel state's signature covers.
+const VECTOR_COMMIT_A: [u8; 32] = [
+    0x4b, 0xf5, 0x12, 0x2f, 0x34, 0x45, 0x54, 0xc5, 0x3b, 0xde, 0x2e, 0xbb, 0x8c, 0xd2, 0xb7, 0xe3,
+    0xd1, 0x60, 0x0a, 0xd6, 0x31, 0xc3, 0x85, 0xa5, 0xd7, 0xcc, 0xe2, 0x3c, 0x77, 0x85, 0x45, 0x9a,
+];
+const VECTOR_COMMIT_B: [u8; 32] = [
+    0xdb, 0xc1, 0xb4, 0xc9, 0x00, 0xff, 0xe4, 0x8d, 0x57, 0x5b, 0x5d, 0xa5, 0xc6, 0x38, 0x04, 0x01,
+    0x25, 0xf6, 0x5d, 0xb0, 0xfe, 0x3e, 0x24, 0x49, 0x4b, 0x76, 0xea, 0x98, 0x64, 0x57, 0xd9, 0x86,
+];
+const VECTOR_COMMITMENT_HASH: [u8; 32] = [
+    0x72, 0x93, 0xec, 0x05, 0x33, 0xb1, 0x37, 0xa1, 0x52, 0x9c, 0xdf, 0x4f, 0x5c, 0x01, 0x60, 0xad,
+    0x27, 0xea, 0x5d, 0xb8, 0x7e, 0x2e, 0xd4, 0x65, 0xf6, 0xa6, 0x89, 0x9c, 0x0d, 0xf8, 0xb6, 0x18,
+];
+
+#[test]
+fn state_hashing_matches_the_javascript_encoder() {
+    let env = Env::default();
+    let state = ChannelState {
+        channel_id: 42,
+        version: 7,
+        balance_a: 600,
+        balance_b: 400,
+        revocation_commit_a: BytesN::from_array(&env, &VECTOR_COMMIT_A),
+        revocation_commit_b: BytesN::from_array(&env, &VECTOR_COMMIT_B),
+        sig_a: BytesN::from_array(&env, &[0u8; 64]),
+        sig_b: BytesN::from_array(&env, &[0u8; 64]),
+    };
+
+    // The 96-byte preimage plus its one-byte domain tag.
+    assert_eq!(signing_message(&env, &state).len(), 97);
+    assert_eq!(
+        crate::state::commitment_hash(&env, &state).to_array(),
+        VECTOR_COMMITMENT_HASH
+    );
+}

--- a/contract/deploy/package-lock.json
+++ b/contract/deploy/package-lock.json
@@ -1,0 +1,1057 @@
+{
+  "name": "@cortex-protocol/deploy",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@cortex-protocol/deploy",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@stellar/stellar-sdk": "^12.0.0",
+        "dotenv": "^16.4.5"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.4.5"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@stellar/js-xdr": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.2.tgz",
+      "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@stellar/stellar-base": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-12.1.1.tgz",
+      "integrity": "sha512-gOBSOFDepihslcInlqnxKZdIW9dMUO1tpOm3AtJR33K2OvpXG6SaVHCzAmCFArcCqI9zXTEiSoh70T48TmiHJA==",
+      "deprecated": "This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stellar/js-xdr": "^3.1.2",
+        "base32.js": "^0.1.0",
+        "bignumber.js": "^9.1.2",
+        "buffer": "^6.0.3",
+        "sha.js": "^2.3.6",
+        "tweetnacl": "^1.0.3"
+      },
+      "optionalDependencies": {
+        "sodium-native": "^4.1.1"
+      }
+    },
+    "node_modules/@stellar/stellar-sdk": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-12.3.0.tgz",
+      "integrity": "sha512-F2DYFop/M5ffXF0lvV5Ezjk+VWNKg0QDX8gNhwehVU3y5LYA3WAY6VcCarMGPaG9Wdgoeh1IXXzOautpqpsltw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stellar/stellar-base": "^12.1.1",
+        "axios": "^1.7.7",
+        "bignumber.js": "^9.1.2",
+        "eventsource": "^2.0.2",
+        "randombytes": "^2.1.0",
+        "toml": "^3.0.0",
+        "urijs": "^1.19.1"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.13.tgz",
+      "integrity": "sha512-gcLdvR9HO1ZJBypsOGqaP6TFEzb6vIta0KSTLt9NAQ6pXQO3cRgSVyCN6pzYqI9DlJgY71XKO0dpDhCf08b3pg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/bare-addon-resolve": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.1.tgz",
+      "integrity": "sha512-F/SD2du8keuYSb4xipnGz5j2E6yhNdHA8ZVxtHae6h2uOrpBIjjbhXvjzKZbr5XUOzqBzh/i8GVFycj2DlFQIA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-module-resolve": "^1.10.0",
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-module-resolve": {
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/bare-module-resolve/-/bare-module-resolve-1.12.4.tgz",
+      "integrity": "sha512-xcfgg2u7HqgJiBmah71O9vvdFAgHCvkqC/WSC2O7Bbgosoc1eC/BWe/6IDJ4OsfKlkxuvC/TDWXC+oH5yeW8mA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-semver": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-semver": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.1.0.tgz",
+      "integrity": "sha512-1Hw5qJ7hXdVt3uPUqjeFTuxyvBUJauvz5A1I2jk8gzjZMHp04n//6nV9MDbG9CMw78JHY2lGV0w6s//LrASm2w==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/base32.js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
+      "integrity": "sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/require-addon": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/require-addon/-/require-addon-1.2.0.tgz",
+      "integrity": "sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-addon-resolve": "^1.3.0"
+      },
+      "engines": {
+        "bare": ">=1.10.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sodium-native": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.3.tgz",
+      "integrity": "sha512-OnxSlN3uyY8D0EsLHpmm2HOFmKddQVvEMmsakCrXUzSd8kjjbzL413t4ZNF3n0UxSwNgwTyUvkmZHTfuCeiYSw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "require-addon": "^1.1.0"
+      }
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "license": "MIT"
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/contract/deploy/src/deployer.ts
+++ b/contract/deploy/src/deployer.ts
@@ -109,6 +109,12 @@ export class Deployer {
             (await this.deployContract("agent_registry")),
           name: "AgentRegistryContract",
         },
+        channels: {
+          address:
+            existing?.contracts.channels.address ||
+            (await this.deployContract("channels")),
+          name: "ChannelsContract",
+        },
       },
     };
 
@@ -358,6 +364,7 @@ export class Deployer {
       MARKETPLACE_CONTRACT_ID: addresses.contracts.marketplace.address,
       MICROPAYMENTS_CONTRACT_ID: addresses.contracts.micropayments.address,
       AGENT_REGISTRY_CONTRACT_ID: addresses.contracts.agent_registry.address,
+      CHANNELS_CONTRACT_ID: addresses.contracts.channels.address,
     };
 
     for (const [key, value] of Object.entries(updates)) {

--- a/contract/deploy/src/types.ts
+++ b/contract/deploy/src/types.ts
@@ -103,6 +103,7 @@ export interface ContractAddresses {
   marketplace: string;
   micropayments: string;
   agent_registry: string;
+  channels: string;
 }
 
 export interface DeployedAddresses {
@@ -112,6 +113,7 @@ export interface DeployedAddresses {
     marketplace: { address: string; name: string };
     micropayments: { address: string; name: string };
     agent_registry: { address: string; name: string };
+    channels: { address: string; name: string };
   };
 }
 

--- a/contract/deploy/src/verifier.ts
+++ b/contract/deploy/src/verifier.ts
@@ -96,6 +96,7 @@ export class Verifier {
     await this.verifyContractExists("marketplace", this.addresses.contracts.marketplace.address);
     await this.verifyContractExists("micropayments", this.addresses.contracts.micropayments.address);
     await this.verifyContractExists("agent_registry", this.addresses.contracts.agent_registry.address);
+    await this.verifyContractExists("channels", this.addresses.contracts.channels.address);
 
     await this.verifyMarketplace();
     await this.verifyAgentRegistry();
@@ -357,6 +358,7 @@ export class Verifier {
         marketplace: this.addresses.contracts.marketplace.address,
         micropayments: this.addresses.contracts.micropayments.address,
         agent_registry: this.addresses.contracts.agent_registry.address,
+        channels: this.addresses.contracts.channels.address,
       },
       checks: this.checks,
       totalChecks: this.checks.length,

--- a/contract/scripts/deploy-all.sh
+++ b/contract/scripts/deploy-all.sh
@@ -46,8 +46,10 @@ BACKEND_ENV="$CONTRACT_DIR/../backend/.env"
 FORCE_REDEPLOY="${FORCE_REDEPLOY:-false}"
 MAX_RETRIES=5
 
-# Deployment order matters: dependents come last.
-CONTRACTS=(agent_registry micropayments marketplace)
+# Deployment order matters: dependents come last. channels has no on-chain
+# dependencies (see contract/contracts/channels), so it is safe anywhere in
+# the list; appended rather than reordering the existing three.
+CONTRACTS=(agent_registry micropayments marketplace channels)
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; BOLD='\033[1m'; RESET='\033[0m'
 log_info()  { echo -e "${CYAN}[INFO]${RESET}  $*"; }
@@ -227,7 +229,7 @@ initialize_contracts() {
 # ── Artifacts ─────────────────────────────────────────────────────────────────
 
 write_addresses_json() {
-  local registry="$1" micropayments="$2" marketplace="$3"
+  local registry="$1" micropayments="$2" marketplace="$3" channels="$4"
   local timestamp
   timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
@@ -239,6 +241,7 @@ write_addresses_json() {
     --arg ar "$registry" \
     --arg mc "$micropayments" \
     --arg mp "$marketplace" \
+    --arg ch "$channels" \
     '{
       network: $network,
       networkPassphrase: $passphrase,
@@ -247,7 +250,8 @@ write_addresses_json() {
       contracts: {
         agent_registry: { address: $ar, name: "AgentRegistryContract" },
         micropayments:  { address: $mc, name: "MicropaymentsContract" },
-        marketplace:    { address: $mp, name: "MarketplaceContract" }
+        marketplace:    { address: $mp, name: "MarketplaceContract" },
+        channels:       { address: $ch, name: "ChannelsContract" }
       }
     }' > "$ADDRESSES_FILE"
 
@@ -255,7 +259,7 @@ write_addresses_json() {
 }
 
 sync_backend_env() {
-  local registry="$1" micropayments="$2" marketplace="$3"
+  local registry="$1" micropayments="$2" marketplace="$3" channels="$4"
 
   if [[ ! -f "$BACKEND_ENV" ]]; then
     if [[ -f "${BACKEND_ENV}.example" ]]; then
@@ -279,6 +283,7 @@ sync_backend_env() {
   _set_env_var "AGENT_REGISTRY_CONTRACT_ID" "$registry"
   _set_env_var "MICROPAYMENTS_CONTRACT_ID"  "$micropayments"
   _set_env_var "MARKETPLACE_CONTRACT_ID"    "$marketplace"
+  _set_env_var "CHANNELS_CONTRACT_ID"       "$channels"
   _set_env_var "SOROBAN_RPC_URL"            "$RPC_URL"
   _set_env_var "NETWORK_PASSPHRASE"         "$NETWORK_PASSPHRASE"
 
@@ -303,12 +308,14 @@ main() {
   log_ok "  micropayments   → $MICROPAYMENTS_ADDR"
   MARKETPLACE_ADDR=$(deploy_contract "marketplace")
   log_ok "  marketplace     → $MARKETPLACE_ADDR"
+  CHANNELS_ADDR=$(deploy_contract "channels")
+  log_ok "  channels        → $CHANNELS_ADDR"
 
   initialize_contracts "$MARKETPLACE_ADDR"
 
   log_step "Writing deployment artifacts"
-  write_addresses_json "$AGENT_REGISTRY_ADDR" "$MICROPAYMENTS_ADDR" "$MARKETPLACE_ADDR"
-  sync_backend_env     "$AGENT_REGISTRY_ADDR" "$MICROPAYMENTS_ADDR" "$MARKETPLACE_ADDR"
+  write_addresses_json "$AGENT_REGISTRY_ADDR" "$MICROPAYMENTS_ADDR" "$MARKETPLACE_ADDR" "$CHANNELS_ADDR"
+  sync_backend_env     "$AGENT_REGISTRY_ADDR" "$MICROPAYMENTS_ADDR" "$MARKETPLACE_ADDR" "$CHANNELS_ADDR"
 
   echo ""
   echo -e "${GREEN}${BOLD}✔ All contracts deployed${RESET}"

--- a/contract/scripts/deploy.sh
+++ b/contract/scripts/deploy.sh
@@ -163,6 +163,7 @@ write_addresses_json() {
   local marketplace="$1"
   local micropayments="$2"
   local agent_registry="$3"
+  local channels="$4"
   local timestamp
   timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
@@ -172,6 +173,7 @@ write_addresses_json() {
     --arg mp "$marketplace" \
     --arg mc "$micropayments" \
     --arg ar "$agent_registry" \
+    --arg ch "$channels" \
     '{
       "network": $network,
       "deployed_at": $ts,
@@ -187,6 +189,10 @@ write_addresses_json() {
         "agent_registry": {
           "address": $ar,
           "name": "AgentRegistryContract"
+        },
+        "channels": {
+          "address": $ch,
+          "name": "ChannelsContract"
         }
       }
     }' > "$ADDRESSES_FILE"
@@ -200,6 +206,7 @@ sync_to_backend_env() {
   local marketplace="$1"
   local micropayments="$2"
   local agent_registry="$3"
+  local channels="$4"
 
   local backend_env="$CONTRACT_DIR/../backend/.env"
 
@@ -227,6 +234,7 @@ sync_to_backend_env() {
   _set_env_var "MARKETPLACE_CONTRACT_ID"    "$marketplace"
   _set_env_var "MICROPAYMENTS_CONTRACT_ID"  "$micropayments"
   _set_env_var "AGENT_REGISTRY_CONTRACT_ID" "$agent_registry"
+  _set_env_var "CHANNELS_CONTRACT_ID"       "$channels"
 
   log_ok "backend/.env updated with contract addresses"
 }
@@ -246,10 +254,11 @@ main() {
   MARKETPLACE_ADDR=$(deploy_contract "marketplace")
   MICROPAYMENTS_ADDR=$(deploy_contract "micropayments")
   AGENT_REGISTRY_ADDR=$(deploy_contract "agent_registry")
+  CHANNELS_ADDR=$(deploy_contract "channels")
 
   log_step "Writing deployment artifacts"
-  write_addresses_json "$MARKETPLACE_ADDR" "$MICROPAYMENTS_ADDR" "$AGENT_REGISTRY_ADDR"
-  sync_to_backend_env  "$MARKETPLACE_ADDR" "$MICROPAYMENTS_ADDR" "$AGENT_REGISTRY_ADDR"
+  write_addresses_json "$MARKETPLACE_ADDR" "$MICROPAYMENTS_ADDR" "$AGENT_REGISTRY_ADDR" "$CHANNELS_ADDR"
+  sync_to_backend_env  "$MARKETPLACE_ADDR" "$MICROPAYMENTS_ADDR" "$AGENT_REGISTRY_ADDR" "$CHANNELS_ADDR"
 
   echo ""
   echo -e "${GREEN}${BOLD}✔ Deployment complete!${RESET}"

--- a/contract/scripts/verify.sh
+++ b/contract/scripts/verify.sh
@@ -51,11 +51,13 @@ load_addresses() {
   MARKETPLACE_ADDR=$(jq -r '.contracts.marketplace.address' "$ADDRESSES_FILE")
   MICROPAYMENTS_ADDR=$(jq -r '.contracts.micropayments.address' "$ADDRESSES_FILE")
   AGENT_REGISTRY_ADDR=$(jq -r '.contracts.agent_registry.address' "$ADDRESSES_FILE")
+  CHANNELS_ADDR=$(jq -r '.contracts.channels.address' "$ADDRESSES_FILE")
 
   log_info "Verifying contracts on $NETWORK"
   log_info "Marketplace:    $MARKETPLACE_ADDR"
   log_info "Micropayments:  $MICROPAYMENTS_ADDR"
   log_info "Agent Registry: $AGENT_REGISTRY_ADDR"
+  log_info "Channels:       $CHANNELS_ADDR"
 }
 
 # ── Query Helper ───────────────────────────────────────────────────────────────
@@ -283,10 +285,16 @@ main() {
   verify_contract_info "Marketplace"    "$MARKETPLACE_ADDR"
   verify_contract_info "Micropayments"  "$MICROPAYMENTS_ADDR"
   verify_contract_info "AgentRegistry"  "$AGENT_REGISTRY_ADDR"
+  verify_contract_info "Channels"       "$CHANNELS_ADDR"
 
   verify_marketplace
   verify_agent_registry
   verify_micropayments
+  # No verify_channels(): init.sh does not yet seed a channel fixture to
+  # assert against (open_channel needs a funded token + two registered
+  # keys, unlike the single-owner marketplace/agent_registry seeds it
+  # already does) — deployment existence is checked above, functional
+  # verification is a natural follow-up once init.sh grows that fixture.
   verify_xdr_decode
 
   print_report


### PR DESCRIPTION
Closes #120.

## Summary

Builds on the merged `ChannelState`/`RevocationStore` core (#124) with the rest of the protocol: the Soroban contract, the off-chain negotiation handshake, and watchtower-based fraud proofs.

### Contract — `contract/contracts/channels/`

`open_channel` / `close_cooperative` / `close_unilateral` / `dispute` / `punish` / `force_close`, plus `register_channel_key` (mirroring micropayments' `register_attestation_key`).

**One deliberate deviation from the issue's literal `ChannelState` struct**, disclosed up front: I added `revocation_commit_a`/`revocation_commit_b` fields, signed alongside the balances. Reasoning: `punish(challenger, channel_id, revocation_secret)` has to decide, from a bare 32-byte secret alone, whether a specific superseded version was revoked — and the contract only ever learns a version's fields at the moment `close_unilateral` posts them. Without a commitment baked into the signed state itself, there is nothing on-chain for a revealed secret to be checked against. Embedding each party's own `RevocationStore` commitment in the state it revokes closes that gap without needing any separate pre-registration call, and keeps `punish`'s on-chain signature exactly as the issue specifies (`challenger`, `channel_id`, `revocation_secret` — nothing else).

25 tests: cooperative/unilateral close, a stale close superseded by a higher version (the issue's version-40-vs-87 scenario), punishment of a revoked close, punishment rejected against a non-revoked state, the closer unable to punish themselves, a race between two unilateral closes (second `close_unilateral` rejected, `dispute` still lets the higher version win), deposit conservation across every close path, and cross-language wire-format vectors pinned against `canonical.js`.

### Backend — `backend/src/channels/`

- **`ChannelNegotiator.js`** — propose/counter-sign/ack/complete. The safety property the issue calls out explicitly ("safe against a counterparty who abandons the exchange half-way"): a party only reveals its own previous-version revocation secret *after* it already holds a fully verified successor state. Abandonment at any point leaves both sides holding whatever they already had — never a state the other can deny, never an old state revoked before a new one is secured.
- **`Watchtower.js` / `FraudProofBuilder.js`** — encrypted-at-rest justice packages keyed by a state's commitment hash; the fraud-proof builder assembles a `punish` claim from whatever `RevocationStore` has revealed.
- **`ChannelMonitor.js`** (`protocol/`) — dispatches `UNILATERAL_CLOSE` events to a `Watchtower` and submits `punish` on a match.
- **`channelRepository.js` + migration `026_add_payment_channels.sql`** — durable backing for the otherwise in-memory `RevocationStore`/`Watchtower`, and the `(buyer, seller, token) → open channel` lookup metering routes through.
- **SDK**: `openChannel`, `joinChannel`, `payInChannel`, `closeChannel`, `registerWatchtower`, and `payForCallViaChannel` (routes a call's payment through an existing channel, falling back to the stream path when none exists — see scope note below).

77 JS tests, including an end-to-end scenario matching the issue's acceptance criteria: an offline party's watchtower punishes a revoked close and the party recovers the full deposit on return.

### Deploy pipeline

`contract/Cargo.toml`, `scripts/deploy-all.sh`, `scripts/deploy.sh`, `scripts/verify.sh`, `deploy/src/{deployer,types,verifier}.ts`, `backend/.env.example`, `backend/src/config/stellar.js` all updated to build, deploy, and address-sync the new contract alongside the existing three.

## Scope note: routing metering through a channel

The issue asks to "route metering through a channel when one exists for (buyer, seller), falling back to the existing stream path when it does not." I implemented this at the SDK layer (`payForCallViaChannel`, fully unit-tested) rather than rewiring `MeteringEngine.meterCall`'s stream-JWT path to accept channel-state-based payment proofs directly. That path handles real money, has existing test coverage I could not run in this environment (no Docker/Postgres available for the testcontainers-backed suite), and a channel payment is fundamentally peer-to-peer rather than backend-brokered the way stream metering is — so the routing decision belongs client-side. Happy to follow up with the deeper backend integration in a separate PR with its own review.

## Test plan

- [x] `cargo test -p channels` — 25/25 passing
- [x] `cargo fmt -p channels --check` / `cargo clippy -p channels --all-targets` — clean
- [x] `cargo check --workspace --exclude marketplace` — clean (the `marketplace` crate has pre-existing compile errors from an unrelated recently-merged PR, unrelated to this change — confirmed by checking out this branch alone still fails the same way in isolation)
- [x] `npx jest` over `channels/`, `sdk/`, and `channelMonitor.test.js` — 77/77 passing
- [x] `npx eslint` over all new/modified JS — clean (one pre-existing unrelated `no-empty` warning in `CortexAgentSDK.js`'s `verifyBatch`, not touched by this PR)
- [x] `npx tsc --noEmit` in `contract/deploy` — clean (two pre-existing unrelated stellar-sdk version-mismatch errors, not touched by this PR)
- [ ] Full DB-integration suite (testcontainers) — not runnable in this sandbox; the migration SQL is hand-verified against the existing schema's conventions but not executed against a live Postgres