### PR TITLE
Fix reputation vote replay and missing backend CI build step

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -37,3 +37,6 @@ jobs:
 
       - name: Run test
         run: npm run test
+
+      - name: Run build
+        run: npm run build

--- a/contract/contracts/agent_registry/src/lib.rs
+++ b/contract/contracts/agent_registry/src/lib.rs
@@ -268,6 +268,10 @@ impl AgentRegistryContract {
         let mut agent = agents.get(agent_id).unwrap();
         assert!(agent.owner != voter, "cannot vote on own agent");
 
+        let vote_key = (REP, voter.clone(), agent_id);
+        let already_voted: Option<ReputationVote> = env.storage().persistent().get(&vote_key);
+        assert!(already_voted.is_none(), "voter has already voted on this agent");
+
         // Fold elapsed decay into the stored score first, so a vote is applied
         // to what the score is worth *now* rather than to a stale snapshot.
         agent.reputation = settle_stored_reputation(&env, agent_id, agent.reputation);
@@ -286,7 +290,6 @@ impl AgentRegistryContract {
             voted_at: env.ledger().timestamp(),
         };
 
-        let vote_key = (REP, voter.clone(), agent_id);
         env.storage().persistent().set(&vote_key, &vote);
 
         env.events()

--- a/contract/contracts/agent_registry/src/test.rs
+++ b/contract/contracts/agent_registry/src/test.rs
@@ -150,6 +150,27 @@ fn test_owner_cannot_vote_own_agent() {
 }
 
 #[test]
+fn test_voter_cannot_vote_twice_on_same_agent() {
+    let (env, contract_id) = setup();
+    let owner = Address::generate(&env);
+    let voter = Address::generate(&env);
+    let client = AgentRegistryContractClient::new(&env, &contract_id);
+
+    client.register_agent(
+        &owner,
+        &String::from_str(&env, "SingleVoterAgent"),
+        &String::from_str(&env, "Test"),
+        &vec![&env, Capability::Reasoning],
+    );
+
+    client.vote_reputation(&voter, &1, &80);
+
+    let result = client.try_vote_reputation(&voter, &1, &0);
+    assert!(result.is_err(), "same voter should not be able to vote twice on the same agent");
+    assert_eq!(client.get_reputation(&1), 5_300);
+}
+
+#[test]
 fn test_score_over_100_rejected() {
     let (env, contract_id) = setup();
     let owner = Address::generate(&env);


### PR DESCRIPTION
- Agent registry: a single address could call vote_reputation repeatedly on the same agent to swing its rolling-average reputation score without limit; reputation votes now follow the same one-vote-per-voter rule that dispute votes already enforce, and a unit test covers the rejection.
- CI: the backend workflow ran lint and test but never npm run build, so a broken build script could pass CI silently; added the missing build step, matching the frontend workflow's pattern.

Closes #5
Closes #7